### PR TITLE
Convert Externals.cfg to use tags

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,13 +2,14 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/GEOSchem_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
-branch = master
+tag = v1.0.0
 protocol = git
 
 [mom]
 required = True
 repo_url = git@github.com:GEOS-ESM/MOM5.git
 local_path = ./GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom
+tag = geos-1.0.0
 branch = geos5
 protocol = git
 

--- a/Externals_sans_mom.cfg
+++ b/Externals_sans_mom.cfg
@@ -1,9 +1,0 @@
-[GEOSchem_GridComp]
-required = True
-repo_url = git@github.com:GEOS-ESM/GEOSchem_GridComp.git
-local_path = ./GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
-branch = master
-protocol = git
-
-[externals_description]
-schema_version = 1.0.0


### PR DESCRIPTION
In prep for fixture tagging, `GEOSgcm_GridComp` needs tags.