### PR TITLE
Fixes #38. Created CircleCI configuration for automated build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: gmao/geos-build-env:3.0.0
+    working_directory: /root/project
+    steps:
+      - run:
+          name: "GEOSgcm_GridComp branch"
+          command: echo ${CIRCLE_BRANCH}
+      - checkout
+      - run:
+          name: "Checkout GEOSgcm fixture and update GEOSgcm_GridComp branch"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}
+            git clone git@github.com:GEOS-ESM/GEOSgcm.git
+            cd GEOSgcm
+            checkout_externals
+            cd src/Components/\@GEOSgcm_GridComp
+            git checkout ${CIRCLE_BRANCH}
+      - run:
+          name: "Build"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm
+            mkdir build
+            cd build
+            cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_BUILD_TYPE=Debug
+            make -j2 install

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # GEOS GCM Component
+[![CircleCI](https://circleci.com/gh/GEOS-ESM/GEOSgcm_GridComp.svg?style=svg)](https://circleci.com/gh/GEOS-ESM/GEOSgcm_GridComp)


### PR DESCRIPTION
Added .circleci/config.yml. Also added a status badge in README.md. To test this component, first the fixture GEOSgcm is checked out first followed by the branch of GEOSgcm_GridComp that is being tested. Finally, the fixture is built.