### PR TITLE
Fixes #35. Applied the same logic as in the fix for Saulo. This might…

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
@@ -6518,11 +6518,11 @@ contains
          ! Get the Kth Field from tracer bundle
          !-------------------------------------
 
-         call ESMF_FieldBundleGet(TR, K, FIELD, RC=STATUS)
+         NAME=QNAMES(K)
+
+         call ESMF_FieldBundleGet(TR, fieldName=NAME, Field=FIELD, RC=STATUS)
          VERIFY_(STATUS)
 
-         call ESMF_FieldGet(FIELD, name=NAME, RC=STATUS)
-         VERIFY_(STATUS)
 
          ! Get items friendly status (default is not friendly)
          !-----------------------------------------------------


### PR DESCRIPTION
… be non-zero diff change, due to fixing the order fetches the correct Henry's law constants, and possibly different sumation order.