### PR TITLE
first crack a make raster/src build with cmake

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Note that directory and library name do not correspond!
 esma_set_this (OVERRIDE GEOS_SurfaceShared)
-
+add_subdirectory(Raster)
 set (srcs
   StieglitzSnow.F90
   SurfParams.F90)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory (src)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/src/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/src/CMakeLists.txt
@@ -1,0 +1,37 @@
+esma_set_this(OVERRIDE raster)
+set (srcs
+date_time_util.F90 
+leap_year.F90 
+easeV1_conv.F90   
+mod_process_hres_data.F90
+easeV2_conv.F90  
+rasterize.F90
+read_riveroutlet.F90
+CubedSphere_GridMod.F90 
+rmTinyCatchParaMod.F90
+sibalb.f
+zenith.f
+zip.c
+util.c
+)  
+
+
+include_directories(${INC_ESMF})
+include_directories(${INC_NETCDF})
+
+esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL_Base)
+
+ecbuild_add_executable (TARGET chk_clsm_params SOURCES chk_clsm_params.F90  LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET CombineRasters SOURCES CombineRasters.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkCatchParam SOURCES mkCatchParam.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkCatchParam_openmp SOURCES mkCatchParam.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkCubeFVRaster SOURCES mkCubeFVRaster.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkLandRaster SOURCES mkLandRaster.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkLatLonRaster SOURCES mkLatLonRaster.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkLISTilesPara SOURCES mkLISTilesPara.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkMITAquaRaster SOURCES mkMITAquaRaster.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkMOMAquaRaster SOURCES mkMOMAquaRaster.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mk_runofftbl SOURCES mk_runofftbl.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkSMAPTilesPara SOURCES mkSMAPTilesPara.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET mkSMAPTilesPara_v2 SOURCES mkSMAPTilesPara_v2.F90 LIBS MAPL_Base ${this})
+ecbuild_add_executable (TARGET rmTinyTiles SOURCES rmTinyTiles.F90 LIBS MAPL_Base ${this})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/src/Raster.h
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/src/Raster.h
@@ -1,0 +1,6 @@
+
+#define VERIFY_(A)   IF(A/=0)THEN;PRINT *,'ERROR AT LINE ', __LINE__;STOP;ENDIF 
+#define ASSERT_(A)   if(.not.A)then;print *,'Error:',__FILE__,__LINE__;stop;endif 
+#define REAL_        real(kind=8)
+#define RASTER_PI    3.14159265358979323846264338_8
+#define RASTERUNDEF  -999


### PR DESCRIPTION
First stab at getting the executables under Raster/src in surface to build under the cmake system.  This has no impact on the rest of the model it is just building new executables. The make_bcs and make_tile scripts are still very broken. Get the src directory in raster to build and install  is the first step in fixing this. The CMakeLists.txt still needs work for openmp and lots of work needs to be done to rewrite the make_bcs and make_tile scripts to function again.