### PR TITLE
Fixes #53 - initialize uc and vc to 0 before assigning the non-halo part

### DIFF
--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/FVdycoreCubed_GridComp/FV_StateMod.F90
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/FVdycoreCubed_GridComp/FV_StateMod.F90
@@ -2913,6 +2913,8 @@ subroutine fv_computeMassFluxes_r8(ucI, vcI, ple, mfx, mfy, cx, cy, dt)
   integer     :: it, nsplt
 
 ! Fill Ghosted arrays and update halos
+  uc = 0d0
+  vc = 0d0
   uc(is:ie,js:je,:) = ucI
   vc(is:ie,js:je,:) = vcI
   call mpp_get_boundary(uc, vc, FV_Atm(1)%domain, &


### PR DESCRIPTION
The r4 version of the code already has this, so add it to the r8 version.