### PR TITLE
Fixes #13 - Compare to ksplt instead of nsplt

### DIFF
--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/FVdycoreCubed_GridComp/fvdycore/model/fv_tracer2d.F90
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/FVdycoreCubed_GridComp/fvdycore/model/fv_tracer2d.F90
@@ -543,7 +543,7 @@ subroutine tracer_2d(q, dp1, mfx, mfy, cx, cy, gridstruct, bd, domain, npx, npy,
                enddo
             enddo
 
-         if ( it /= nsplt ) then
+         if ( it /= ksplt(k) ) then
               do j=js,je
                  do i=is,ie
                     dp1(i,j,k) = dp2(i,j)


### PR DESCRIPTION
This is re-submission of https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/14 as a hotfix to master