### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,11 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
+# Everything in GEOSgcm_GridComp should be owned by the GCM Gatekeepers
+* @GEOS-ESM/gcm-gatekeepers
+
+# The ocean is the Ocean Team's responsibility
+/GEOSogcm_GridComp/ @GEOS-ESM/ocean-team
+
 # The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
 CMakeLists.txt @GEOS-ESM/cmake-team
-


### PR DESCRIPTION
This should make @GEOS-ESM/gcm-gatekeepers the owners of all of `GEOSgcm_GridComp`. But, and I think I have this right, the @GEOS-ESM/ocean-team is the owner of the files in `GEOSogcm_GridComp` and below.