### PR TITLE
Fixes #68 - Pass npz to ArrDescrInit

### DIFF
--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/FVdycoreCubed_GridComp/interp_restarts.F90
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/FVdycoreCubed_GridComp/interp_restarts.F90
@@ -437,7 +437,7 @@ program interp_restarts
    jsl=(npx-1)*(tile-1)+js
    jel=(npx-1)*(tile-1)+je
 
-   call ArrDescrInit(Arrdes,MPI_COMM_WORLD,npx-1,(npx-1)*6,npes_x,npes_y*6,n_readers,n_writers,isl,iel,jsl,jel,rc=status)
+   call ArrDescrInit(Arrdes,MPI_COMM_WORLD,npx-1,(npx-1)*6,npz,npes_x,npes_y*6,n_readers,n_writers,isl,iel,jsl,jel,rc=status)
    call ArrDescrSet(arrdes,offset=0_MPI_OFFSET_KIND)
    if (allocated(schmidt_parameters)) then
       csfactory = CubedSphereGridFactory(im_world=npx-1,lm=npz,nx=npes_x,ny=npes_y,stretch_factor=schmidt_parameters(3), &


### PR DESCRIPTION
This allows dev/MAPL2.0 of the GCM to build with the corresponding MAPL version. I'll make this PR passing only `npz`. If @bena-nasa or @mathomp4 think it needs to be `npz+1` I'll change it.