### PR TITLE
moved land physics parameters from AGCM.rc to GEOS_LandGridComp.rc

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/CMakeLists.txt
@@ -1,5 +1,12 @@
 set (this GEOS_LandShared)
 
+set (resource_files
+    GEOS_LandGridComp.rc
+   ) 
+
+install( FILES ${resource_files} 
+   DESTINATION etc
+   )
 set (srcs
   catch_constants.f90 lsm_routines.F90 sibalb_coeff.f90
   )

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/GEOS_LandGridComp.rc
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/GEOS_LandGridComp.rc
@@ -1,0 +1,125 @@
+# ---- Choose land model version
+#    Icarus  : Current DEFAULT for the Icarus AGCM (Scientifically close to MERRA-2)
+#    V24_C05 : DEFAULT for GEOSldas_m4-17_0
+#    NRv7.2  : Current DEFAULT beginning with GEOSldas_m4-17_6
+#
+# LAND_PARAMS: NRv7.2
+
+# ---- Surface layer turbulence scheme:
+#    0 : Louis                  (MERRA, Fortuna-DAS, SMAP NRv4/4.1/5/7.2)
+#    1 : Helfand Monin-Obukhov  (Fortuna-AR5, Ganymed, Heracles, Icarus-3_2, MERRA-2)
+#
+# CHOOSEMOSFC: 0
+
+# ---- Formulation for turbulent roughness length (Z0):
+#    0 : Fortuna,      SMAP NRv3
+#    1 : Ganymed-4_1,  SMAP NRv4/NRv4.1
+#    2 : Heracles-4_3, Icarus (AGCM default)
+#    3 :               SMAP NRv5/NRv7.2
+#    4 : JP testing
+Z0_FORMULATION: 4
+IGNORE_VEG_HEIGHTS: 1
+
+# ---- ASCAT-derived roughness length:
+#    0 : Default - do not use ASCAT information.
+#    1 : Replace model roughness length with ASCAT Z0 where climatological NDVI<0.2.
+#
+# USE_ASCATZ0: 0
+
+# ---- Prescribe interannually varying MODIS V006  LAI, VISDF, and NIRDF
+#    0 : DEFAULT climatologies in BCSDIR are used
+#    1 : prescribe interannually varying  MCD43GF.006 LAI and MCD43GF.006 VISDF and NIRDF albedo
+#
+# MODIS_DVG: 0
+
+#--------------------------------------------------------#
+#           Aerosol Depositions on surface snow          #
+#--------------------------------------------------------#
+
+# ---- Aerosol deposition on snow (available only with MERRA-2 forcings):
+#    0 : DEFAULT, ALL GOCART Aerosol are NOT used
+#    1 : use all GOCART aerosol data 
+#    2 : GOCART DUST is NOT used
+#    3 : GOCART Black Carbon is NOT used
+#    4 : GOCART Organic Carbon is NOT used
+#
+# AEROSOL_DEPOSITION: 0
+
+# ---- Number of constituents for GOSWIM (the GOddard SnoW Impurity Module)
+# Note 2 separate parameters for LAND and LANDICE
+#    0 : Default, GOSWIM snow albedo scheme is turned OFF for land
+#    9 : GOSWIM snow albedo scheme is turned ON for land
+#
+# N_CONST_LAND4SNWALB: 0
+# N_CONST_LANDICE4SNWALB: 0 
+
+#--------------------------------------------------------#
+#                       Irrigation Model                 #
+#--------------------------------------------------------#
+
+# ---- Run the irrigation model :
+#    0 : Default - NO Do not run the irrigation model
+#    1 : YES run the irrigation model
+#
+# RUN_IRRIG: 0
+
+# ---- irrigation model method :
+#    0 : Default - Sprinkler and Flood irrigation combined
+#    1 : sprinkler irrigation only
+#    2 : flood irrigation only
+#
+# IRRIG_METHOD: 0
+
+#--------------------------------------------------------#
+#                   River Routing Model                  #
+#--------------------------------------------------------#
+
+# ---- Run River Routing Model interactively 
+#    0 : Default - NO
+#    1 : YES
+#
+# RUN_ROUTE: 0
+
+# ---- Time step for river routing
+#
+# RRM_DT: 3600 # 1-hourly
+
+#--------------------------------------------------------#
+#             CatchCN Model specific parameters          #
+#--------------------------------------------------------#
+
+# ---- Time step for carbon/nitrogen routines in CatchmentCN model (default 5400):
+#      (Time step for water/energy routines is controlled by HEARTBEAT_DT in CAP.rc)
+#
+# DTCN: 5400
+
+#  ---- Atmospheric CO2
+# 0--use a fix value as defined by below CO2 (default=350.e-6)
+# 1--NOAA CT tracker monthly mean diurnal cycle
+# 2--NOAA CT tracker monthly mean diurnal cycle scaled to match EEA global average CO2
+#    By default NOAA CT CO2 is scaled to the EEA global average CO2 linearly interpolated to the METFORCE year. 
+#    For offline simulations : the default holds but with the below optional parameter CO2_YEAR, which permits user to 
+#    set the beginning year of the atmospheric CO2 concentration of the simulation if it's earlier than the METFORCE year.
+# 3--CMIP5 recommended annual average global mean concentrations from getco2.F90 (1765-2150)
+# 4--import AGCM model CO2 (AGCM Only)
+#
+# ATM_CO2: 2
+# CO2: 350.e-6
+# CO2_YEAR:
+
+# ---- Prescribe daily LAI and SAI data from an archived CATCHCN simulation 
+# 0--NO Run CN Model interactively
+# 1--YES Prescribe interannually varying LAI and SAI
+# 2--YES Prescribe climatological LAI and SAI
+# 3--Estimated LAI/SAI using anomalies at the beginning of the foeecast and climatological LAI/SAI
+# 4--Write LAI/SAI anomalies in catchcn_internal_rst for above option 3
+#
+# PRESCRIBE_DVG: 0
+
+# ---- Scale CATCHCN ALBEDO and FPAR
+# 0--NO
+# 1-- Scale albedo to match interannually varying MODIS NIRDF and VISDF anomaly
+# 2-- Scale albedo to match interannually varying MODIS NIRDF and VISDF plus FPAR to match MODIS FPAR CDF 
+#
+# SCALE_ALBFPAR: 0
+


### PR DESCRIPTION
The new file GEOS_LandGridComp.rc is part of PR [GEOS-ESM/GEOSgcm_App/#39](https://github.com/GEOS-ESM/GEOSgcm_App/pull/39#pullrequestreview-281633374)

The same file has a PR [GEOS-ESM/GEOSgcm_GridComp/#61](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/61) to ldas-surface. 

The change is merely moving land physics parameters from the driver RC file (AGCM.rc) to new land physics RC file (GEOS_LandGridComp.rc) to accommodate the growing land parameter list - so this is zero-diff. I just want to help close [#39](https://github.com/GEOS-ESM/GEOSgcm_App/pull/39#pullrequestreview-281633374) and [#61](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/61).

I branch off develop (instead ldas-surface) for a quick merge.