### PR TITLE
MOM6 in GEOS - Part 2

### DIFF
--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/CMakeLists.txt
@@ -4,7 +4,7 @@ set (rename_MOM_GEOS5PlugMod MOM_GEOS5Plug)
 
 esma_add_library (${this}
   SRCS GuestOcean_GridComp.F90
-  SUBCOMPONENTS MOM_GEOS5PlugMod
+  SUBCOMPONENTS MOM_GEOS5PlugMod MOM6_GEOSPlug
   DEPENDENCIES GEOSdatasea_GridComp MAPL_Base
   INCLUDES ${INC_ESMF} ${INC_NETCDF})
 

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
@@ -733,16 +733,20 @@ contains
     call MAPL_TimerOn (STATE,"TOTAL"     )
 
     if(DO_DATASEA==0) then
-       call MAPL_GetPointer(EXPORT, MASKO, 'MASKO'  , alloc=.true.,RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(GEX(OCN), MASK3D, 'MOM_3D_MASK', RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(GEX(OCN), DH, 'DH', RC=STATUS); VERIFY_(STATUS)
-
-       MASK => MASK3D(:,:,1)
-       if(associated(MASKO)) MASKO = MASK
+       call MAPL_GetPointer(GEX(OCN), DH, 'DH', __RC__)
+       select case (trim(OCEAN_NAME))
+          case ("MOM")
+             call MAPL_GetPointer(EXPORT, MASKO, 'MASKO'  , alloc=.true.,__RC__)
+             call MAPL_GetPointer(GEX(OCN), MASK3D, 'MOM_3D_MASK', __RC__)
+             MASK => MASK3D(:,:,1)
+             if(associated(MASKO)) MASKO = MASK
+          case ("MOM6")
+             call MAPL_GetPointer(GEX(OCN), MASK, 'MOM_2D_MASK', __RC__)
+       end select
 
 ! The following sets the depth in orphan points. This is needed to calculate SWHEAT in these points.
 ! Unfortunately, frocean is zero at this point so we set OrphanDepth in all MOM land points.
-       where(mask == 0.0)
+       where(MASK == 0.0)
           DH(:,:,1) = OrphanDepth
        end where
     end if

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
@@ -1,5 +1,5 @@
 !$Id$
-  
+
 #include "MAPL_Generic.h"
 
 module GuestOcean_GridCompMod
@@ -8,12 +8,12 @@ module GuestOcean_GridCompMod
 ! !MODULE: GuestOcean_GridCompMod -- Implements ESMF wrapper to invoke the DATASEA/MIT/MOM ocean models.
 
 ! !USES:
- 
+
   use ESMF
   use MAPL_Mod
-  use MOM_GEOS5PlugMod, only: MOMSetServices => SetServices  ! this sets IRF
-  use MOM6_GEOSPlugMod,        only: MOM6SetServices    => SetServices  ! this sets IRF
-  use GEOS_DataSeaGridCompMod,           only : DataSeaSetServices  => SetServices
+  use MOM_GEOS5PlugMod, only: MOMSetServices  => SetServices  ! this sets IRF
+  use MOM6_GEOSPlugMod, only: MOM6SetServices => SetServices  ! this sets IRF
+  use GEOS_DataSeaGridCompMod, only: DataSeaSetServices  => SetServices
 
   implicit none
   private
@@ -27,9 +27,9 @@ module GuestOcean_GridCompMod
   real :: OrphanDepth
 
 ! !DESCRIPTION:
-! 
+!
 !   {\tt GuestOcean\_GridComp} is a light-weight gridded component that serves an
-!   interface to ocean/data\_ocean components. 
+!   interface to ocean/data\_ocean components.
 !
 !EOP
 
@@ -41,7 +41,7 @@ module GuestOcean_GridCompMod
      type(T_PrivateState), pointer :: ptr
   end type T_PrivateState_Wrap
 
-  integer ::          OCN 
+  integer :: OCN
 
 contains
 
@@ -56,28 +56,28 @@ contains
 ! !ARGUMENTS:
 
     type(ESMF_GridComp), intent(INOUT) :: GC  ! gridded component
-    integer, optional	               :: RC  ! return code
+    integer, optional                  :: RC  ! return code
 
-! !DESCRIPTION: This version uses the MAPL\_GenericSetServices, 
-!       which sets the Run, Initialize, and Finalize services, 
-!       as well as allocating our instance of a generic state and putting it in the 
-!	gridded component (GC). Here we override all three methods and declare
-!       the specs for the Imports and Export States (no MAPL controlled Internal State). 
+! !DESCRIPTION: This version uses the MAPL\_GenericSetServices,
+!       which sets the Run, Initialize, and Finalize services,
+!       as well as allocating our instance of a generic state and putting it in the
+!   gridded component (GC). Here we override all three methods and declare
+!       the specs for the Imports and Export States (no MAPL controlled Internal State).
 !       GuestOcean state variables (the bulletin board and the time) are kept
-!       in the GuestOcean's Private Internal state. 
-!   
+!       in the GuestOcean's Private Internal state.
+!
 !EOP
 
 !=============================================================================
 !
 ! ErrLog Variables
 
-    character(len=ESMF_MAXSTR)	       :: IAm
+    character(len=ESMF_MAXSTR)         :: IAm
     integer                            :: STATUS
-    character(len=ESMF_MAXSTR)	       :: COMP_NAME
+    character(len=ESMF_MAXSTR)         :: COMP_NAME
 
 ! Local vars
-    type (MAPL_MetaComp),  pointer     :: MAPL  
+    type  (MAPL_MetaComp), pointer     :: MAPL
     type  (ESMF_Config)                :: CF
     character(len=ESMF_MAXSTR)         :: charbuf_
 
@@ -285,7 +285,7 @@ contains
         VLOCATION          = MAPL_VLocationNone,                  &
                                                        RC=STATUS  )
      VERIFY_(STATUS)
-     
+
      call MAPL_AddImportSpec(GC,                               &
         LONG_NAME          = 'ocean_rainfall'            ,&
         UNITS              = 'kg m-2 s-1'                ,&
@@ -294,14 +294,14 @@ contains
         VLOCATION          = MAPL_VLocationNone          ,&
           RC=STATUS  )
      VERIFY_(STATUS)
-     
+
      call MAPL_AddImportSpec(GC,                    &
         SHORT_NAME         = 'FRESH',                         &
         LONG_NAME          = 'fresh_water_flux_due_to_ice_dynamics', &
           UNITS              = 'kg m-2 s-1'                ,&
           DIMS               = MAPL_DimsHorzOnly           ,&
           VLOCATION          = MAPL_VLocationNone          ,&
-          RC=STATUS  ) 
+          RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC,                             &
@@ -334,10 +334,10 @@ contains
          DEFAULT            = 280.0, &
          RC=STATUS  )
     VERIFY_(STATUS)
-    
+
 
 !  !EXPORT STATE:
-    
+
     select case (trim(OCEAN_NAME))
         case ("MOM", "DATASEA")
             charbuf_ = 'MASKO'
@@ -345,9 +345,9 @@ contains
             charbuf_ = 'MASK'
     end select
     call MAPL_AddExportSpec(GC,                               &
-         SHORT_NAME         = trim(charbuf_),                     &
-         LONG_NAME          = 'ocean_mask',&
-         UNITS              = '1',                               &
+         SHORT_NAME         = trim(charbuf_),                      &
+         LONG_NAME          = 'ocean_mask',                        &
+         UNITS              = '1',                                 &
          DIMS               = MAPL_DimsHorzOnly,                   &
          VLOCATION          = MAPL_VLocationNone,                  &
          RC=STATUS  )
@@ -550,19 +550,19 @@ contains
             CHILD_ID   = OCN,                                         &
             RC=STATUS  )
        VERIFY_(STATUS)
-       
+
        call MAPL_AddExportSpec ( GC   ,                          &
             SHORT_NAME = 'T',                                         &
             CHILD_ID   = OCN,                                         &
             RC=STATUS  )
-       VERIFY_(STATUS)       
+       VERIFY_(STATUS)
        call MAPL_AddExportSpec ( GC   ,                          &
             SHORT_NAME = 'S',                                         &
             CHILD_ID   = OCN,                                         &
             RC=STATUS  )
        VERIFY_(STATUS)
     end if
-    
+
 !EOS
 
     if(DO_DATASEA==0) then
@@ -573,13 +573,13 @@ contains
             CHILD=OCN,                          RC=STATUS  )
        VERIFY_(STATUS)
     end if
- 
+
 ! Set the Initialize, Run, Finalize entry points
 ! ----------------------------------------------
 
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE, Initialize, RC=status)
     VERIFY_(STATUS)
-    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,	  Run,        RC=status)
+    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,    Run,        RC=status)
     VERIFY_(STATUS)
 
 !=============================================================================
@@ -598,10 +598,10 @@ contains
     VERIFY_(STATUS)
     call MAPL_TimerAdd(GC,   name="--ModRun"   ,RC=STATUS)
     VERIFY_(STATUS)
-	
+
 ! All Done
 !---------
-	
+
     RETURN_(ESMF_SUCCESS)
   end subroutine SetServices
 
@@ -617,7 +617,7 @@ contains
 
 ! !ARGUMENTS:
 
-    type(ESMF_GridComp),      intent(INOUT) :: GC     ! Gridded component 
+    type(ESMF_GridComp),      intent(INOUT) :: GC     ! Gridded component
     type(ESMF_State),         intent(INOUT) :: IMPORT ! Import state
     type(ESMF_State),         intent(INOUT) :: EXPORT ! Export state
     type(ESMF_Clock),         intent(INOUT) :: CLOCK  ! The clock
@@ -627,13 +627,13 @@ contains
 
 ! ErrLog Variables
 
-    character(len=ESMF_MAXSTR)		:: IAm
-    integer				:: STATUS
+    character(len=ESMF_MAXSTR)      :: IAm
+    integer             :: STATUS
     character(len=ESMF_MAXSTR)          :: COMP_NAME
 
 ! Local derived type aliases
-    
-    type (MAPL_MetaComp),     pointer   :: State 
+
+    type (MAPL_MetaComp),     pointer   :: State
     type (ESMF_Grid)                    :: Grid
     type (T_PrivateState),    pointer   :: PrivateSTATE
     type (T_PrivateState_Wrap)          :: WRAP
@@ -643,7 +643,7 @@ contains
     type (ESMF_State       ), pointer   :: GIM(:)
     type (ESMF_State       ), pointer   :: GEX(:)
     type (ESMF_TimeInterval)            :: timeStep
-    type (ESMF_Time)                    :: currTime 
+    type (ESMF_Time)                    :: currTime
 
     real, pointer :: MASK(:,:)
     real, pointer :: MASKO(:,:)
@@ -652,7 +652,7 @@ contains
 
 !=============================================================================
 
-! Begin... 
+! Begin...
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -686,7 +686,7 @@ contains
 
 ! Allocate the private state...
 !------------------------------
-    
+
     allocate( PrivateSTATE , stat=STATUS )
     VERIFY_(STATUS)
 
@@ -694,7 +694,7 @@ contains
 
 ! And put it in the GC
 !---------------------
-    
+
     CALL ESMF_UserCompSetInternalState( GC, TRIM(OCEAN_NAME)//'_internal_state', WRAP, STATUS )
     VERIFY_(status)
 
@@ -704,7 +704,7 @@ contains
     VERIFY_(status)
     call MAPL_GetResource(STATE,DT,  Label="OCEAN_DT:",  DEFAULT=DT, RC=STATUS) ! set Default OCEAN_DT to AGCM Heartbeat
     VERIFY_(status)
-    
+
     CALL ESMF_TimeIntervalSet(timeStep, S=NINT(DT), RC=status)
     VERIFY_(status)
 
@@ -757,20 +757,20 @@ contains
           case ("MOM")
              call MAPL_GetPointer(EXPORT, MASKO, 'MASKO'  , alloc=.true.,__RC__)
              call MAPL_GetPointer(GEX(OCN), MASK3D, 'MOM_3D_MASK', __RC__)
-       MASK => MASK3D(:,:,1)
-       if(associated(MASKO)) MASKO = MASK
+             MASK => MASK3D(:,:,1)
+             if(associated(MASKO)) MASKO = MASK
           case ("MOM6")
              call MAPL_GetPointer(GEX(OCN), MASK, 'MOM_2D_MASK', __RC__)
        end select
 
 ! The following sets the depth in orphan points. This is needed to calculate SWHEAT in these points.
-! Unfortunately, frocean is zero at this point so we set OrphanDepth in all MOM land points. 
+! Unfortunately, frocean is zero at this point so we set OrphanDepth in all MOM land points.
        call MAPL_GetPointer(GEX(OCN), DH, 'DH', __RC__)
        where(MASK == 0.0)
           DH(:,:,1) = OrphanDepth
        end where
     end if
- 
+
     call MAPL_TimerOff(STATE,"INITIALIZE")
     call MAPL_TimerOff(STATE,"TOTAL"     )
 
@@ -779,7 +779,7 @@ contains
     RETURN_(ESMF_SUCCESS)
 
   end subroutine Initialize
-  
+
 ! ========================================================
 
 !BOP
@@ -792,7 +792,7 @@ contains
 
 ! !ARGUMENTS:
 
-    type(ESMF_GridComp), intent(INOUT) :: gc     ! Gridded component 
+    type(ESMF_GridComp), intent(INOUT) :: gc     ! Gridded component
     type(ESMF_State),    intent(INOUT) :: import ! Import state
     type(ESMF_State),    intent(INOUT) :: export ! Export state
     type(ESMF_Clock),    intent(INOUT) :: clock  ! The supervisor clock
@@ -802,13 +802,13 @@ contains
 
 ! ErrLog Variables
 
-    character(len=ESMF_MAXSTR)		:: IAm
-    integer				:: STATUS
+    character(len=ESMF_MAXSTR)          :: IAm
+    integer                             :: STATUS
     character(len=ESMF_MAXSTR)          :: COMP_NAME
 
 ! Local derived type aliases
 
-    type (MAPL_MetaComp),     pointer   :: STATE 
+    type (MAPL_MetaComp),     pointer   :: STATE
     type (ESMF_Time)                    :: EndTime
     type (ESMF_Time)                    :: MyTime,ct
     type (T_PrivateState),    pointer   :: PrivateSTATE
@@ -840,7 +840,7 @@ contains
     real, pointer :: FSALT(:,:)
 
 ! Pointers to Exports
-    
+
     real, pointer :: TS_FOUND (:,:)
     real, pointer :: SS_FOUND (:,:)
     real, pointer :: FRZMLT(:,:)
@@ -941,7 +941,7 @@ contains
 
 ! Check the clocks to set set-up the "run-to" time
 !-------------------------------------------------
-    
+
     call ESMF_ClockGet( CLOCK, currTime=endTime, RC=STATUS)
     VERIFY_(status)
 
@@ -951,7 +951,7 @@ contains
     CALL ESMF_UserCompGetInternalState( GC, TRIM(OCEAN_NAME)//'_internal_state', WRAP, STATUS )
     VERIFY_(STATUS)
 
-    PrivateSTATE => WRAP%PTR 
+    PrivateSTATE => WRAP%PTR
 
     call ESMF_ClockGet( PrivateState%CLOCK, currTime=myTime, RC=STATUS)
     VERIFY_(status)
@@ -977,13 +977,13 @@ contains
 
     if( MyTime <= EndTime ) then ! Time to run
 
-! We get the ocean-land mask (now computed in Initialize of Plug)  
+! We get the ocean-land mask (now computed in Initialize of Plug)
 ! ---------------------------------------------------------------
        if(DO_DATASEA==0) then
           select case(trim(OCEAN_NAME))
              case ("MOM")
                 call MAPL_GetPointer(GEX(OCN), MASK3D, 'MOM_3D_MASK', __RC__)
-          MASK => MASK3D(:,:,1)
+                MASK => MASK3D(:,:,1)
              case ("MOM6")
                 call MAPL_GetPointer(GEX(OCN), MASK, 'MOM_2D_MASK', __RC__)
              end select
@@ -992,11 +992,11 @@ contains
           MASK3D=1.0
           allocate(MASK(IM,JM), STAT=STATUS); VERIFY_(STATUS)
           MASK=1.0
-       end if       
+       end if
 
 ! Get ocean time step and misc. parameters
 !-----------------------------------------
-       
+
        call MAPL_GetResource(STATE,DT,  Label="RUN_DT:",    RC=STATUS)             ! Get AGCM Heartbeat
        VERIFY_(status)
        call MAPL_GetResource(STATE,DT,  Label="OCEAN_DT:",  DEFAULT=DT, RC=STATUS) ! set Default OCEAN_DT to AGCM Heartbeat
@@ -1044,14 +1044,14 @@ contains
           call MAPL_GetPointer(GIM(OCN), SNOW, 'SNOW'  , RC=STATUS); VERIFY_(STATUS)
           call MAPL_GetPointer(GIM(OCN), SFLX, 'SFLX'  , RC=STATUS); VERIFY_(STATUS)
        end if
-       
+
        call MAPL_GetPointer(GEX(OCN), TW,   'TW'  , alloc=.true., RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(GEX(OCN), SW,   'SW'  , alloc=.true., RC=STATUS); VERIFY_(STATUS)
 
        if(DO_DATASEA==0) then
           call MAPL_GetPointer(GEX(OCN), FRAZIL,   'FRAZIL'  , alloc=.true., RC=STATUS); VERIFY_(STATUS)
        end if
-       
+
 ! Get pointers to exports
 !--------------------------------------------------------
 
@@ -1073,7 +1073,7 @@ contains
        call MAPL_GetPointer(EXPORT, QFLUXe, 'QFLUX'  , RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(EXPORT, RAINe, 'RAIN'  , RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(EXPORT, SNOWe, 'SNOW'  , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, SFLXe, 'SFLX'  , RC=STATUS); VERIFY_(STATUS)       
+       call MAPL_GetPointer(EXPORT, SFLXe, 'SFLX'  , RC=STATUS); VERIFY_(STATUS)
 
        if(associated(FROCEANe)) FROCEANe = FROCEAN
 
@@ -1103,8 +1103,8 @@ contains
           DISCHARGE = DISCHARGEi * WGHT
           LWFLX = LWFLXi * WGHT
           QFLUX = QFLUXi * WGHT
-          SHFLX = (SHFLXi- FHOCN) * WGHT 
-          RAIN = (RAINi+FRESH) * WGHT 
+          SHFLX = (SHFLXi- FHOCN) * WGHT
+          RAIN = (RAINi+FRESH) * WGHT
           SNOW = SNOWi * WGHT
           SFLX = FSALT * WGHT
 
@@ -1113,23 +1113,23 @@ contains
           TAUX = TAUXi * WGHT
           TAUY = TAUYi * WGHT
 
-       
+
 ! Prepare radiative heating for ocean
 !------------------------------------
 
           if(associated(RFLUX )) RFLUX  = 0.0
           select case (trim(OCEAN_NAME))
              case ("MOM", "DATASEA")
-          do L=1,LM
-             HEAT(:,:,L) = HEATi(:,:,L)*WGHT 
-             if(associated(RFLUX)) then
-                RFLUX = RFLUX + (1.0-MASK3D(:,:,L))*HEAT(:,:,L)
-             end if
-          end do
+                do L=1,LM
+                   HEAT(:,:,L) = HEATi(:,:,L)*WGHT
+                   if(associated(RFLUX)) then
+                      RFLUX = RFLUX + (1.0-MASK3D(:,:,L))*HEAT(:,:,L)
+                   end if
+                end do
              case ("MOM6")
                 ! No 3D Mask from MOM6. Do nothing for now!
           end select
-          
+
           if (associated(HEATe)) HEATe = HEAT
           if (associated(TAUXe)) TAUXe = TAUX
           if (associated(TAUYe)) TAUYe = TAUY
@@ -1148,7 +1148,7 @@ contains
 
        NUM = 0
        do while ( MyTime <= endTime )
-          
+
 ! Run ocean for one time step (DT)
 !---------------------------------
 
@@ -1171,7 +1171,7 @@ contains
 
        end do
 
-       if(associated(SS_FOUND)) then 
+       if(associated(SS_FOUND)) then
           SS_FOUND = OrphanSalinity
           where(WGHT > 0.0)
              SS_FOUND = SW
@@ -1187,14 +1187,14 @@ contains
              FRZMLT = 0.0
        end if
        end if
-       
+
        where(WGHT > 0.0)
           TS_FOUND = TW
           end where
 
 ! Update orphan points
        if(DO_DATASEA == 0) then
-          WGHT=FROCEAN*(1-MASK)                    
+          WGHT=FROCEAN*(1-MASK)
           Tfreeze=MAPL_TICE-0.054*OrphanSalinity
 
           where(wght>0.0)
@@ -1203,7 +1203,7 @@ contains
              FRZMLT = (Tfreeze - TS_FOUND) * (MAPL_RHO_SEAWATER*MAPL_CAPWTR*OrphanDepth)/DT
              TS_FOUND=max(TS_FOUND, Tfreeze)
           end where
-        
+
        end if
 
        deallocate(WGHT, STAT=STATUS); VERIFY_(STATUS)
@@ -1212,7 +1212,7 @@ contains
           deallocate(MASK3D, STAT=STATUS); VERIFY_(STATUS)
           deallocate(MASK, STAT=STATUS); VERIFY_(STATUS)
        end if
-    
+
     end if ! Time to run
 
 ! Profilers

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
@@ -733,7 +733,6 @@ contains
     call MAPL_TimerOn (STATE,"TOTAL"     )
 
     if(DO_DATASEA==0) then
-       call MAPL_GetPointer(GEX(OCN), DH, 'DH', __RC__)
        select case (trim(OCEAN_NAME))
           case ("MOM")
              call MAPL_GetPointer(EXPORT, MASKO, 'MASKO'  , alloc=.true.,__RC__)
@@ -746,6 +745,7 @@ contains
 
 ! The following sets the depth in orphan points. This is needed to calculate SWHEAT in these points.
 ! Unfortunately, frocean is zero at this point so we set OrphanDepth in all MOM land points.
+       call MAPL_GetPointer(GEX(OCN), DH, 'DH', __RC__)
        where(MASK == 0.0)
           DH(:,:,1) = OrphanDepth
        end where
@@ -958,7 +958,7 @@ contains
     if( MyTime <= EndTime ) then ! Time to run
 
 ! We get the ocean-land mask (now computed in Initialize of Plug)
-!----------------------------------------------------------
+! ---------------------------------------------------------------
        if(DO_DATASEA==0) then
           select case(trim(OCEAN_NAME))
              case ("MOM")

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
@@ -1040,19 +1040,19 @@ contains
 
 ! Diagnostics exports
 !---------------------------------------------------------
-       call MAPL_GetPointer(EXPORT, RFLUX,  'RFLUX' , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, FROCEANe,'FROCEAN', RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, TAUXe, 'TAUX'   , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, TAUYe, 'TAUY'   , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, HEATe, 'SWHEAT' , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, DISCHARGEe, 'DISCHARGE'  , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, LWFLXe, 'LWFLX'  , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, SWFLXe, 'SWFLX'  , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, SHFLXe, 'SHFLX'  , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, QFLUXe, 'QFLUX'  , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, RAINe, 'RAIN'  , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, SNOWe, 'SNOW'  , RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetPointer(EXPORT, SFLXe, 'SFLX'  , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, RFLUX,      'RFLUX',     __RC__)
+       call MAPL_GetPointer(EXPORT, FROCEANe,   'FROCEAN',   __RC__)
+       call MAPL_GetPointer(EXPORT, TAUXe,      'TAUX',      __RC__)
+       call MAPL_GetPointer(EXPORT, TAUYe,      'TAUY',      __RC__)
+       call MAPL_GetPointer(EXPORT, HEATe,      'SWHEAT',    __RC__)
+       call MAPL_GetPointer(EXPORT, DISCHARGEe, 'DISCHARGE', __RC__)
+       call MAPL_GetPointer(EXPORT, LWFLXe,     'LWFLX',     __RC__)
+       call MAPL_GetPointer(EXPORT, SWFLXe,     'SWFLX',     __RC__)
+       call MAPL_GetPointer(EXPORT, SHFLXe,     'SHFLX',     __RC__)
+       call MAPL_GetPointer(EXPORT, QFLUXe,     'QFLUX',     __RC__)
+       call MAPL_GetPointer(EXPORT, RAINe,      'RAIN',      __RC__)
+       call MAPL_GetPointer(EXPORT, SNOWe,      'SNOW',      __RC__)
+       call MAPL_GetPointer(EXPORT, SFLXe,      'SFLX',      __RC__)
 
        if(associated(FROCEANe)) FROCEANe = FROCEAN
 
@@ -1097,12 +1097,17 @@ contains
 !------------------------------------
 
           if(associated(RFLUX )) RFLUX  = 0.0
-          do L=1,LM
-             HEAT(:,:,L) = HEATi(:,:,L)*WGHT
-             if(associated(RFLUX)) then
-                RFLUX = RFLUX + (1.0-MASK3D(:,:,L))*HEAT(:,:,L)
-             end if
-          end do
+          select case (trim(OCEAN_NAME))
+             case ("MOM", "DATASEA")
+                do L=1,LM
+                   HEAT(:,:,L) = HEATi(:,:,L)*WGHT
+                   if(associated(RFLUX)) then
+                      RFLUX = RFLUX + (1.0-MASK3D(:,:,L))*HEAT(:,:,L)
+                   end if
+                end do
+             case ("MOM6")
+                ! No 3D Mask from MOM6. Do nothing for now!
+          end select
 
           if (associated(HEATe)) HEATe = HEAT
           if (associated(TAUXe)) TAUXe = TAUX

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
@@ -1,5 +1,5 @@
 !$Id$
-
+  
 #include "MAPL_Generic.h"
 
 module GuestOcean_GridCompMod
@@ -8,12 +8,12 @@ module GuestOcean_GridCompMod
 ! !MODULE: GuestOcean_GridCompMod -- Implements ESMF wrapper to invoke the DATASEA/MIT/MOM ocean models.
 
 ! !USES:
-
+ 
   use ESMF
   use MAPL_Mod
-  use MOM_GEOS5PlugMod,        only: MOMSetServices     => SetServices  ! this sets IRF
+  use MOM_GEOS5PlugMod, only: MOMSetServices => SetServices  ! this sets IRF
   use MOM6_GEOSPlugMod,        only: MOM6SetServices    => SetServices  ! this sets IRF
-  use GEOS_DataSeaGridCompMod, only: DataSeaSetServices => SetServices
+  use GEOS_DataSeaGridCompMod,           only : DataSeaSetServices  => SetServices
 
   implicit none
   private
@@ -27,9 +27,9 @@ module GuestOcean_GridCompMod
   real :: OrphanDepth
 
 ! !DESCRIPTION:
-!
+! 
 !   {\tt GuestOcean\_GridComp} is a light-weight gridded component that serves an
-!   interface to ocean/data\_ocean components.
+!   interface to ocean/data\_ocean components. 
 !
 !EOP
 
@@ -41,7 +41,7 @@ module GuestOcean_GridCompMod
      type(T_PrivateState), pointer :: ptr
   end type T_PrivateState_Wrap
 
-  integer ::          OCN
+  integer ::          OCN 
 
 contains
 
@@ -56,28 +56,28 @@ contains
 ! !ARGUMENTS:
 
     type(ESMF_GridComp), intent(INOUT) :: GC  ! gridded component
-    integer, optional                  :: RC  ! return code
+    integer, optional	               :: RC  ! return code
 
-! !DESCRIPTION: This version uses the MAPL\_GenericSetServices,
-!       which sets the Run, Initialize, and Finalize services,
-!       as well as allocating our instance of a generic state and putting it in the
-!   gridded component (GC). Here we override all three methods and declare
-!       the specs for the Imports and Export States (no MAPL controlled Internal State).
+! !DESCRIPTION: This version uses the MAPL\_GenericSetServices, 
+!       which sets the Run, Initialize, and Finalize services, 
+!       as well as allocating our instance of a generic state and putting it in the 
+!	gridded component (GC). Here we override all three methods and declare
+!       the specs for the Imports and Export States (no MAPL controlled Internal State). 
 !       GuestOcean state variables (the bulletin board and the time) are kept
-!       in the GuestOcean's Private Internal state.
-!
+!       in the GuestOcean's Private Internal state. 
+!   
 !EOP
 
 !=============================================================================
 !
 ! ErrLog Variables
 
-    character(len=ESMF_MAXSTR)         :: IAm
+    character(len=ESMF_MAXSTR)	       :: IAm
     integer                            :: STATUS
-    character(len=ESMF_MAXSTR)         :: COMP_NAME
+    character(len=ESMF_MAXSTR)	       :: COMP_NAME
 
 ! Local vars
-    type (MAPL_MetaComp),  pointer     :: MAPL
+    type (MAPL_MetaComp),  pointer     :: MAPL  
     type  (ESMF_Config)                :: CF
     character(len=ESMF_MAXSTR)         :: charbuf_
 
@@ -230,6 +230,26 @@ contains
          RC=STATUS  )
     VERIFY_(STATUS)
 
+!!$     call MAPL_AddImportSpec(GC,                             &
+!!$        SHORT_NAME         = 'TR',                                &
+!!$        LONG_NAME          = 'tracer_mixing_ratios',              &
+!!$        UNITS              = '1',                                 &
+!!$        DIMS               = MAPL_DimsHorzVert,                   &
+!!$        VLOCATION          = MAPL_VLocationCenter,                &
+!!$        DATATYPE           = MAPL_BundleItem,                     &
+!!$                                                       RC=STATUS  )
+!!$     VERIFY_(STATUS)
+!!$
+!!$     call MAPL_AddImportSpec(GC,                             &
+!!$        SHORT_NAME         = 'TRFLUX',                            &
+!!$        LONG_NAME          = 'surface_fluxes_of_tracers',         &
+!!$        UNITS              = 'X',                                 &
+!!$        DIMS               = MAPL_DimsHorzOnly,                   &
+!!$        VLOCATION          = MAPL_VLocationNone,                  &
+!!$        DATATYPE           = MAPL_BundleItem,                     &
+!!$                                                       RC=STATUS  )
+!!$     VERIFY_(STATUS)
+
     call MAPL_AddImportSpec(GC,                             &
         LONG_NAME          = 'surface_net_downward_longwave_flux',&
         UNITS              = 'W m-2',                             &
@@ -265,7 +285,7 @@ contains
         VLOCATION          = MAPL_VLocationNone,                  &
                                                        RC=STATUS  )
      VERIFY_(STATUS)
-
+     
      call MAPL_AddImportSpec(GC,                               &
         LONG_NAME          = 'ocean_rainfall'            ,&
         UNITS              = 'kg m-2 s-1'                ,&
@@ -274,14 +294,14 @@ contains
         VLOCATION          = MAPL_VLocationNone          ,&
           RC=STATUS  )
      VERIFY_(STATUS)
-
+     
      call MAPL_AddImportSpec(GC,                    &
         SHORT_NAME         = 'FRESH',                         &
         LONG_NAME          = 'fresh_water_flux_due_to_ice_dynamics', &
           UNITS              = 'kg m-2 s-1'                ,&
           DIMS               = MAPL_DimsHorzOnly           ,&
           VLOCATION          = MAPL_VLocationNone          ,&
-          RC=STATUS  )
+          RC=STATUS  ) 
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC,                             &
@@ -314,10 +334,10 @@ contains
          DEFAULT            = 280.0, &
          RC=STATUS  )
     VERIFY_(STATUS)
-
+    
 
 !  !EXPORT STATE:
-
+    
     select case (trim(OCEAN_NAME))
         case ("MOM", "DATASEA")
             charbuf_ = 'MASKO'
@@ -530,19 +550,19 @@ contains
             CHILD_ID   = OCN,                                         &
             RC=STATUS  )
        VERIFY_(STATUS)
-
+       
        call MAPL_AddExportSpec ( GC   ,                          &
             SHORT_NAME = 'T',                                         &
             CHILD_ID   = OCN,                                         &
             RC=STATUS  )
-       VERIFY_(STATUS)
+       VERIFY_(STATUS)       
        call MAPL_AddExportSpec ( GC   ,                          &
             SHORT_NAME = 'S',                                         &
             CHILD_ID   = OCN,                                         &
             RC=STATUS  )
        VERIFY_(STATUS)
     end if
-
+    
 !EOS
 
     if(DO_DATASEA==0) then
@@ -553,13 +573,13 @@ contains
             CHILD=OCN,                          RC=STATUS  )
        VERIFY_(STATUS)
     end if
-
+ 
 ! Set the Initialize, Run, Finalize entry points
 ! ----------------------------------------------
 
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE, Initialize, RC=status)
     VERIFY_(STATUS)
-    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,    Run,        RC=status)
+    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,	  Run,        RC=status)
     VERIFY_(STATUS)
 
 !=============================================================================
@@ -578,10 +598,10 @@ contains
     VERIFY_(STATUS)
     call MAPL_TimerAdd(GC,   name="--ModRun"   ,RC=STATUS)
     VERIFY_(STATUS)
-
+	
 ! All Done
 !---------
-
+	
     RETURN_(ESMF_SUCCESS)
   end subroutine SetServices
 
@@ -597,7 +617,7 @@ contains
 
 ! !ARGUMENTS:
 
-    type(ESMF_GridComp),      intent(INOUT) :: GC     ! Gridded component
+    type(ESMF_GridComp),      intent(INOUT) :: GC     ! Gridded component 
     type(ESMF_State),         intent(INOUT) :: IMPORT ! Import state
     type(ESMF_State),         intent(INOUT) :: EXPORT ! Export state
     type(ESMF_Clock),         intent(INOUT) :: CLOCK  ! The clock
@@ -607,13 +627,13 @@ contains
 
 ! ErrLog Variables
 
-    character(len=ESMF_MAXSTR)      :: IAm
-    integer             :: STATUS
+    character(len=ESMF_MAXSTR)		:: IAm
+    integer				:: STATUS
     character(len=ESMF_MAXSTR)          :: COMP_NAME
 
 ! Local derived type aliases
-
-    type (MAPL_MetaComp),     pointer   :: State
+    
+    type (MAPL_MetaComp),     pointer   :: State 
     type (ESMF_Grid)                    :: Grid
     type (T_PrivateState),    pointer   :: PrivateSTATE
     type (T_PrivateState_Wrap)          :: WRAP
@@ -623,7 +643,7 @@ contains
     type (ESMF_State       ), pointer   :: GIM(:)
     type (ESMF_State       ), pointer   :: GEX(:)
     type (ESMF_TimeInterval)            :: timeStep
-    type (ESMF_Time)                    :: currTime
+    type (ESMF_Time)                    :: currTime 
 
     real, pointer :: MASK(:,:)
     real, pointer :: MASKO(:,:)
@@ -632,7 +652,7 @@ contains
 
 !=============================================================================
 
-! Begin...
+! Begin... 
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -666,7 +686,7 @@ contains
 
 ! Allocate the private state...
 !------------------------------
-
+    
     allocate( PrivateSTATE , stat=STATUS )
     VERIFY_(STATUS)
 
@@ -674,7 +694,7 @@ contains
 
 ! And put it in the GC
 !---------------------
-
+    
     CALL ESMF_UserCompSetInternalState( GC, TRIM(OCEAN_NAME)//'_internal_state', WRAP, STATUS )
     VERIFY_(status)
 
@@ -684,7 +704,7 @@ contains
     VERIFY_(status)
     call MAPL_GetResource(STATE,DT,  Label="OCEAN_DT:",  DEFAULT=DT, RC=STATUS) ! set Default OCEAN_DT to AGCM Heartbeat
     VERIFY_(status)
-
+    
     CALL ESMF_TimeIntervalSet(timeStep, S=NINT(DT), RC=status)
     VERIFY_(status)
 
@@ -737,20 +757,20 @@ contains
           case ("MOM")
              call MAPL_GetPointer(EXPORT, MASKO, 'MASKO'  , alloc=.true.,__RC__)
              call MAPL_GetPointer(GEX(OCN), MASK3D, 'MOM_3D_MASK', __RC__)
-             MASK => MASK3D(:,:,1)
-             if(associated(MASKO)) MASKO = MASK
+       MASK => MASK3D(:,:,1)
+       if(associated(MASKO)) MASKO = MASK
           case ("MOM6")
              call MAPL_GetPointer(GEX(OCN), MASK, 'MOM_2D_MASK', __RC__)
        end select
 
 ! The following sets the depth in orphan points. This is needed to calculate SWHEAT in these points.
-! Unfortunately, frocean is zero at this point so we set OrphanDepth in all MOM land points.
+! Unfortunately, frocean is zero at this point so we set OrphanDepth in all MOM land points. 
        call MAPL_GetPointer(GEX(OCN), DH, 'DH', __RC__)
        where(MASK == 0.0)
           DH(:,:,1) = OrphanDepth
        end where
     end if
-
+ 
     call MAPL_TimerOff(STATE,"INITIALIZE")
     call MAPL_TimerOff(STATE,"TOTAL"     )
 
@@ -759,7 +779,7 @@ contains
     RETURN_(ESMF_SUCCESS)
 
   end subroutine Initialize
-
+  
 ! ========================================================
 
 !BOP
@@ -772,7 +792,7 @@ contains
 
 ! !ARGUMENTS:
 
-    type(ESMF_GridComp), intent(INOUT) :: gc     ! Gridded component
+    type(ESMF_GridComp), intent(INOUT) :: gc     ! Gridded component 
     type(ESMF_State),    intent(INOUT) :: import ! Import state
     type(ESMF_State),    intent(INOUT) :: export ! Export state
     type(ESMF_Clock),    intent(INOUT) :: clock  ! The supervisor clock
@@ -782,13 +802,13 @@ contains
 
 ! ErrLog Variables
 
-    character(len=ESMF_MAXSTR)      :: IAm
-    integer             :: STATUS
+    character(len=ESMF_MAXSTR)		:: IAm
+    integer				:: STATUS
     character(len=ESMF_MAXSTR)          :: COMP_NAME
 
 ! Local derived type aliases
 
-    type (MAPL_MetaComp),     pointer   :: STATE
+    type (MAPL_MetaComp),     pointer   :: STATE 
     type (ESMF_Time)                    :: EndTime
     type (ESMF_Time)                    :: MyTime,ct
     type (T_PrivateState),    pointer   :: PrivateSTATE
@@ -820,7 +840,7 @@ contains
     real, pointer :: FSALT(:,:)
 
 ! Pointers to Exports
-
+    
     real, pointer :: TS_FOUND (:,:)
     real, pointer :: SS_FOUND (:,:)
     real, pointer :: FRZMLT(:,:)
@@ -921,7 +941,7 @@ contains
 
 ! Check the clocks to set set-up the "run-to" time
 !-------------------------------------------------
-
+    
     call ESMF_ClockGet( CLOCK, currTime=endTime, RC=STATUS)
     VERIFY_(status)
 
@@ -931,7 +951,7 @@ contains
     CALL ESMF_UserCompGetInternalState( GC, TRIM(OCEAN_NAME)//'_internal_state', WRAP, STATUS )
     VERIFY_(STATUS)
 
-    PrivateSTATE => WRAP%PTR
+    PrivateSTATE => WRAP%PTR 
 
     call ESMF_ClockGet( PrivateState%CLOCK, currTime=myTime, RC=STATUS)
     VERIFY_(status)
@@ -957,25 +977,26 @@ contains
 
     if( MyTime <= EndTime ) then ! Time to run
 
-! We get the ocean-land mask (now computed in Initialize of Plug)
+! We get the ocean-land mask (now computed in Initialize of Plug)  
 ! ---------------------------------------------------------------
        if(DO_DATASEA==0) then
           select case(trim(OCEAN_NAME))
              case ("MOM")
                 call MAPL_GetPointer(GEX(OCN), MASK3D, 'MOM_3D_MASK', __RC__)
-                MASK => MASK3D(:,:,1)
+          MASK => MASK3D(:,:,1)
              case ("MOM6")
                 call MAPL_GetPointer(GEX(OCN), MASK, 'MOM_2D_MASK', __RC__)
              end select
        else
           allocate(MASK3D(IM,JM,LM), STAT=STATUS); VERIFY_(STATUS)
+          MASK3D=1.0
           allocate(MASK(IM,JM), STAT=STATUS); VERIFY_(STATUS)
-          MASK3D=1.0 ; MASK=1.0
-       end if
+          MASK=1.0
+       end if       
 
 ! Get ocean time step and misc. parameters
 !-----------------------------------------
-
+       
        call MAPL_GetResource(STATE,DT,  Label="RUN_DT:",    RC=STATUS)             ! Get AGCM Heartbeat
        VERIFY_(status)
        call MAPL_GetResource(STATE,DT,  Label="OCEAN_DT:",  DEFAULT=DT, RC=STATUS) ! set Default OCEAN_DT to AGCM Heartbeat
@@ -1023,14 +1044,14 @@ contains
           call MAPL_GetPointer(GIM(OCN), SNOW, 'SNOW'  , RC=STATUS); VERIFY_(STATUS)
           call MAPL_GetPointer(GIM(OCN), SFLX, 'SFLX'  , RC=STATUS); VERIFY_(STATUS)
        end if
-
+       
        call MAPL_GetPointer(GEX(OCN), TW,   'TW'  , alloc=.true., RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(GEX(OCN), SW,   'SW'  , alloc=.true., RC=STATUS); VERIFY_(STATUS)
 
        if(DO_DATASEA==0) then
           call MAPL_GetPointer(GEX(OCN), FRAZIL,   'FRAZIL'  , alloc=.true., RC=STATUS); VERIFY_(STATUS)
        end if
-
+       
 ! Get pointers to exports
 !--------------------------------------------------------
 
@@ -1040,19 +1061,19 @@ contains
 
 ! Diagnostics exports
 !---------------------------------------------------------
-       call MAPL_GetPointer(EXPORT, RFLUX,      'RFLUX',     __RC__)
-       call MAPL_GetPointer(EXPORT, FROCEANe,   'FROCEAN',   __RC__)
-       call MAPL_GetPointer(EXPORT, TAUXe,      'TAUX',      __RC__)
-       call MAPL_GetPointer(EXPORT, TAUYe,      'TAUY',      __RC__)
-       call MAPL_GetPointer(EXPORT, HEATe,      'SWHEAT',    __RC__)
-       call MAPL_GetPointer(EXPORT, DISCHARGEe, 'DISCHARGE', __RC__)
-       call MAPL_GetPointer(EXPORT, LWFLXe,     'LWFLX',     __RC__)
-       call MAPL_GetPointer(EXPORT, SWFLXe,     'SWFLX',     __RC__)
-       call MAPL_GetPointer(EXPORT, SHFLXe,     'SHFLX',     __RC__)
-       call MAPL_GetPointer(EXPORT, QFLUXe,     'QFLUX',     __RC__)
-       call MAPL_GetPointer(EXPORT, RAINe,      'RAIN',      __RC__)
-       call MAPL_GetPointer(EXPORT, SNOWe,      'SNOW',      __RC__)
-       call MAPL_GetPointer(EXPORT, SFLXe,      'SFLX',      __RC__)
+       call MAPL_GetPointer(EXPORT, RFLUX,  'RFLUX' , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, FROCEANe,'FROCEAN', RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, TAUXe, 'TAUX'   , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, TAUYe, 'TAUY'   , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, HEATe, 'SWHEAT' , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, DISCHARGEe, 'DISCHARGE'  , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, LWFLXe, 'LWFLX'  , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, SWFLXe, 'SWFLX'  , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, SHFLXe, 'SHFLX'  , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, QFLUXe, 'QFLUX'  , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, RAINe, 'RAIN'  , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, SNOWe, 'SNOW'  , RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT, SFLXe, 'SFLX'  , RC=STATUS); VERIFY_(STATUS)       
 
        if(associated(FROCEANe)) FROCEANe = FROCEAN
 
@@ -1082,8 +1103,8 @@ contains
           DISCHARGE = DISCHARGEi * WGHT
           LWFLX = LWFLXi * WGHT
           QFLUX = QFLUXi * WGHT
-          SHFLX = (SHFLXi- FHOCN) * WGHT
-          RAIN = (RAINi+FRESH) * WGHT
+          SHFLX = (SHFLXi- FHOCN) * WGHT 
+          RAIN = (RAINi+FRESH) * WGHT 
           SNOW = SNOWi * WGHT
           SFLX = FSALT * WGHT
 
@@ -1092,23 +1113,23 @@ contains
           TAUX = TAUXi * WGHT
           TAUY = TAUYi * WGHT
 
-
+       
 ! Prepare radiative heating for ocean
 !------------------------------------
 
           if(associated(RFLUX )) RFLUX  = 0.0
           select case (trim(OCEAN_NAME))
              case ("MOM", "DATASEA")
-                do L=1,LM
-                   HEAT(:,:,L) = HEATi(:,:,L)*WGHT
-                   if(associated(RFLUX)) then
-                      RFLUX = RFLUX + (1.0-MASK3D(:,:,L))*HEAT(:,:,L)
-                   end if
-                end do
+          do L=1,LM
+             HEAT(:,:,L) = HEATi(:,:,L)*WGHT 
+             if(associated(RFLUX)) then
+                RFLUX = RFLUX + (1.0-MASK3D(:,:,L))*HEAT(:,:,L)
+             end if
+          end do
              case ("MOM6")
                 ! No 3D Mask from MOM6. Do nothing for now!
           end select
-
+          
           if (associated(HEATe)) HEATe = HEAT
           if (associated(TAUXe)) TAUXe = TAUX
           if (associated(TAUYe)) TAUYe = TAUY
@@ -1127,7 +1148,7 @@ contains
 
        NUM = 0
        do while ( MyTime <= endTime )
-
+          
 ! Run ocean for one time step (DT)
 !---------------------------------
 
@@ -1150,7 +1171,7 @@ contains
 
        end do
 
-       if(associated(SS_FOUND)) then
+       if(associated(SS_FOUND)) then 
           SS_FOUND = OrphanSalinity
           where(WGHT > 0.0)
              SS_FOUND = SW
@@ -1166,14 +1187,14 @@ contains
              FRZMLT = 0.0
        end if
        end if
-
+       
        where(WGHT > 0.0)
           TS_FOUND = TW
           end where
 
 ! Update orphan points
        if(DO_DATASEA == 0) then
-          WGHT=FROCEAN*(1.0-MASK)
+          WGHT=FROCEAN*(1-MASK)                    
           Tfreeze=MAPL_TICE-0.054*OrphanSalinity
 
           where(wght>0.0)
@@ -1182,7 +1203,7 @@ contains
              FRZMLT = (Tfreeze - TS_FOUND) * (MAPL_RHO_SEAWATER*MAPL_CAPWTR*OrphanDepth)/DT
              TS_FOUND=max(TS_FOUND, Tfreeze)
           end where
-
+        
        end if
 
        deallocate(WGHT, STAT=STATUS); VERIFY_(STATUS)
@@ -1191,7 +1212,7 @@ contains
           deallocate(MASK3D, STAT=STATUS); VERIFY_(STATUS)
           deallocate(MASK, STAT=STATUS); VERIFY_(STATUS)
        end if
-
+    
     end if ! Time to run
 
 ! Profilers


### PR DESCRIPTION
This PR adapts `GuestOcean_GridComp.F90` to select DATASEA, MOM5 or MOM6 at runtime.  MOM6 plug was introduced in PR #73. In this PR a stub for MOM6 is being created to test for zero-diff changes introduced by modifying the `GuestOcean_GridComp.F90`.

Benchmark comparisons are performed by running a 24 hour forecast on Discover in both AMIP and coupled (w/ MOM5) modes.  The experiments are available here:
```
/discover/nobackup/rmahajan/experiments/master_amip
/discover/nobackup/rmahajan/experiments/stub_amip
/discover/nobackup/rmahajan/experiments/master_cpld
/discover/nobackup/rmahajan/experiments/stub_cpld
```

The AGCM (and Ocean) checkpoints were compared using `nccmp -dfmgS` between the `develop` and `feature/mom6-stub` branch using:
`/discover/nobackup/rmahajan/experiments/compare_rst.sh` and can be executed as:

```
$> compare_rst.sh master_amip stub_amip
$> compare_rst.sh master_cpld stub_cpld
```

This is ongoing work related to issue GEOS-ESM/GEOSgcm_GridComp#70
