### PR TITLE
Fixes #75. Renames GFDL_fms to fms

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/FVdycoreCubed_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
-tag = v1.0.6
+tag = v1.0.7
 externals = Externals.cfg
 protocol = git
 
@@ -17,7 +17,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/MOM5.git
 local_path = ./GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom
-tag = geos/v1.0.0
+tag = geos/v1.0.1
 protocol = git
 
 [externals_description]

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -10,7 +10,7 @@ set (srcs
   # ras00.F90 cloud.F90
   )
 
-get_target_property (extra_incs GFDL_fms_r4 INCLUDE_DIRECTORIES)
+get_target_property (extra_incs fms_r4 INCLUDE_DIRECTORIES)
 
 esma_add_library (${this}
   SRCS ${srcs}


### PR DESCRIPTION
This has two places to fix. One is `Externals.cfg` and the other is in
the Moist `CMakeLists.txt`.

For `Externals.cfg` we point to new versions of FV3 and MOM.

For Moist, we rename the library