### PR TITLE
Fix Chem GC to allow Debug build

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -10,7 +10,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/GEOSchem_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
-tag = v1.0.3
+tag = v1.0.4
 protocol = git
 
 [mom]


### PR DESCRIPTION
The @GEOS-ESM/chemistry-gatekeepers were nice enough to create a new release, v1.0.4, that has a fix to re-enable the the debug build. See GEOS-ESM/GEOSchem_GridComp#30 and GEOS-ESM/GEOSchem_GridComp#31.

I'm labeling as 0-diff trivial as it does not really affect running the model in GOCART, etc. mode at all (or even GMI). But please test if needed.