### PR TITLE
clarified LONG_NAME of "snow depth" variable

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -1361,7 +1361,7 @@ module GEOS_SurfaceGridCompMod
     VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'snow_depth'                        ,&
+        LONG_NAME          = 'snow_depth_within_snow_covered_area_fraction'   ,&
         UNITS              = 'm'                                 ,&
         SHORT_NAME         = 'SNOWDP'                            ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
@@ -1872,7 +1872,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snow_depth_in_snow_covered_area' ,&
+    LONG_NAME          = 'snow_depth_within_snow_covered_area_fraction'   ,&
     UNITS              = 'm'                         ,&
     SHORT_NAME         = 'SNOWDP'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&


### PR DESCRIPTION
Trying to correct a long-standing problem with users misunderstanding of the GEOS snow mass and snow depth output.   See "snow depth" entry in MERRA-2 FAQ:
[https://gmao.gsfc.nasa.gov/reanalysis/MERRA-2/FAQ/#](url)
This has been an issue for years, with multiple inquiries about "funny" MERRA-2 output.  This past summer, we narrowly avoided two peer-reviewed papers by ECMWF and Meteo-France showing very unhelpful MERRA-2 results.  Ask me if you want to know more.
By fixing the F90 src code, we have at least a chance of getting this critical information into new versions of GEOS file specs documents.
Similar edits may be good to have for snow depth over glaciated surfaces, which is why I added @lcandre2 and @zhaobin74 to the list of reviewers.  (Richard Cullather isn't on Github.)

