### PR TITLE
pmn: bugfix for all-sky-no-aerosol longwave fluxes under Chou-Suarez

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/irrad.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/irrad.F90
@@ -1032,7 +1032,7 @@ contains
             bu(k2-1)=(blevel(k2-1)+blevel(k2))-bd(k2-1)
 
             if(do_aerosol) then
-               xx=taant
+               xx=(1.-enn(k2-1))*taant
                yy=min(0.9999,xx)
                yy=max(0.00001,yy)
                xx=(blevel(k2-1)-blevel(k2))/alog(yy)


### PR DESCRIPTION
Fixes issue #172 
Pete Colarco identified an issue with the all-sky no-aerosol fluxes from the Chou-Suarez longwave code. There is erroneous cloud contamination in OLR-OLRNA (aerosol forcing). Peter Norris has tracked down the bug is pushing this bugfix to the develop branch. It will be "zero-diff" in the sense that Chou-Suarez is no longer the default.
