### PR TITLE
Update CircleCI with checkout-if-exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             mepo init
             mepo clone
             mepo develop GEOSgcm_GridComp GEOSgcm_App
-            mepo checkout ${CIRCLE_BRANCH} GEOSgcm_GridComp
+            mepo checkout-if-exists ${CIRCLE_BRANCH}
             mepo status
       - run:
           name: "Fix linker flags"


### PR DESCRIPTION
The latest version of `mepo` has the ability to do:
```
mepo checkout-if-exists <branch>
```
which then checks out <branch> on any sub-repo that has it.