### PR TITLE
Fix logging error with ESMF in GCM

### DIFF
--- a/GEOS_GcmGridComp.F90
+++ b/GEOS_GcmGridComp.F90
@@ -1702,7 +1702,9 @@ contains
 
     ! Ensure Active PREDICTOR_STEP Alarm of OFF
     ! -----------------------------------------
-    IF(ESMF_AlarmIsRinging(PredictorIsActive)) CALL ESMF_AlarmRingerOff(PredictorIsActive, RC=STATUS)
+    if(ESMF_AlarmIsCreated(PredictorIsActive)) then
+       IF(ESMF_AlarmIsRinging(PredictorIsActive)) CALL ESMF_AlarmRingerOff(PredictorIsActive, RC=STATUS)
+    end if
     VERIFY_(STATUS)
 
     ! the usual time step


### PR DESCRIPTION
ESMF was logging an error due to calling `ESMF_AlarmIsRinging` on an alarm that's only created if running replay (I think?). So we protect to make sure the alarm is created.