### PR TITLE
J36p2_updates

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -10,7 +10,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/GEOSchem_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
-tag = v1.2.0
+tag = v1.3.1
 protocol = git
 
 [mom]

--- a/GEOS_GcmGridComp.F90
+++ b/GEOS_GcmGridComp.F90
@@ -1052,8 +1052,7 @@ contains
                                            RingInterval = CORRECTOR_DURATION, sticky=.false., rc=status )
        VERIFY_(STATUS)
 
-       replayShutoffAlarm = ESMF_AlarmCreate( name='ReplayShutOff', clock=clock, &
-                                              RingInterval = Shutoff, sticky=.false., RC=STATUS )
+       replayShutoffAlarm = ESMF_AlarmCreate( name='ReplayShutOff', clock=clock, RingInterval = Shutoff, sticky=.true., RC=STATUS )
        VERIFY_(STATUS)
 
 
@@ -1677,7 +1676,7 @@ contains
           if (shutoffRpl ) then
              ! clear IAU tendencies
              ! --------------------
-             if( MAPL_AM_I_Root() ) PRINT *,TRIM(Iam)//":  Zeroing IAU forcing ..."
+             ! if( MAPL_AM_I_Root() ) PRINT *,TRIM(Iam)//":  Zeroing IAU forcing ..."
              call ESMF_GridCompRun ( GCS(AIAU), importState=GIM(AIAU), exportState=GEX(AIAU), clock=clock, phase=2, userRC=status )
              VERIFY_(STATUS)
              call MAPL_GetObjectFromGC ( GCS(AGCM), MAPL_AGCM, RC=STATUS)

--- a/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
@@ -1273,14 +1273,6 @@ contains
    if(   (adjustl(ReplayMode)=="Exact"  ) .or.   &
        ( (adjustl(ReplayMode)=="Regular") .and. (PREDICTOR_DURATION.gt.MKIAU_FREQUENCY/2) )  ) then
 
-      call MAPL_GetResource(STATE, RPL_SHUTOFF, 'REPLAY_SHUTOFF:', default=4000*21600., RC=STATUS ) ! Default: 1000 days
-      VERIFY_(STATUS)
-      call ESMF_TimeIntervalSet(TIMEINT, S=nint(RPL_SHUTOFF), RC=STATUS)
-      VERIFY_(STATUS)
-
-      ALARM = ESMF_AlarmCreate ( name='ReplayShutOff', clock=CLOCK, ringInterval=TIMEINT, sticky=.false., RC=STATUS )
-      VERIFY_(STATUS)
-
       call MAPL_GetResource(STATE, RPL_INTERVAL, 'REPLAY_INTERVAL:', default=21600., RC=STATUS )
       VERIFY_(STATUS)
       call ESMF_TimeIntervalSet(TIMEINT, S=nint(RPL_INTERVAL), RC=STATUS)


### PR DESCRIPTION
Changed REPLAY_Shutoff alarm from NON-STICKY to STICKY, and used it in GAAS to stop updates in forecasts during REPLAY mode. This PR must be taken with [GEOSchem_GridComp#67](https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/67).