### PR TITLE
bug fix: removed local declaration of SURFLAY in RUN0

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
@@ -5873,7 +5873,6 @@ subroutine RUN0(gc, import, export, clock, rc)
   !! Miscellaneous
   integer :: ntiles
   real, allocatable :: dummy(:)
-  real :: SURFLAY
   real, allocatable :: dzsf(:), ar1(:), ar2(:), wesnn(:,:)
   real, allocatable :: catdefcp(:), srfexccp(:), rzexccp(:)
 


### PR DESCRIPTION
A bug was identified in the most recent merge #240.  (See also GEOSldas merge no. 160).

The bug fix removes the local declaration of variable SURFLAY in subroutine RUN0() of GEOS_CatchGridComp.F90.  This declaration was inadvertently left in place and should have been removed before the most recent merge #240.

The bug left SURFLAY locally undefined, and the model crashed in the GEOSldas **debug** tests with both the Intel and GNU compilers.

When the build used optimization, the compilers apparently corrected the problem, which would explain the 0-diff results obtained before the most recent merge #240.

The bug was revealed in the LDAS Nightly Tests, which include "debug" version of the "conus" test.  To date, this "debugconus" test was not required for the approval of pull requests.  Going forward, the "debugconus" test will be required.

The bug fix was tested successfully using the Intel compiler and the GEOSldas "debugconus" test.

For the GNU tests, the LDAS_Nightly_Cron.csh script seems to always test the "develop" branch (regardless of the "-b [BRANCH]" argument supplied).  This will need to be addressed separately.  

cc: @mathomp4 , @smahanam , @weiyuan-jiang , @tclune , @rdkoster   


