### PR TITLE
Update CircleCI to use 6.0.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gmao/geos-build-env-gcc-source:6.0.10
+      - image: gmao/geos-build-env-gcc-source:6.0.11
     working_directory: /root/project
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gmao/geos-build-env-gcc-source:6.0.4
+      - image: gmao/geos-build-env-gcc-source:6.0.10
     working_directory: /root/project
     steps:
       - run:


### PR DESCRIPTION
This is future proofing for MAPL 2.1 which needs Baselibs 6.0.10. Will work even now.