### PR TITLE
Update Externals for FV3 GC 1.1.1

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/FVdycoreCubed_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
-tag = v1.1.0
+tag = v1.1.1
 externals = Externals.cfg
 protocol = git
 


### PR DESCRIPTION
This will fix a bug in `interp_restarts.x` preventing `regrid.pl` from working.