### PR TITLE
Move to use Baselibs 6.0.13 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gmao/geos-build-env-gcc-source:6.0.12
+      - image: gmao/geos-build-env-gcc-source:6.0.13-openmpi_4.0.3-gcc_9.3.0
     working_directory: /root/project
     steps:
       - run:


### PR DESCRIPTION
Keep CI in sync with master GEOSgcm. Zero-diff.