### PR TITLE
Update to GEOSchem_GridComp v1.3.5

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -10,7 +10,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/GEOSchem_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
-tag = v1.3.4
+tag = v1.3.5
 protocol = git
 
 [mom]


### PR DESCRIPTION
This is a zero-diff update to Chem to support MAPL 2.2