### PR TITLE
renamed F90 variables: master --> root

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
@@ -162,7 +162,7 @@ module gfdl2_cloud_microphys_mod
     
     logical :: tables_are_initialized = .false.
     
-    ! logical :: rootproc
+    ! logical :: root_proc
     ! integer :: id_rh, id_vtr, id_vts, id_vtg, id_vti, id_rain, id_snow, id_graupel, &
     ! id_ice, id_prec, id_cond, id_var, id_droplets
     ! integer :: gfdl_mp_clock ! clock for timing of driver routine
@@ -546,7 +546,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! used = send_data (id_snow, snow, time, is_in = iis, js_in = jjs)
     ! if (mp_print .and. seconds == 0) then
     ! tot_prec = g_sum (snow, is, ie, js, je, area, 1)
-    ! if (rootproc) write (*, *) 'mean snow = ', tot_prec
+    ! if (root_proc) write (*, *) 'mean snow = ', tot_prec
     ! endif
     ! endif
     !
@@ -555,7 +555,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! used = send_data (id_graupel, graupel, time, is_in = iis, js_in = jjs)
     ! if (mp_print .and. seconds == 0) then
     ! tot_prec = g_sum (graupel, is, ie, js, je, area, 1)
-    ! if (rootproc) write (*, *) 'mean graupel = ', tot_prec
+    ! if (root_proc) write (*, *) 'mean graupel = ', tot_prec
     ! endif
     ! endif
     !
@@ -564,7 +564,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! used = send_data (id_ice, ice, time, is_in = iis, js_in = jjs)
     ! if (mp_print .and. seconds == 0) then
     ! tot_prec = g_sum (ice, is, ie, js, je, area, 1)
-    ! if (rootproc) write (*, *) 'mean ice_mp = ', tot_prec
+    ! if (root_proc) write (*, *) 'mean ice_mp = ', tot_prec
     ! endif
     ! endif
     !
@@ -573,7 +573,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! used = send_data (id_rain, rain, time, is_in = iis, js_in = jjs)
     ! if (mp_print .and. seconds == 0) then
     ! tot_prec = g_sum (rain, is, ie, js, je, area, 1)
-    ! if (rootproc) write (*, *) 'mean rain = ', tot_prec
+    ! if (root_proc) write (*, *) 'mean rain = ', tot_prec
     ! endif
     ! endif
     !
@@ -593,7 +593,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! if (seconds == 0) then
     ! prec1 (:, :) = prec1 (:, :) * dt_in / 86400.
     ! tot_prec = g_sum (prec1, is, ie, js, je, area, 1)
-    ! if (rootproc) write (*, *) 'daily prec_mp = ', tot_prec
+    ! if (root_proc) write (*, *) 'daily prec_mp = ', tot_prec
     ! prec1 (:, :) = 0.
     ! endif
     ! endif
@@ -3359,12 +3359,12 @@ subroutine setupm
     fac_rc = (4. / 3.) * pie * rhor * rthresh ** 3
     
     if (prog_ccn) then
-        ! if (rootproc) write (*, *) 'prog_ccn option is .t.'
+        ! if (root_proc) write (*, *) 'prog_ccn option is .t.'
     else
         den_rc = fac_rc * ccn_o * 1.e6
-        ! if (rootproc) write (*, *) 'mp: for ccn_o = ', ccn_o, 'ql_rc = ', den_rc
+        ! if (root_proc) write (*, *) 'mp: for ccn_o = ', ccn_o, 'ql_rc = ', den_rc
         den_rc = fac_rc * ccn_l * 1.e6
-        ! if (rootproc) write (*, *) 'mp: for ccn_l = ', ccn_l, 'ql_rc = ', den_rc
+        ! if (root_proc) write (*, *) 'mp: for ccn_l = ', ccn_l, 'ql_rc = ', den_rc
     endif
     
     vdifu = 2.11e-5
@@ -3487,7 +3487,7 @@ subroutine gfdl_cloud_microphys_init ()
     ! logical :: flag
     ! real :: tmp, q1, q2
     
-    ! rootproc = (mpp_pe () .eq.mpp_root_pe ())
+    ! root_proc = (mpp_pe () .eq.mpp_root_pe ())
     
 #ifdef INTERNAL_FILE_NML
     read (input_nml_file, nml = gfdl_cloud_microphysics_nml)
@@ -3514,7 +3514,7 @@ subroutine gfdl_cloud_microphys_init ()
     endif
     
     ! write version number and namelist to log file
-   !if (me == rootproc) then
+   !if (me == root_proc) then
    !    write (logunit, *) " ================================================================== "
    !    write (logunit, *) "gfdl_cloud_microphys_mod"
    !    write (logunit, nml = gfdl_cloud_microphysics_nml)
@@ -3531,7 +3531,7 @@ subroutine gfdl_cloud_microphys_init ()
     tice0 = tice - 0.01
     t_wfr = tice - 40.0 ! supercooled water can exist down to - 48 c, which is the "absolute"
     
-    ! if (rootproc) write (logunit, nml = gfdl_cloud_microphys_nml)
+    ! if (root_proc) write (logunit, nml = gfdl_cloud_microphys_nml)
     !
     ! id_vtr = register_diag_field (mod_name, 'vt_r', axes (1:3), time, &
     ! 'rain fall speed', 'm / s', missing_value = missing_value)
@@ -3558,7 +3558,7 @@ subroutine gfdl_cloud_microphys_init ()
     ! id_prec = register_diag_field (mod_name, 'prec_lin', axes (1:2), time, &
     ! 'prec_lin', 'mm / day', missing_value = missing_value)
     
-    ! if (rootproc) write (*, *) 'prec_lin diagnostics initialized.', id_prec
+    ! if (root_proc) write (*, *) 'prec_lin diagnostics initialized.', id_prec
     
     ! id_cond = register_diag_field (mod_name, 'cond_lin', axes (1:2), time, &
     ! 'total condensate', 'kg / m ** 2', missing_value = missing_value)
@@ -3569,7 +3569,7 @@ subroutine gfdl_cloud_microphys_init ()
     
     ! testing the water vapor tables
     
-    ! if (mp_debug .and. rootproc) then
+    ! if (mp_debug .and. root_proc) then
     ! write (*, *) 'testing water vapor tables in gfdl_cloud_microphys'
     ! tmp = tice - 90.
     ! do k = 1, 25
@@ -3580,7 +3580,7 @@ subroutine gfdl_cloud_microphys_init ()
     ! enddo
     ! endif
     
-    ! if (rootproc) write (*, *) 'gfdl_cloud_micrphys diagnostics initialized.'
+    ! if (root_proc) write (*, *) 'gfdl_cloud_micrphys diagnostics initialized.'
     
     ! gfdl_mp_clock = mpp_clock_id ('gfdl_cloud_microphys', grain = clock_routine)
     
@@ -3620,7 +3620,7 @@ subroutine setup_con
     
     implicit none
     
-    ! rootproc = (mpp_pe () .eq.mpp_root_pe ())
+    ! root_proc = (mpp_pe () .eq.mpp_root_pe ())
     
     rgrav = 1. / grav
     
@@ -3715,8 +3715,8 @@ subroutine qsmith_init
     
     if (.not. tables_are_initialized) then
         
-        ! rootproc = (mpp_pe () .eq. mpp_root_pe ())
-        ! if (rootproc) print *, ' gfdl mp: initializing qs tables'
+        ! root_proc = (mpp_pe () .eq. mpp_root_pe ())
+        ! if (root_proc) print *, ' gfdl mp: initializing qs tables'
         
         ! debug code
         ! print *, mpp_pe (), allocated (table), allocated (table2), &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
@@ -162,7 +162,7 @@ module gfdl2_cloud_microphys_mod
     
     logical :: tables_are_initialized = .false.
     
-    ! logical :: master
+    ! logical :: rootproc
     ! integer :: id_rh, id_vtr, id_vts, id_vtg, id_vti, id_rain, id_snow, id_graupel, &
     ! id_ice, id_prec, id_cond, id_var, id_droplets
     ! integer :: gfdl_mp_clock ! clock for timing of driver routine
@@ -546,7 +546,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! used = send_data (id_snow, snow, time, is_in = iis, js_in = jjs)
     ! if (mp_print .and. seconds == 0) then
     ! tot_prec = g_sum (snow, is, ie, js, je, area, 1)
-    ! if (master) write (*, *) 'mean snow = ', tot_prec
+    ! if (rootproc) write (*, *) 'mean snow = ', tot_prec
     ! endif
     ! endif
     !
@@ -555,7 +555,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! used = send_data (id_graupel, graupel, time, is_in = iis, js_in = jjs)
     ! if (mp_print .and. seconds == 0) then
     ! tot_prec = g_sum (graupel, is, ie, js, je, area, 1)
-    ! if (master) write (*, *) 'mean graupel = ', tot_prec
+    ! if (rootproc) write (*, *) 'mean graupel = ', tot_prec
     ! endif
     ! endif
     !
@@ -564,7 +564,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! used = send_data (id_ice, ice, time, is_in = iis, js_in = jjs)
     ! if (mp_print .and. seconds == 0) then
     ! tot_prec = g_sum (ice, is, ie, js, je, area, 1)
-    ! if (master) write (*, *) 'mean ice_mp = ', tot_prec
+    ! if (rootproc) write (*, *) 'mean ice_mp = ', tot_prec
     ! endif
     ! endif
     !
@@ -573,7 +573,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! used = send_data (id_rain, rain, time, is_in = iis, js_in = jjs)
     ! if (mp_print .and. seconds == 0) then
     ! tot_prec = g_sum (rain, is, ie, js, je, area, 1)
-    ! if (master) write (*, *) 'mean rain = ', tot_prec
+    ! if (rootproc) write (*, *) 'mean rain = ', tot_prec
     ! endif
     ! endif
     !
@@ -593,7 +593,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     ! if (seconds == 0) then
     ! prec1 (:, :) = prec1 (:, :) * dt_in / 86400.
     ! tot_prec = g_sum (prec1, is, ie, js, je, area, 1)
-    ! if (master) write (*, *) 'daily prec_mp = ', tot_prec
+    ! if (rootproc) write (*, *) 'daily prec_mp = ', tot_prec
     ! prec1 (:, :) = 0.
     ! endif
     ! endif
@@ -3359,12 +3359,12 @@ subroutine setupm
     fac_rc = (4. / 3.) * pie * rhor * rthresh ** 3
     
     if (prog_ccn) then
-        ! if (master) write (*, *) 'prog_ccn option is .t.'
+        ! if (rootproc) write (*, *) 'prog_ccn option is .t.'
     else
         den_rc = fac_rc * ccn_o * 1.e6
-        ! if (master) write (*, *) 'mp: for ccn_o = ', ccn_o, 'ql_rc = ', den_rc
+        ! if (rootproc) write (*, *) 'mp: for ccn_o = ', ccn_o, 'ql_rc = ', den_rc
         den_rc = fac_rc * ccn_l * 1.e6
-        ! if (master) write (*, *) 'mp: for ccn_l = ', ccn_l, 'ql_rc = ', den_rc
+        ! if (rootproc) write (*, *) 'mp: for ccn_l = ', ccn_l, 'ql_rc = ', den_rc
     endif
     
     vdifu = 2.11e-5
@@ -3487,7 +3487,7 @@ subroutine gfdl_cloud_microphys_init ()
     ! logical :: flag
     ! real :: tmp, q1, q2
     
-    ! master = (mpp_pe () .eq.mpp_root_pe ())
+    ! rootproc = (mpp_pe () .eq.mpp_root_pe ())
     
 #ifdef INTERNAL_FILE_NML
     read (input_nml_file, nml = gfdl_cloud_microphysics_nml)
@@ -3514,7 +3514,7 @@ subroutine gfdl_cloud_microphys_init ()
     endif
     
     ! write version number and namelist to log file
-   !if (me == master) then
+   !if (me == rootproc) then
    !    write (logunit, *) " ================================================================== "
    !    write (logunit, *) "gfdl_cloud_microphys_mod"
    !    write (logunit, nml = gfdl_cloud_microphysics_nml)
@@ -3531,7 +3531,7 @@ subroutine gfdl_cloud_microphys_init ()
     tice0 = tice - 0.01
     t_wfr = tice - 40.0 ! supercooled water can exist down to - 48 c, which is the "absolute"
     
-    ! if (master) write (logunit, nml = gfdl_cloud_microphys_nml)
+    ! if (rootproc) write (logunit, nml = gfdl_cloud_microphys_nml)
     !
     ! id_vtr = register_diag_field (mod_name, 'vt_r', axes (1:3), time, &
     ! 'rain fall speed', 'm / s', missing_value = missing_value)
@@ -3558,7 +3558,7 @@ subroutine gfdl_cloud_microphys_init ()
     ! id_prec = register_diag_field (mod_name, 'prec_lin', axes (1:2), time, &
     ! 'prec_lin', 'mm / day', missing_value = missing_value)
     
-    ! if (master) write (*, *) 'prec_lin diagnostics initialized.', id_prec
+    ! if (rootproc) write (*, *) 'prec_lin diagnostics initialized.', id_prec
     
     ! id_cond = register_diag_field (mod_name, 'cond_lin', axes (1:2), time, &
     ! 'total condensate', 'kg / m ** 2', missing_value = missing_value)
@@ -3569,7 +3569,7 @@ subroutine gfdl_cloud_microphys_init ()
     
     ! testing the water vapor tables
     
-    ! if (mp_debug .and. master) then
+    ! if (mp_debug .and. rootproc) then
     ! write (*, *) 'testing water vapor tables in gfdl_cloud_microphys'
     ! tmp = tice - 90.
     ! do k = 1, 25
@@ -3580,7 +3580,7 @@ subroutine gfdl_cloud_microphys_init ()
     ! enddo
     ! endif
     
-    ! if (master) write (*, *) 'gfdl_cloud_micrphys diagnostics initialized.'
+    ! if (rootproc) write (*, *) 'gfdl_cloud_micrphys diagnostics initialized.'
     
     ! gfdl_mp_clock = mpp_clock_id ('gfdl_cloud_microphys', grain = clock_routine)
     
@@ -3620,7 +3620,7 @@ subroutine setup_con
     
     implicit none
     
-    ! master = (mpp_pe () .eq.mpp_root_pe ())
+    ! rootproc = (mpp_pe () .eq.mpp_root_pe ())
     
     rgrav = 1. / grav
     
@@ -3715,8 +3715,8 @@ subroutine qsmith_init
     
     if (.not. tables_are_initialized) then
         
-        ! master = (mpp_pe () .eq. mpp_root_pe ())
-        ! if (master) print *, ' gfdl mp: initializing qs tables'
+        ! rootproc = (mpp_pe () .eq. mpp_root_pe ())
+        ! if (rootproc) print *, ' gfdl mp: initializing qs tables'
         
         ! debug code
         ! print *, mpp_pe (), allocated (table), allocated (table2), &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/CNEcosystemDynMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/CNEcosystemDynMod.F90
@@ -45,7 +45,6 @@ contains
 !
 ! !USES:
     use clmtype
-!   use spmdMod              , only: masterproc
     use CNSetValueMod        , only: CNZeroFluxes
     use CNNDynamicsMod       , only: CNNDeposition,CNNFixation, CNNLeaching
     use CNMRespMod           , only: CNMResp

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/math_routines.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/math_routines.F90
@@ -12,7 +12,7 @@ integer, parameter :: nbins = 40, N_RANDOM_YEARS = 41
 ! initialize to non-MPI values
   include 'mpif.h'	
 !integer,public   :: myid=0, numprocs=1, mpierr, mpistatus(MPI_STATUS_SIZE)  
-!logical, public  :: master_proc=.true.
+!logical, public  :: root_proc=.true.
 
 contains
 
@@ -1173,12 +1173,12 @@ END SUBROUTINE RSQ
  !   call MPI_COMM_RANK( MPI_COMM_WORLD, myid, mpierr )
  !   call MPI_COMM_SIZE( MPI_COMM_WORLD, numprocs, mpierr )
  !
- !   if (myid .ne. 0)  master_proc = .false.
+ !   if (myid .ne. 0)  root_proc = .false.
  !   
 !!    call init_MPI_types()
  !   
  !   write (*,*) "MPI process ", myid, " of ", numprocs, " is alive"    
- !   write (*,*) "MPI process ", myid, ": master_proc=", master_proc
+ !   write (*,*) "MPI process ", myid, ": root_proc=", root_proc
 !
 !  end subroutine init_MPI
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/mk_restarts/mk_CatchRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/mk_restarts/mk_CatchRestarts.F90
@@ -11,7 +11,7 @@ program  mk_CatchRestarts
   ! initialize to non-MPI values
 
   integer  :: myid=0, numprocs=1, mpierr, mpistatus(MPI_STATUS_SIZE)  
-  logical  :: master_proc=.true.
+  logical  :: root_proc=.true.
 
   character*256 :: Usage="mk_CatchRestarts OutTileFile InTileFile InRestart SURFLAY <OutIsOld>"
   character*256 :: OutTileFile
@@ -72,7 +72,7 @@ program  mk_CatchRestarts
 
   inquire(file=trim(DataDir)//"mosaic_veg_typs_fracs",exist=havedata)
 
-  if (master_proc) then
+  if (root_proc) then
 
      ! Read Output/Input  .til files
      call ReadTileFile_RealLatLon(OutTileFile, ntiles, lono, lato)  
@@ -87,7 +87,7 @@ program  mk_CatchRestarts
   endif
 
   if (havedata) then
-     if (master_proc) call read_and_write_rst (NTILES, SURFLAY, OutIsOld, NTILES)
+     if (root_proc) call read_and_write_rst (NTILES, SURFLAY, OutIsOld, NTILES)
   else
 
      call MPI_BCAST  (ntiles   , 1, MPI_INTEGER, 0,MPI_COMM_WORLD, mpierr)
@@ -232,7 +232,7 @@ program  mk_CatchRestarts
      deallocate (loni,lati,lonn,latt, tid_in)
      call MPI_Barrier(MPI_COMM_WORLD, mpierr)
  
-     if (master_proc) call read_and_write_rst (NTILES, SURFLAY, OutIsOld, NTILES_IN, id)
+     if (root_proc) call read_and_write_rst (NTILES, SURFLAY, OutIsOld, NTILES_IN, id)
   
   endif
 
@@ -763,10 +763,10 @@ contains
     call MPI_COMM_RANK( MPI_COMM_WORLD, myid, mpierr )
     call MPI_COMM_SIZE( MPI_COMM_WORLD, numprocs, mpierr )
 
-    if (myid .ne. 0)  master_proc = .false.
+    if (myid .ne. 0)  root_proc = .false.
         
 !    write (*,*) "MPI process ", myid, " of ", numprocs, " is alive"    
-!    write (*,*) "MPI process ", myid, ": master_proc=", master_proc
+!    write (*,*) "MPI process ", myid, ": root_proc=", root_proc
 
   end subroutine init_MPI
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
@@ -998,12 +998,12 @@ contains
 
 ! ---------------------------------------------------------------------------
 
-  subroutine InitializeRiverRouting(MYPE, numprocs, master_proc,           &
+  subroutine InitializeRiverRouting(MYPE, numprocs, root_proc,           &
        pfaf_code, AllActive, AlldstCatchID, srcProcsID, LocDstCatchID, rc)
     
     implicit none
     INTEGER, INTENT (IN)                             :: MYPE, numprocs
-    LOGICAL, INTENT (IN)                             :: master_proc
+    LOGICAL, INTENT (IN)                             :: root_proc
     INTEGER, DIMENSION (:),  INTENT (IN)             :: pfaf_code
     INTEGER, DIMENSION (N_CatG),          INTENT (INOUT) :: srcProcsID, LocDstCatchID
     INTEGER, DIMENSION (N_CatG,numprocs), INTENT (INOUT) :: Allactive,  AlldstCatchID
@@ -1052,7 +1052,7 @@ contains
        Allactive (:,i) = global_buff((i-1)*N_CatG+1:i*N_CatG)
     enddo
 
-    if (master_proc) then
+    if (root_proc) then
 
        DO N = 1, N_CatG
           NPROCS = count(Allactive(N,:) >= 1)


### PR DESCRIPTION
@sdrabenh : This pull request simply renames a few instances of variables that include "master" in their names.  Most instances are in the Catch[CN] and Route GridComps, which are not used in the GCM at this time.  The only other file touched by this pull request was edited only in lines that are commented out.  

There is one more instance in the GCM_GridComp that includes the term "master":
`GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/cldwat2m_micro.F90:   use spmd_utils,    only: masterproc`
Here, `masterproc` does not seem to be used, but I don't know where `spmd_utils` comes from, so I didn't make any edits.  It's probably as simple as deleting the use `spmd_utils` statement.

I did not test the branch, given the trivially 0-diff nature of the changes.  Maybe you'll be testing this together with another change anyway.

Can you please take it from here?  Thanks!

cc: @tclune @weiyuan-jiang @mathomp4 @wmputman 