### PR TITLE
Zero diff updates to support new vertical levels with lowest level <100m

### DIFF
--- a/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
@@ -897,11 +897,13 @@ contains
     call MAPL_AddConnectivity ( GC,                                                        &
          SRC_NAME  = (/'U            ','V            ','TH           ','T            ',    &
                        'ZLE          ','PS           ','TA           ','QA           ',    &
+                       'US           ','VS           ',                                    &
                        'SPEED        ','DZ           ','PLE          ','W            ',    &
                        'PREF         ','TROPP_BLENDED','S            ','PLK          ',    &
                        'PV           ','OMEGA        ','PKE          '/),                  &
          DST_NAME  = (/'U     ','V     ','TH    ','T     ',                                &
                        'ZLE   ','PS    ','TA    ','QA    ',                                &
+                       'UA    ','VA    ',                                                  &
                        'SPEED ','DZ    ','PLE   ','W     ',                                &
                        'PREF  ','TROPP ','S     ','PLK   ',                                &
                        'PV    ','OMEGA ','PKE   '/),                                       &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
@@ -1386,8 +1386,7 @@ contains
 
      call MAPL_TerminateImport    ( GC,   &
           SHORT_NAME = (/'SH   ','TAUX ','TAUY ','EVAP ','DEWL ','FRSL ',     &
-                         'DSH  ','DFU  ','DFV  ','DEVAP','DDEWL','DFRSL',     &
-                         'UA   ','VA   '                                  /), &
+                         'DSH  ','DFU  ','DFV  ','DEVAP','DDEWL','DFRSL'/),   &
           CHILD      = SURF,           &
           RC=STATUS  )
      VERIFY_(STATUS)
@@ -1974,6 +1973,7 @@ contains
    logical                             :: DPEDT_PHYS
    real                                :: DT
    real                                :: SYNCTQ, DOPHYSICS
+   real                                :: HGT_SURFACE
   
    real, pointer, dimension(:,:,:)     :: S, T, ZLE, TH, PLE, PLK, U, V, W
    real, pointer, dimension(:,:,:)     :: DM, DPI, TOT, FRI, TTN, STN,TMP
@@ -2020,7 +2020,6 @@ contains
    real, pointer, dimension(:,:  )     :: PEPHY
    real, pointer, dimension(:,:  )     :: KEPHY
    real, pointer, dimension(:,:  )     :: KETND
-   real, pointer, dimension(:,:  )     :: UA, VA
    real, pointer, dimension(:,:  )     :: AREA
 
    real*8, allocatable, dimension(:,:)   :: sumq
@@ -2039,13 +2038,13 @@ contains
    real, pointer, dimension(:,:,:)     :: TGWD, DTDTGWD, TFORMOIST, THFORMOIST
    real, pointer, dimension(:,:,:)     :: SAFTERMOIST, THAFMOIST
    real, pointer, dimension(:,:,:)     :: THFORCHEM, TFORCHEM, TFORRAD
-   real, pointer, dimension(:,:)       :: TFORSURF
+   real, pointer, dimension(:,:)       :: UA, VA, TFORSURF
    real, pointer, dimension(:,:,:)     :: SFORTURB, THFORTURB, TFORTURB
    real, pointer, dimension(:,:,:)     :: SAFDIFFUSE, SAFUPDATE
-   real, allocatable, dimension(:,:,:) :: PK
+   real, allocatable, dimension(:,:,:) :: PK, HGT, DTAFTURB
    real, allocatable, dimension(:,:,:) :: TDPOLD, TDPNEW
    real, allocatable, dimension(:,:,:) :: TFORQS
-   real, allocatable, dimension(:,:)   :: qs,pmean
+   real, allocatable, dimension(:,:)   :: qs,pmean,DTSURFAFTURB
 
    real(kind=MAPL_R8), allocatable, dimension(:,:) :: sumdq
    real(kind=MAPL_R8), allocatable, dimension(:,:) ::  dpe
@@ -2184,6 +2183,8 @@ contains
     call MAPL_GetResource(STATE, SYNCTQ,    'SYNCTQ:',    DEFAULT= 1.0, RC=STATUS)
     VERIFY_(STATUS)
     call MAPL_GetResource(STATE, DOPHYSICS, 'DOPHYSICS:', DEFAULT= 1.0, RC=STATUS)
+    VERIFY_(STATUS)
+    call MAPL_GetResource(STATE, HGT_SURFACE, Label="HGT_SURFACE:", DEFAULT= 50.0, RC=STATUS)
     VERIFY_(STATUS)
 
 
@@ -2394,14 +2395,9 @@ contains
        VERIFY_(STATUS)
     end if
 
-    call MAPL_GetPointer ( GIM(SURF),  UA,  'UA', RC=STATUS)
-    VERIFY_(STATUS)
+     call MAPL_GetPointer ( GIM(SURF),  UA,  'UA', RC=STATUS)
+     call MAPL_GetPointer ( GIM(SURF),  VA,  'VA', RC=STATUS)
 
-    call MAPL_GetPointer ( GIM(SURF),  VA,  'VA', RC=STATUS)
-    VERIFY_(STATUS)
-
-    UA = U(:,:,LM)
-    VA = V(:,:,LM)
 !----------------------
 
     if ( SYNCTQ.eq.1. ) then
@@ -2491,7 +2487,15 @@ contains
 
 !  AMM - Update TA for surf using TH after MOIST
     if ( SYNCTQ.eq.1. ) then
-     TFORSURF = THAFMOIST(:,:,LM)*PK(:,:,LM)
+     if ( (LM .ne. 72) .and. (HGT_SURFACE .gt. 0.0) ) then
+       allocate(HGT(IM,JM,LM+1),stat=STATUS);VERIFY_(STATUS)
+       do k = 1,LM+1
+         HGT(:,:,k) = (ZLE(:,:,k-1) - ZLE(:,:,LM))
+       enddo
+       call VertInterp(TFORSURF,THAFMOIST*PK,-HGT,-HGT_SURFACE, status)
+     else
+       TFORSURF = THAFMOIST(:,:,LM)*PK(:,:,LM)
+     endif
     endif
 
 !-srf-gf-scheme
@@ -2550,10 +2554,17 @@ contains
 
     if ( SYNCTQ.eq.1. ) then
 !AMM - update TA for surface using turb updated S - assume change in S is all change in T
-     TforSURF = TforSURF + ( SafDIFFUSE(:,:,LM) - SforTURB(:,:,LM) ) / MAPL_CP
-! set THforCHEM and TforRAD using turb run 1 updated S - assume change in S is all change in T
-     THFORCHEM = THFORTURB + (SafDIFFUSE -SforTURB) / (PK * MAPL_CP)
-     TFORRAD = TFORTURB + (SafDIFFUSE -SforTURB) / MAPL_CP
+     if ( (LM .ne. 72) .and. (HGT_SURFACE .gt. 0.0) ) then
+       allocate(DTSURFAFTURB(IM,JM),stat=STATUS);VERIFY_(STATUS)
+       call VertInterp(DTSURFAFTURB,(SAFDIFFUSE-SFORTURB)/MAPL_CP,-HGT,-HGT_SURFACE, status)
+       TFORSURF = TFORSURF + DTSURFAFTURB
+       deallocate(DTSURFAFTURB)
+     else
+       TFORSURF = TFORSURF + ( SAFDIFFUSE(:,:,LM) - SFORTURB(:,:,LM) ) / MAPL_CP
+     endif
+! set THFORCHEM and TFORRAD using turb run 1 updated S - assume change in S is all change in T
+     THFORCHEM = THFORTURB + (SAFDIFFUSE -SFORTURB) / (PK * MAPL_CP)
+     TFORRAD = TFORTURB + (SAFDIFFUSE -SFORTURB) / MAPL_CP
     endif
 
     I=SURF
@@ -2619,6 +2630,7 @@ contains
 !AMM
     if ( SYNCTQ.eq.1. ) then
       deallocate(PK)
+      if ( (LM .ne. 72) .and. (HGT_SURFACE .gt. 0.0) ) deallocate(HGT)
     endif
 
     endif     !   end of if do physics condition
@@ -2670,7 +2682,7 @@ contains
        allocate(FRI(IM,JM,LM),stat=STATUS)
        VERIFY_(STATUS)
        FRI         = INTDIS + TOPDIS
-    !  FRI(:,:,LM) = FRI(:,:,LM)  + SRFDIS
+    !  FRI(:,:,LM) = FRI(:,:,LM)  + SRFDIS ! Already included in Turbulence
     end if
 
     if(NEED_TTN) then
@@ -3198,5 +3210,58 @@ contains
   end subroutine Run
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  subroutine VertInterp(v2,v3,ple,pp,rc)
+
+    real    , intent(OUT) :: v2(:,:)
+    real    , intent(IN ) :: v3(:,:,:)
+    real    , intent(IN ) :: ple(:,:,:)
+    real    , intent(IN ) :: pp
+    integer, optional, intent(OUT) :: rc
+
+    real, dimension(size(v2,1),size(v2,2)) :: al,PT,PB
+    integer k,km
+    logical edge
+
+    character*(10) :: Iam='VertInterp'
+
+    km   = size(ple,3)-1
+    edge = size(v3,3)==km+1
+
+    _ASSERT(edge .or. size(v3,3)==km,'needs informative message')
+
+    v2   = MAPL_UNDEF
+
+    if(EDGE) then
+       pb   = ple(:,:,km+1)
+       do k=km,1,-1
+          pt = ple(:,:,k)
+          if(all(pb<pp)) exit
+          where(pp>pt .and. pp<=pb)
+             al = (pb-pp)/(pb-pt)
+             v2 = v3(:,:,k)*al + v3(:,:,k+1)*(1.0-al)
+          end where
+          pb = pt
+       end do
+    else
+       pb = 0.5*(ple(:,:,km)+ple(:,:,km+1))
+       do k=km,2,-1
+          pt = 0.5*(ple(:,:,k-1)+ple(:,:,k))
+          if(all(pb<pp)) exit
+          where( (pp>pt.and.pp<=pb) )
+             al = (pb-pp)/(pb-pt)
+             v2 = v3(:,:,k-1)*al + v3(:,:,k)*(1.0-al)
+          end where
+          pb = pt
+       end do
+       pt = 0.5*(ple(:,:,km)+ple(:,:,km-1))
+       pb = 0.5*(ple(:,:,km)+ple(:,:,km+1))
+          where( (pp>pb.and.pp<=ple(:,:,km+1)) )
+             v2 = v3(:,:,km)
+          end where
+    end if
+
+    RETURN_(ESMF_SUCCESS)
+  end subroutine VertInterp
 
 end module GEOS_PhysicsGridCompMod

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -839,15 +839,15 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     call MAPL_GetResource( MAPL, effgwbkg, Label="EFFGWBKG:", default=0.125, RC=STATUS)
     VERIFY_(STATUS)
 
-    if( LM .le. 72 ) then
+    if( LM .eq. 72 ) then
         call MAPL_GetResource( MAPL, pgwv,        Label="PGWV:",        default=4,    RC=STATUS)
         VERIFY_(STATUS)
         call MAPL_GetResource( MAPL, bgstressmax, Label="BGSTRESSMAX:", default=0.9,  RC=STATUS)
         VERIFY_(STATUS)
      else
-        call MAPL_GetResource( MAPL, pgwv,        Label="PGWV:",        default=8,    RC=STATUS)
+        call MAPL_GetResource( MAPL, pgwv,        Label="PGWV:",        default=NINT(4*LM/72.0),    RC=STATUS)
         VERIFY_(STATUS)
-        call MAPL_GetResource( MAPL, bgstressmax, Label="BGSTRESSMAX:", default=2.25, RC=STATUS)
+        call MAPL_GetResource( MAPL, bgstressmax, Label="BGSTRESSMAX:", default=0.9, RC=STATUS)
         VERIFY_(STATUS)
      endif
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/cloudnew.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/cloudnew.F90
@@ -2494,7 +2494,7 @@ contains
        endif
       elseif(flag.eq.2) then
        qtmode =  qtmean + (sigmaqt1-sigmaqt2)/3.
-       qtmin = min(qtmode-sigmaqt1,0.)
+       qtmin = max(qtmode-sigmaqt1,0.)
        qtmax = qtmode + sigmaqt2
        if(qtmax.lt.qstar) then
         clfrac = 0.
@@ -2550,7 +2550,7 @@ contains
        endif
       elseif(flag.eq.2) then
        qtmode =  qtmean + (sigmaqt1-sigmaqt2)/3.d0
-       qtmin = min(qtmode-sigmaqt1,0.d0)
+       qtmin = max(qtmode-sigmaqt1,0.d0)
        qtmax = qtmode + sigmaqt2
        if ( qtmax.lt.qstar ) then
         condensate = 0.d0

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/cloudnew.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/cloudnew.F90
@@ -31,6 +31,9 @@ module cloudnew
    PUBLIC ICE_FRACTION
    PUBLIC T_CLOUD_CTL
    PUBLIC fix_up_clouds
+   PUBLIC pdffrac
+   PUBLIC pdfcondensate
+   PUBLIC RADCOUPLE
 #endif
 
    type T_CLOUD_CTL
@@ -1597,12 +1600,12 @@ contains
                CLDREFFL_dev(I,K)   = 0.
                CLDREFFI_dev(I,K)   = 0.
             ELSE
-               call RADCOUPLE ( TEMP, PP_dev(I,K), PPE_dev(I,K)-PPE_dev(I,K-1), KH_dev(I,K-1), DTS_dev(I), CLDFRC_dev(I,K), ANVFRC_dev(I,K), &
+               call RADCOUPLE ( TEMP, PP_dev(I,K), CLDFRC_dev(I,K), ANVFRC_dev(I,K), &
                      Q_dev(I,K), QLW_LS_dev(I,K), QIW_LS_dev(I,K), QLW_AN_dev(I,K), QIW_AN_dev(I,K), QRN_ALL, QSN_ALL, NACTL_dev(I,K), NACTI_dev(I,K), & 
                      RAD_QV_dev(I,K), RAD_QL_dev(I,K), RAD_QI_dev(I,K), RAD_QR_dev(I,K), RAD_QS_dev(I,K), RAD_CLDFRC_dev(I,K), & 
                      CLDREFFL_dev(I,K), CLDREFFI_dev(I,K), &
-                     TEMPOR_dev(I), FRLAND_dev(I), CNV_FRACTION_dev(I), &
-                     SCLMFDFR, FR_AN_WAT, CONVPAR_OPTION,RHX_DEV(I,K) )
+                     FRLAND_dev(I), CNV_FRACTION_dev(I), &
+                     FR_AN_WAT, FAC_RL, MIN_RL, MAX_RL, FAC_RI, MIN_RI, MAX_RI, RHX_DEV(I,K) )
             END IF
 
             QRN_CU_dev(I,K) = QRN_CU_1D
@@ -2491,7 +2494,7 @@ contains
        endif
       elseif(flag.eq.2) then
        qtmode =  qtmean + (sigmaqt1-sigmaqt2)/3.
-       qtmin = max(qtmode-sigmaqt1,0.)
+       qtmin = min(qtmode-sigmaqt1,0.)
        qtmax = qtmode + sigmaqt2
        if(qtmax.lt.qstar) then
         clfrac = 0.
@@ -2547,7 +2550,7 @@ contains
        endif
       elseif(flag.eq.2) then
        qtmode =  qtmean + (sigmaqt1-sigmaqt2)/3.d0
-       qtmin = max(qtmode-sigmaqt1,0.d0)
+       qtmin = min(qtmode-sigmaqt1,0.d0)
        qtmax = qtmode + sigmaqt2
        if ( qtmax.lt.qstar ) then
         condensate = 0.d0
@@ -3798,7 +3801,7 @@ contains
   
        ELSEIF(ITYPE == ICE) THEN
 
-        IF (adjustl(CLDMICRO)=="GFDL") THEN
+        IF (adjustl(CLDMICRO)=="SAVE_FOR_AEROSOLS...") THEN
 
          RHO = 100.*PL / (MAPL_RGAS*TE )
          !- ice water content
@@ -3830,7 +3833,7 @@ contains
             !if((PL<300. .and. PL>200.) .and. (QC>1.e-6)) print*,"GOCRI=", RHO*QC,TE,NNI, RADIUS* 1.e+6
          ENDIF
   
-        ELSE ! CLDMICRO =1MOMENT
+        ELSE ! CLDMICRO =1MOMENT or GFDL
 
             !------ice cloud effective radius ----- [klaus wyser, 1998]
             !- air density (kg/m^3)
@@ -4038,9 +4041,6 @@ contains
    subroutine RADCOUPLE(  &
          TE,              & 
          PL,              & 
-         DELP,            &
-         KH,              &
-         DTS,             &
          CF,              & 
          AF,              & 
          QV,              &
@@ -4060,26 +4060,22 @@ contains
          RAD_CF,          & 
          RAD_RL,          & 
          RAD_RI,          & 
-         TEMPOR, FRLAND, CNV_FRACTION, SCLMFDFR, FR_AN_WAT, &
-         CONVPAR_OPTION,  &
+         FRLAND, CNV_FRACTION, FR_AN_WAT, &
+         FAC_RL, MIN_RL, MAX_RL, &
+         FAC_RI, MIN_RI, MAX_RI, &
 	 RHX)
 
       real, intent(in ) :: TE
-      real, intent(in ) :: PL, DELP, KH, DTS
+      real, intent(in ) :: PL
       real, intent(in ) :: AF,CF, QV, QClAN, QCiAN, QClLS, QCiLS
       real, intent(in ) :: QRN_ALL, QSN_ALL
       real, intent(in ) :: NL,NI
       real, intent(out) :: RAD_QV,RAD_QL,RAD_QI,RAD_QR,RAD_QS,RAD_CF,RAD_RL,RAD_RI
 
-      real, intent(in )  :: tempor, FRLAND, CNV_FRACTION, SCLMFDFR,RHX
+      real, intent(in )  :: FRLAND, CNV_FRACTION, RHX
+      real, intent(in )  :: FAC_RL, MIN_RL, MAX_RL, FAC_RI, MIN_RI, MAX_RI
       integer, intent(in) :: FR_AN_WAT
-      character(LEN=*), INTENT(IN) :: CONVPAR_OPTION
-      real :: RElAN, REiAN, RElLS, REiLS, QCm, ss
-      real :: QClANm, QCiANm, QClLSm, QCiLSm, QCtot, AFx
-      real :: rampt, rampu, rampp
-
-      real :: ALPH, CFPBL
-      real :: CIP, TEM2D, TEM2, TEM3
+      real :: ALPH, SS, AFx
       real :: NN, NN_LAND, NN_OCEAN
 
       ! Limits on Radii needed to ensure

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
@@ -47,7 +47,8 @@ module gfdl2_cloud_microphys_mod
     ! check_nml_error, file_exist, close_file
 
     use fms_mod,             only: write_version_number, open_namelist_file, &
-                                   check_nml_error, close_file, file_exist
+                                   check_nml_error, close_file, file_exist,  &
+                                   fms_init
 
     implicit none
     
@@ -209,7 +210,7 @@ module gfdl2_cloud_microphys_mod
     real :: tau_l2v = 300. !< cloud water to water vapor (evaporation)
     real :: tau_g2v = 900. !< graupel sublimation
     real :: tau_v2g = 21600. !< graupel deposition -- make it a slow process
-    real :: tau_revp = 150. !< rain re-evaporation
+    real :: tau_revp = 900. !< rain re-evaporation
     ! horizontal subgrid variability
     
     real :: dw_land = 0.20 !< base value for subgrid deviation / variability over land
@@ -309,7 +310,9 @@ module gfdl2_cloud_microphys_mod
         vs_max, vg_max, vr_max, qs_mlt, qs0_crt, qi_gen, ql0_max, qi0_max,    &
         qi0_crt, qr0_crt, fast_sat_adj, rh_inc, rh_ins, rh_inr, const_vi,     &
         const_vs, const_vg, const_vr, use_ccn, rthresh, ccn_l, ccn_o, qc_crt, &
-        tau_g2v, tau_v2g, tau_revp, sat_adj0, c_piacr, tau_imlt, tau_v2l, tau_l2v,      &
+        tau_g2v, tau_v2g, &
+        tau_revp, &
+        sat_adj0, c_piacr, tau_imlt, tau_v2l, tau_l2v,      &
         tau_i2s, tau_l2r, qi_lim, ql_gen, c_paut, c_psaci, c_pgacs,           &
         z_slope_liq, z_slope_ice, prog_ccn, c_cracw, alin, clin, tice,        &
         rad_snow, rad_graupel, rad_rain, cld_min, use_ppm, mono_prof,         &
@@ -321,7 +324,9 @@ module gfdl2_cloud_microphys_mod
         vs_max, vg_max, vr_max, qs_mlt, qs0_crt, qi_gen, ql0_max, qi0_max,    &
         qi0_crt, qr0_crt, fast_sat_adj, rh_inc, rh_ins, rh_inr, const_vi,     &
         const_vs, const_vg, const_vr, use_ccn, rthresh, ccn_l, ccn_o, qc_crt, &
-        tau_g2v, tau_v2g, tau_revp, sat_adj0, c_piacr, tau_imlt, tau_v2l, tau_l2v,      &
+        tau_g2v, tau_v2g, &
+        tau_revp, &
+        sat_adj0, c_piacr, tau_imlt, tau_v2l, tau_l2v,      &
         tau_i2s, tau_l2r, qi_lim, ql_gen, c_paut, c_psaci, c_pgacs,           &
         z_slope_liq, z_slope_ice, prog_ccn, c_cracw, alin, clin, tice,        &
         rad_snow, rad_graupel, rad_rain, cld_min, use_ppm, mono_prof,         &
@@ -338,7 +343,7 @@ contains
 subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
         qv_dt, ql_dt, qr_dt, qi_dt, qs_dt, qg_dt, qa_dt, pt_dt, pt, w,    &
         uin, vin, udt, vdt, dz, delp, area, dt_in, land, cnv_fraction,    &
-        anv_icefall, lsc_icefall, &
+        revap, isubl,                                                     &
         rain, snow, ice, &
         graupel, m2_rain, m2_sol, hydrostatic, phys_hydrostatic,          &
         iis, iie, jjs, jje, kks, kke, ktop, kbot)
@@ -356,8 +361,6 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     real, intent (in), dimension (:, :) :: land !< land fraction
     real, intent (in), dimension (:, :) :: cnv_fraction !< diagnosed convective fraction
 
-    real, intent (in) :: anv_icefall, lsc_icefall
-
     real, intent (in), dimension (:, :, :) :: delp, dz, uin, vin
     real, intent (in), dimension (:, :, :) :: pt, qv, ql, qr, qg, qa, qn
     
@@ -368,6 +371,8 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
     
     real, intent (out), dimension (:, :) :: rain, snow, ice, graupel
     real, intent (out), dimension (:, :, :) :: m2_rain, m2_sol ! Rain and Ice fluxes (Pa kg/kg)
+    real, intent (out), dimension (:, :, :) :: revap ! Rain evaporation
+    real, intent (out), dimension (:, :, :) :: isubl ! Ice sublimation
     
     ! logical :: used
     
@@ -462,7 +467,7 @@ subroutine gfdl_cloud_microphys_driver (qv, ql, qr, qi, qs, qg, qa, qn,   &
             qa, qn, dz, is, ie, js, je, ks, ke, ktop, kbot, j, dt_in, ntimes,  &
             rain (:, j), snow (:, j), graupel (:, j), ice (:, j), m2_rain,     &
             m2_sol, cond (:, j), area (:, j), land (:, j), cnv_fraction(:, j), &
-            anv_icefall, lsc_icefall,                                          &
+            revap, isubl,                                                      &
             udt, vdt, pt_dt,                                                   &
             qv_dt, ql_dt, qr_dt, qi_dt, qs_dt, qg_dt, qa_dt, w_var, vt_r,      &
             vt_s, vt_g, vt_i, qn2)
@@ -619,7 +624,7 @@ end subroutine gfdl_cloud_microphys_driver
 subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
         qg, qa, qn, dz, is, ie, js, je, ks, ke, ktop, kbot, j, dt_in, ntimes, &
         rain, snow, graupel, ice, m2_rain, m2_sol, cond, area1, land,         &
-        cnv_fraction, anv_icefall, lsc_icefall,                               &
+        cnv_fraction, revap, isubl,                                           &
         u_dt, v_dt, pt_dt, qv_dt, ql_dt, qr_dt, qi_dt, qs_dt, qg_dt, qa_dt,   &
         w_var, vt_r, vt_s, vt_g, vt_i, qn2)
     
@@ -634,15 +639,14 @@ subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
     
     real, intent (in), dimension (is:) :: area1, land
     real, intent (in), dimension (is:) :: cnv_fraction
-   
-    real, intent (in) :: anv_icefall, lsc_icefall
- 
+    
     real, intent (in), dimension (is:, js:, ks:) :: uin, vin, delp, pt, dz
     real, intent (in), dimension (is:, js:, ks:) :: qv, ql, qr, qg, qa, qn
     
     real, intent (inout), dimension (is:, js:, ks:) :: qi, qs
     real, intent (inout), dimension (is:, js:, ks:) :: u_dt, v_dt, w, pt_dt, qa_dt
     real, intent (inout), dimension (is:, js:, ks:) :: qv_dt, ql_dt, qr_dt, qi_dt, qs_dt, qg_dt
+    real, intent (  out), dimension (is:, js:, ks:) :: revap, isubl
     
     real, intent (inout), dimension (is:) :: rain, snow, ice, graupel, cond
     
@@ -657,7 +661,7 @@ subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
     real, dimension (ktop:kbot) :: dp0, dp1, dz0, dz1
     real, dimension (ktop:kbot) :: qv0, ql0, qr0, qi0, qs0, qg0, qa0
     real, dimension (ktop:kbot) :: t0, den, den0, tz, p1, denfac
-    real, dimension (ktop:kbot) :: ccn, c_praut, m1_rain, m1_sol, m1
+    real, dimension (ktop:kbot) :: ccn, c_praut, m1_rain, m1_sol, m1, evap1, subl1
     real, dimension (ktop:kbot) :: u0, v0, u1, v1, w1
     
     real :: cpaut, rh_adj, rh_rain
@@ -826,7 +830,9 @@ subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
         
         m2_rain (i, j, :) = 0.
         m2_sol (i, j, :) = 0.
-        
+        revap (i, j, :) = 0.
+        isubl (i, j, :) = 0.
+ 
         do n = 1, ntimes
             
             ! -----------------------------------------------------------------------
@@ -852,11 +858,13 @@ subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
             ! -----------------------------------------------------------------------
             
             call warm_rain (dt_rain, ktop, kbot, dp1, dz1, tz, qvz, qlz, qrz, qiz, qsz, &
-                qgz, den, denfac, ccn, c_praut, rh_rain, vtrz, r1, m1_rain, w1, h_var)
+                qgz, den, denfac, ccn, c_praut, rh_rain, vtrz, r1, evap1, subl1, m1_rain, w1, h_var)
             
             rain (i) = rain (i) + r1
-            
+ 
             do k = ktop, kbot
+                revap (i,j,k) = revap (i,j,k) + evap1(k)
+                isubl (i,j,k) = isubl (i,j,k) + subl1(k)
                 m2_rain (i, j, k) = m2_rain (i, j, k) + m1_rain (k)
                 m1 (k) = m1 (k) + m1_rain (k)
             enddo
@@ -865,8 +873,7 @@ subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
             ! sedimentation of cloud ice, snow, and graupel
             ! -----------------------------------------------------------------------
             
-            call fall_speed (ktop, kbot, p1, cnv_fraction(i), anv_icefall, lsc_icefall, &
-                             den, qsz, qiz, qgz, qlz, tz, vtsz, vtiz, vtgz)
+            call fall_speed (ktop, kbot, cnv_fraction(i), den, qsz, qiz, qgz, qlz, tz, vtsz, vtiz, vtgz)
             
             call terminal_fall (dts, ktop, kbot, tz, qvz, qlz, qrz, qgz, qsz, qiz, &
                 dz1, dp1, den, vtgz, vtsz, vtiz, r1, g1, s1, i1, m1_sol, w1)
@@ -889,11 +896,13 @@ subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
             ! -----------------------------------------------------------------------
             
             call warm_rain (dt_rain, ktop, kbot, dp1, dz1, tz, qvz, qlz, qrz, qiz, qsz, &
-                qgz, den, denfac, ccn, c_praut, rh_rain, vtrz, r1, m1_rain, w1, h_var)
+                qgz, den, denfac, ccn, c_praut, rh_rain, vtrz, r1, evap1, subl1, m1_rain, w1, h_var)
             
             rain (i) = rain (i) + r1
             
             do k = ktop, kbot
+                revap (i,j,k) = revap (i,j,k) + evap1(k)
+                isubl (i,j,k) = isubl (i,j,k) + subl1(k)
                 m2_rain (i, j, k) = m2_rain (i, j, k) + m1_rain (k)
                 m2_sol (i, j, k) = m2_sol (i, j, k) + m1_sol (k)
                 m1 (k) = m1 (k) + m1_rain (k) + m1_sol (k)
@@ -956,7 +965,7 @@ subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
                 qa_dt (i, j, k) = qa_dt (i, j, k) + rdt * (qaz (k) / real (ntimes) - qa0 (k))
             endif
         enddo
-        
+
         ! -----------------------------------------------------------------------
         ! fms diagnostics:
         ! -----------------------------------------------------------------------
@@ -1061,7 +1070,7 @@ end subroutine sedi_heat
 ! -----------------------------------------------------------------------
 
 subroutine warm_rain (dt, ktop, kbot, dp, dz, tz, qv, ql, qr, qi, qs, qg, &
-        den, denfac, ccn, c_praut, rh_rain, vtr, r1, m1_rain, w1, h_var)
+        den, denfac, ccn, c_praut, rh_rain, vtr, r1, evap1, subl1, m1_rain, w1, h_var)
     
     implicit none
     
@@ -1075,13 +1084,13 @@ subroutine warm_rain (dt, ktop, kbot, dp, dz, tz, qv, ql, qr, qi, qs, qg, &
     
     real, intent (inout), dimension (ktop:kbot) :: tz, vtr
     real, intent (inout), dimension (ktop:kbot) :: qv, ql, qr, qi, qs, qg
-    real, intent (inout), dimension (ktop:kbot) :: m1_rain, w1
-    
+    real, intent (inout), dimension (ktop:kbot) :: evap1, subl1, m1_rain, w1
+
     real, intent (out) :: r1
     
     real, parameter :: so3 = 7. / 3.
     
-    real, dimension (ktop:kbot) :: dl, dm
+    real, dimension (ktop:kbot) :: dl, dm, revap, isubl
     real, dimension (ktop:kbot + 1) :: ze, zt
     
     real :: sink, dq, qc0, qc
@@ -1105,6 +1114,8 @@ subroutine warm_rain (dt, ktop, kbot, dp, dz, tz, qv, ql, qr, qi, qs, qg, &
     ! terminal speed of rain
     ! -----------------------------------------------------------------------
     
+    evap1 (:) = 0.
+    subl1 (:) = 0.
     m1_rain (:) = 0.
     
     call check_column (ktop, kbot, qr, no_fall)
@@ -1143,8 +1154,10 @@ subroutine warm_rain (dt, ktop, kbot, dp, dz, tz, qv, ql, qr, qi, qs, qg, &
         ! -----------------------------------------------------------------------
         
         ! if (.not. fast_sat_adj) &
-        call revap_racc (ktop, kbot, dt5, tz, qv, ql, qr, qi, qs, qg, den, denfac, rh_rain, h_var)
-        
+        call revap_racc (ktop, kbot, dt5, tz, qv, ql, qr, qi, qs, qg, revap, isubl, den, denfac, rh_rain, h_var)
+        evap1 = revap
+        subl1 = isubl
+ 
         if (do_sedi_w) then
             do k = ktop, kbot
                 dm (k) = dp (k) * (1. + qv (k) + ql (k) + qr (k) + qi (k) + qs (k) + qg (k))
@@ -1193,7 +1206,9 @@ subroutine warm_rain (dt, ktop, kbot, dp, dz, tz, qv, ql, qr, qi, qs, qg, &
         ! evaporation and accretion of rain for the remaing 1 / 2 time step
         ! -----------------------------------------------------------------------
         
-        call revap_racc (ktop, kbot, dt5, tz, qv, ql, qr, qi, qs, qg, den, denfac, rh_rain, h_var)
+        call revap_racc (ktop, kbot, dt5, tz, qv, ql, qr, qi, qs, qg, revap, isubl, den, denfac, rh_rain, h_var)
+        evap1 = evap1 + revap
+        subl1 = subl1 + isubl
         
     endif
     
@@ -1232,7 +1247,7 @@ subroutine warm_rain (dt, ktop, kbot, dp, dz, tz, qv, ql, qr, qi, qs, qg, &
     else
         
         ! -----------------------------------------------------------------------
-        ! with subgrid varaibility
+        ! with subgrid variability
         ! -----------------------------------------------------------------------
         
         call linear_prof (kbot - ktop + 1, ql (ktop), dl (ktop), z_slope_liq, h_var)
@@ -1275,7 +1290,7 @@ end subroutine warm_rain
 !> evaporation of rain
 ! -----------------------------------------------------------------------
 
-subroutine revap_racc (ktop, kbot, dt, tz, qv, ql, qr, qi, qs, qg, den, denfac, rh_rain, h_var)
+subroutine revap_racc (ktop, kbot, dt, tz, qv, ql, qr, qi, qs, qg, revap, isubl, den, denfac, rh_rain, h_var)
     
     implicit none
     
@@ -1287,6 +1302,8 @@ subroutine revap_racc (ktop, kbot, dt, tz, qv, ql, qr, qi, qs, qg, den, denfac, 
     real, intent (in), dimension (ktop:kbot) :: den, denfac
     
     real, intent (inout), dimension (ktop:kbot) :: tz, qv, qr, ql, qi, qs, qg
+
+    real, intent (inout), dimension (ktop:kbot) :: revap, isubl
     
     real, dimension (ktop:kbot) :: lhl, cvm, q_liq, q_sol, lcpk
     
@@ -1294,7 +1311,10 @@ subroutine revap_racc (ktop, kbot, dt, tz, qv, ql, qr, qi, qs, qg, den, denfac, 
     real :: qpz, dq, dqh, tin
     real :: fac_revp 
     integer :: k
-    
+   
+    revap(:) = 0.
+    isubl(:) = 0.
+ 
     do k = ktop, kbot
         
         if (tz (k) > t_wfr .and. qr (k) > qrmin) then
@@ -1343,7 +1363,7 @@ subroutine revap_racc (ktop, kbot, dt, tz, qv, ql, qr, qi, qs, qg, den, denfac, 
                     exp (0.725 * log (qden))) / (crevp (4) * t2 + crevp (5) * qsat * den (k))
                 fac_revp = 1. - exp (- dt / tau_revp)
                 evap = min (qr (k), dt * fac_revp * evap, dqv / (1. + lcpk (k) * dqsdt))
-              !!evap = min (qr (k), dt * evap, dqv / (1. + lcpk (k) * dqsdt))
+          !!!!! evap = min (qr (k), dt *            evap, dqv / (1. + lcpk (k) * dqsdt))
                 ! -----------------------------------------------------------------------
                 ! alternative minimum evap in dry environmental air
                 ! sink = min (qr (k), dim (rh_rain * qsat, qv (k)) / (1. + lcpk (k) * dqsdt))
@@ -1354,6 +1374,7 @@ subroutine revap_racc (ktop, kbot, dt, tz, qv, ql, qr, qi, qs, qg, den, denfac, 
                 q_liq (k) = q_liq (k) - evap
                 cvm (k) = c_air + qv (k) * c_vap + q_liq (k) * c_liq + q_sol (k) * c_ice
                 tz (k) = tz (k) - evap * lhl (k) / cvm (k)
+                revap(k) = evap / dt
             endif
             
             ! -----------------------------------------------------------------------
@@ -1366,6 +1387,7 @@ subroutine revap_racc (ktop, kbot, dt, tz, qv, ql, qr, qi, qs, qg, den, denfac, 
                 sink = sink / (1. + sink) * ql (k)
                 ql (k) = ql (k) - sink
                 qr (k) = qr (k) + sink
+                isubl(k) = sink / dt
             endif
             
         endif ! warm - rain
@@ -1922,7 +1944,7 @@ subroutine icloud (ktop, kbot, tzk, p1, qvk, qlk, qrk, qik, qsk, qgk, dp1, &
 end subroutine icloud
 
 ! =======================================================================
-!>temperature sentive high vertical resolution processes
+!>temperature sensitive high vertical resolution processes
 ! =======================================================================
 
 subroutine subgrid_z_proc (ktop, kbot, p1, den, denfac, dts, rh_adj, tz, qv, &
@@ -3168,15 +3190,14 @@ end subroutine cs_limiters
 !>@brief The subroutine 'fall_speed' calculates vertical fall speed.
 ! =======================================================================
 
-subroutine fall_speed (ktop, kbot, pl, cnv_fraction, anv_icefall, lsc_icefall, &
-                       den, qs, qi, qg, ql, tk, vts, vti, vtg)
+subroutine fall_speed (ktop, kbot, cnv_fraction, den, qs, qi, qg, ql, tk, vts, vti, vtg)
     
     implicit none
     
     integer, intent (in) :: ktop, kbot
     
-    real, intent (in) :: cnv_fraction, anv_icefall, lsc_icefall 
-    real, intent (in), dimension (ktop:kbot) :: pl, den, qs, qi, qg, ql, tk
+    real, intent (in) :: cnv_fraction 
+    real, intent (in), dimension (ktop:kbot) :: den, qs, qi, qg, ql, tk
     real, intent (out), dimension (ktop:kbot) :: vts, vti, vtg
     
     ! fall velocity constants:
@@ -3213,7 +3234,7 @@ subroutine fall_speed (ktop, kbot, pl, cnv_fraction, anv_icefall, lsc_icefall, &
     
     real, dimension (ktop:kbot) :: qden, tc, rhof
     
-    real :: vi1, vi0, viCNV, viLSC, XIm, LXIm, IWC
+    real :: vi0, viCNV, viLSC, XIm, LXIm, IWC
     
     integer :: k
     
@@ -3239,18 +3260,17 @@ subroutine fall_speed (ktop, kbot, pl, cnv_fraction, anv_icefall, lsc_icefall, &
     else
 #define GFDL_ICE_FALL
 #ifdef GFDL_ICE_FALL
-       !vi0 = ( lsc_icefall*(1.0-cnv_fraction) + anv_icefall*(cnv_fraction) )
+        ! -----------------------------------------------------------------------
+        ! use deng and mace (2008, grl), which gives smaller fall speed than hd90 formula
+        ! -----------------------------------------------------------------------
+        vi0 = 0.01 * vi_fac
         do k = ktop, kbot
-          ! vi1 = 0.01 * vi_fac * vi0
-          ! vi1 = 0.01 * vi_fac * ( lsc_icefall*(1.0-cnv_fraction) + anv_icefall*(cnv_fraction) )
-          ! vi1 = 0.01 * MAX(vi0,(vi_fac*MIN(1.0,pl(k)/60000.)**2)) ! WMP: pressure dependent icefall speeds
-            vi1 = 0.01 * vi_fac * MAX(anv_icefall,SQRT(MIN(lsc_icefall,pl(k)/60000.)))
             if (qi (k) < thi) then ! this is needed as the fall - speed maybe problematic for small qi
                 vti (k) = vf_min
             else
                 tc (k) = tk (k) - tice
                 vti (k) = (3. + log10 (qi (k) * den (k))) * (tc (k) * (aa * tc (k) + bb) + cc) + dd * tc (k) + ee
-                vti (k) = vi1 * exp (log_10 * vti (k))
+                vti (k) = vi0 * exp (log_10 * vti (k))
                 vti (k) = min (vi_max, max (vf_min, vti (k)))
             endif
         enddo
@@ -3258,7 +3278,7 @@ subroutine fall_speed (ktop, kbot, pl, cnv_fraction, anv_icefall, lsc_icefall, &
         ! -----------------------------------------------------------------------
         ! use deng and mace (2008, grl), which gives smaller fall speed than hd90 formula
         ! -----------------------------------------------------------------------
-        vi0 = 0.01 * vi_fac * ( lsc_icefall*(1.0-cnv_fraction) + anv_icefall*(cnv_fraction) )
+        vi0 = 0.01 * ( vi_fac*(1.0-cnv_fraction) + cnv_fraction ) ! Keep vi_fac=1 in cnv regions
         do k = ktop, kbot
             if (qi (k) < thi) then ! this is needed as the fall - speed maybe problematic for small qi
                 vti (k) = vf_min
@@ -3486,7 +3506,9 @@ subroutine gfdl_cloud_microphys_init ()
     ! integer :: unit, io, ierr, k, logunit
     ! logical :: flag
     ! real :: tmp, q1, q2
-    
+   
+    call fms_init()     
+ 
     ! master = (mpp_pe () .eq.mpp_root_pe ())
     
 #ifdef INTERNAL_FILE_NML

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOS_SuperdynGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOS_SuperdynGridComp.F90
@@ -300,6 +300,18 @@ integer ::          ADV = -1
     VERIFY_(STATUS)
 
     call MAPL_AddExportSpec ( GC   ,                               &
+         SHORT_NAME = 'US',                                        &
+         CHILD_ID   = DYN,                                         &
+                                                        RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec ( GC   ,                               &
+         SHORT_NAME = 'VS',                                        &
+         CHILD_ID   = DYN,                                         &
+                                                        RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'TA',                                        &
          CHILD_ID   = DYN,                                         &
                                                         RC=STATUS  )


### PR DESCRIPTION
These are zero-diff updates (for 72L and 1MOMENT) to add support for increased vertical resolution and updates in FV3 and GFDL microphysics.

@sdrabenh can verify zero-diff and then merge onto the main develop branch.