### PR TITLE
Restore missing VERIFY_

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
@@ -2396,7 +2396,9 @@ contains
     end if
 
      call MAPL_GetPointer ( GIM(SURF),  UA,  'UA', RC=STATUS)
+     VERIFY_(STATUS)
      call MAPL_GetPointer ( GIM(SURF),  VA,  'VA', RC=STATUS)
+     VERIFY_(STATUS)
 
 !----------------------
 


### PR DESCRIPTION
As noted in #298 (https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/298/files#r443514047), some `VERIFY_()` statements were removed. This restores them.