### PR TITLE
Rename ocean_state_type for GNU build issue

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -17,7 +17,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/MOM5.git
 local_path = ./GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom
-tag = geos/5.1.0+1.1.0
+tag = geos/5.1.0+1.1.1
 protocol = git
 
 [mom6]

--- a/GEOSogcm_GridComp/GEOS_OgcmGridComp.F90
+++ b/GEOSogcm_GridComp/GEOS_OgcmGridComp.F90
@@ -1011,7 +1011,8 @@ contains
      if (trim(OCEAN_NAME) == "MOM") then  ! MOM5
        call MAPL_AddConnectivity ( GC,  &
             SHORT_NAME  = (/'TAUXBOT ','TAUYBOT ', 'HICE    ', 'HSNO    ', &
-            'STROCNXB', 'STROCNYB', 'AICEU   ', 'FRESH   ', 'FSALT   ', 'FHOCN  '/), &
+                            'STROCNXB','STROCNYB', 'AICEU   ', 'FRESH   ', &
+                            'FSALT   ','FHOCN   '/), &
             DST_ID = OCEAN,             &
             SRC_ID = SEAICE,            &
             RC=STATUS  )
@@ -1019,7 +1020,7 @@ contains
      else ! MOM6
        call MAPL_AddConnectivity ( GC,  &
             SHORT_NAME  = (/'TAUXBOT ','TAUYBOT ', 'HICE    ', 'HSNO    ', &
-            'FRESH   ', 'FSALT   ', 'FHOCN   ', 'AICE   '/), &
+                            'FRESH   ','FSALT   ', 'FHOCN   ', 'AICE    '/), &
             DST_ID = OCEAN,             &
             SRC_ID = SEAICE,            &
             RC=STATUS  )

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/MOM_GEOS5PlugMod.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/MOM_GEOS5PlugMod.F90
@@ -752,8 +752,8 @@ contains
 ! Locals
 
     type(ice_ocean_boundary_type), pointer :: boundary
-    type(ocean_public_type),         pointer :: Ocean
-    type(mom5_ocean_state_type),          pointer :: Ocean_State
+    type(ocean_public_type),       pointer :: Ocean
+    type(mom5_ocean_state_type),   pointer :: Ocean_State
     type(MOM_MAPL_Type),           pointer :: MOM_MAPL_internal_state 
     type(MOM_MAPLWrap_Type)                :: wrap
 
@@ -1170,7 +1170,7 @@ contains
     type(MOM_MAPLWrap_Type)                :: wrap
     type(ice_ocean_boundary_type), pointer :: boundary
     type(ocean_public_type),       pointer :: Ocean
-    type(mom5_ocean_state_type),        pointer :: Ocean_State
+    type(mom5_ocean_state_type),   pointer :: Ocean_State
     type(domain2d)                         :: OceanDomain
     integer                                :: isc,iec,jsc,jec
     integer                                :: isd,ied,jsd,jed
@@ -1867,7 +1867,7 @@ contains
     type(MOM_MAPLWrap_Type)                :: wrap
 !    type(ice_ocean_boundary_type), pointer :: boundary
 !    type(ocean_public_type),       pointer :: Ocean
-!    type(mom5_ocean_state_type),        pointer :: Ocean_State
+!    type(mom5_ocean_state_type),   pointer :: Ocean_State
 !    type(domain2d)                         :: OceanDomain
     integer                                :: isc,iec,jsc,jec
     integer                                :: isd,ied,jsd,jed
@@ -1983,8 +1983,8 @@ contains
     type(ESMF_Time)                  :: MyTime
     type(MOM_MAPL_Type),     pointer :: MOM_MAPL_internal_state 
     type(MOM_MAPLWrap_Type)          :: wrap
-    type(ocean_public_type),   pointer :: Ocean
-    type(mom5_ocean_state_type),    pointer :: Ocean_State
+    type(ocean_public_type),     pointer :: Ocean
+    type(mom5_ocean_state_type), pointer :: Ocean_State
 
 ! ErrLog Variables
 

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/MOM_GEOS5PlugMod.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/MOM_GEOS5PlugMod.F90
@@ -50,7 +50,7 @@ module MOM_GEOS5PlugMod
 
   use ocean_model_mod,          only: ocean_model_init, update_ocean_model, ocean_model_end, ocean_model_restart
   use ocean_types_mod,          only: ocean_public_type, ice_ocean_boundary_type
-  use ocean_model_mod,          only: get_ocean_domain, ocean_state_type
+  use ocean_model_mod,          only: get_ocean_domain, mom5_ocean_state_type
 
 ! mjs added these two
 
@@ -751,7 +751,7 @@ contains
 
     type(ice_ocean_boundary_type), pointer :: boundary
     type(ocean_public_type),         pointer :: Ocean
-    type(ocean_state_type),          pointer :: Ocean_State
+    type(mom5_ocean_state_type),          pointer :: Ocean_State
     type(MOM_MAPL_Type),           pointer :: MOM_MAPL_internal_state 
     type(MOM_MAPLWrap_Type)                :: wrap
 
@@ -1168,7 +1168,7 @@ contains
     type(MOM_MAPLWrap_Type)                :: wrap
     type(ice_ocean_boundary_type), pointer :: boundary
     type(ocean_public_type),       pointer :: Ocean
-    type(ocean_state_type),        pointer :: Ocean_State
+    type(mom5_ocean_state_type),        pointer :: Ocean_State
     type(domain2d)                         :: OceanDomain
     integer                                :: isc,iec,jsc,jec
     integer                                :: isd,ied,jsd,jed
@@ -1865,7 +1865,7 @@ contains
     type(MOM_MAPLWrap_Type)                :: wrap
 !    type(ice_ocean_boundary_type), pointer :: boundary
 !    type(ocean_public_type),       pointer :: Ocean
-!    type(ocean_state_type),        pointer :: Ocean_State
+!    type(mom5_ocean_state_type),        pointer :: Ocean_State
 !    type(domain2d)                         :: OceanDomain
     integer                                :: isc,iec,jsc,jec
     integer                                :: isd,ied,jsd,jed
@@ -1982,7 +1982,7 @@ contains
     type(MOM_MAPL_Type),     pointer :: MOM_MAPL_internal_state 
     type(MOM_MAPLWrap_Type)          :: wrap
     type(ocean_public_type),   pointer :: Ocean
-    type(ocean_state_type),    pointer :: Ocean_State
+    type(mom5_ocean_state_type),    pointer :: Ocean_State
 
 ! ErrLog Variables
 
@@ -2083,7 +2083,7 @@ contains
     type (MAPL_MetaComp), pointer    :: MAPL 
     type(MOM_MAPL_Type),     pointer :: MOM_MAPL_internal_state 
     type(MOM_MAPLWrap_Type)          :: wrap
-    type(ocean_state_type),  pointer :: Ocean_State
+    type(mom5_ocean_state_type),  pointer :: Ocean_State
 
 ! ErrLog Variables
 

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/MOM_GEOS5PlugMod.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/MOM_GEOS5PlugMod.F90
@@ -50,7 +50,9 @@ module MOM_GEOS5PlugMod
 
   use ocean_model_mod,          only: ocean_model_init, update_ocean_model, ocean_model_end, ocean_model_restart
   use ocean_types_mod,          only: ocean_public_type, ice_ocean_boundary_type
-  use ocean_model_mod,          only: get_ocean_domain, mom5_ocean_state_type
+  
+! MAT ocean_state_type renamed due to GNU build issue with simultaneous MOM5/MOM6 model
+  use ocean_model_mod,          only: get_ocean_domain, mom5_ocean_state_type 
 
 ! mjs added these two
 


### PR DESCRIPTION
Kind of ugly hack-workaround to help fix issue https://github.com/GEOS-ESM/GEOSgcm/issues/177. Rename `ocean_state_type` in MOM5 to `mom5_ocean_state_type`.

Currently testing with Intel to make sure it is benign.