### PR TITLE
Update to FV3 Grid Comp v1.2.0

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/FVdycoreCubed_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
-tag = v1.1.4
+tag = v1.2.0
 externals = Externals.cfg
 protocol = git
 


### PR DESCRIPTION
This is a zero-diff update to FV3 GC that adds in an `fv3_setup` and `fv3.j` script for the FV3 Standalone.