### PR TITLE
Use xlarge resource for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
       - image: gmao/geos-build-env-gcc-source:6.0.13-openmpi_4.0.3-gcc_9.3.0
+    resource_class: xlarge
     working_directory: /root/project
     steps:
       - run:
@@ -34,4 +35,4 @@ jobs:
           name: "Build"
           command: |
             cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm/build
-            make -j2 install
+            make -j"$(nproc)" install


### PR DESCRIPTION
Should allow for faster (~3x) CI builds of GEOS.