### PR TITLE
Update to FVdycoreCubed_Gridcomp v1.2.3

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/FVdycoreCubed_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
-tag = v1.2.0
+tag = v1.2.1
 externals = Externals.cfg
 protocol = git
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/FVdycoreCubed_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
-tag = v1.2.1
+tag = v1.2.2
 externals = Externals.cfg
 protocol = git
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/FVdycoreCubed_GridComp.git
 local_path = ./GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
-tag = v1.2.2
+tag = v1.2.3
 externals = Externals.cfg
 protocol = git
 


### PR DESCRIPTION
This moves GEOSgcm_GridComp to use [FVdycoreCubed_GridComp v1.2.3](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.3) which is a zero-diff update that only affects the `fv3.j` and `fv3_setup` scripts used to run the FV3 Standalone.