### PR TITLE
Remove clock rewind only in replay logic in Guest

### DIFF
--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/GuestOcean_GridComp.F90
@@ -1015,23 +1015,20 @@ contains
     call ESMF_ClockGet( PrivateState%CLOCK, currTime=myTime, RC=STATUS)
     VERIFY_(status)
 
-    call MAPL_GetResource(state,ReplayMode,  'REPLAY_MODE:',  default="NoReplay", RC=STATUS )
-    if (trim(replayMode)=="Regular" ) then
-       if (myTime > EndTime) then
-          call ESMF_ClockSet(PrivateState%Clock,direction=ESMF_DIRECTION_REVERSE,rc=status)
-          VERIFY_(status)
-          do
-            call ESMF_ClockAdvance(PrivateState%Clock,rc=status)
-            VERIFY_(status)
-            call ESMF_ClockGet(PrivateState%Clock,currTime=ct,rc=status)
-            VERIFY_(status)
-            if (ct==endTime) exit
-          enddo
-          call ESMF_ClockSet(PrivateState%Clock,direction=ESMF_DIRECTION_FORWARD,rc=status)
-          VERIFY_(status)
-          call ESMF_ClockGet( PrivateState%CLOCK, currTime=myTime, RC=STATUS)
-          VERIFY_(status)
-       end if
+    if (myTime > EndTime) then
+       call ESMF_ClockSet(PrivateState%Clock,direction=ESMF_DIRECTION_REVERSE,rc=status)
+       VERIFY_(status)
+       do
+         call ESMF_ClockAdvance(PrivateState%Clock,rc=status)
+         VERIFY_(status)
+         call ESMF_ClockGet(PrivateState%Clock,currTime=ct,rc=status)
+         VERIFY_(status)
+         if (ct==endTime) exit
+       enddo
+       call ESMF_ClockSet(PrivateState%Clock,direction=ESMF_DIRECTION_FORWARD,rc=status)
+       VERIFY_(status)
+       call ESMF_ClockGet( PrivateState%CLOCK, currTime=myTime, RC=STATUS)
+       VERIFY_(status)
     end if
 
     if( MyTime <= EndTime ) then ! Time to run


### PR DESCRIPTION
A proposed small change in GuestOcean, detailed description in issue #337 ,there is logic that I just can't see any justifiable reason for having unless I'm missing something.
To support future work when running GEOS in Jedi this either needs to be removed or we have to somehow have a 2nd conditional in addition to if running replay. I can't see why we need any condition at all around the rewind.

In testing both replay and AMIP it is zero diff.