### PR TITLE
add TOA RRTMG Band6 (window region) IR diagnostics for Allie

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -688,6 +688,22 @@ contains
     VERIFY_(STATUS)
 
     call MAPL_AddExportSpec(GC,                                   &
+        SHORT_NAME = 'OLRB06RG',                                  &
+        LONG_NAME  = 'upwelling_longwave_flux_at_toa_in_RRTMG_band06 (820-980 cm-1)', &
+        UNITS      = 'W m-2',                                     &
+        DIMS       = MAPL_DimsHorzOnly,                           &
+        VLOCATION  = MAPL_VLocationNone,               RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec(GC,                                   &
+        SHORT_NAME = 'TBRB06RG',                                  &
+        LONG_NAME  = 'brightness_temperature_in_RRTMG_band06 (820-980 cm-1)',         &
+        UNITS      = 'K',                                         &
+        DIMS       = MAPL_DimsHorzOnly,                           &
+        VLOCATION  = MAPL_VLocationNone,               RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec(GC,                                   &
         SHORT_NAME = 'OLRB09RG',                                  &
         LONG_NAME  = 'upwelling_longwave_flux_at_toa_in_RRTMG_band09 (1180-1390 cm-1)', &
         UNITS      = 'W m-2',                                     &
@@ -1020,6 +1036,20 @@ contains
     VERIFY_(STATUS)
 
     call MAPL_AddInternalSpec(GC,                                 &
+        SHORT_NAME = 'OLRB06RG',                                  &
+        LONG_NAME  = 'upwelling_longwave_flux_at_toa_in_RRTMG_band06', &
+        UNITS      = 'W m-2',                                     &
+        DIMS       = MAPL_DimsHorzOnly,                           &
+        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+
+    call MAPL_AddInternalSpec(GC,                                 &
+        SHORT_NAME = 'DOLRB06RGDT',                               &
+        LONG_NAME  = 'derivative_of_upwelling_longwave_flux_at_toa_in_RRTMG_band06_wrt_surface_temp', &
+        UNITS      = 'W m-2 K-1',                                 &
+        DIMS       = MAPL_DimsHorzOnly,                           &
+        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+
+    call MAPL_AddInternalSpec(GC,                                 &
         SHORT_NAME = 'OLRB09RG',                                  &
         LONG_NAME  = 'upwelling_longwave_flux_at_toa_in_RRTMG_band09', &
         UNITS      = 'W m-2',                                     &
@@ -1188,8 +1218,8 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
    real, pointer, dimension(:,:,:)   :: DFDTSC
    real, pointer, dimension(:,:,:)   :: DFDTSCNA
 
-   real, pointer, dimension(:,:  )   :: OLRB09RG_INT, OLRB10RG_INT, OLRB11RG_INT
-   real, pointer, dimension(:,:  )   :: DOLRB09RG_DT, DOLRB10RG_DT, DOLRB11RG_DT
+   real, pointer, dimension(:,:  )   :: OLRB06RG_INT, OLRB09RG_INT, OLRB10RG_INT, OLRB11RG_INT
+   real, pointer, dimension(:,:  )   :: DOLRB06RG_DT, DOLRB09RG_DT, DOLRB10RG_DT, DOLRB11RG_DT
 
    real, external :: getco2
 
@@ -1305,6 +1335,8 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
    call MAPL_GetPointer(INTERNAL, DFDTSNA,   'DFDTSNA', RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(INTERNAL, DFDTSCNA,  'DFDTSCNA',RC=STATUS); VERIFY_(STATUS)
 
+   call MAPL_GetPointer(INTERNAL, OLRB06RG_INT, 'OLRB06RG'   , __RC__)
+   call MAPL_GetPointer(INTERNAL, DOLRB06RG_DT, 'DOLRB06RGDT', __RC__)
    call MAPL_GetPointer(INTERNAL, OLRB09RG_INT, 'OLRB09RG'   , __RC__)
    call MAPL_GetPointer(INTERNAL, DOLRB09RG_DT, 'DOLRB09RGDT', __RC__)
    call MAPL_GetPointer(INTERNAL, OLRB10RG_INT, 'OLRB10RG'   , __RC__)
@@ -1520,6 +1552,7 @@ contains
    real,    allocatable, dimension(:,:)   :: HR, HRC
    integer, allocatable, dimension(:,:)   :: CLOUDFLAG
    real,    allocatable, dimension(:)     :: ALAT
+   real,    allocatable, dimension(:)     :: OLRB06RG_1D, DOLRB06RG_DT_1D
    real,    allocatable, dimension(:)     :: OLRB09RG_1D, DOLRB09RG_DT_1D
    real,    allocatable, dimension(:)     :: OLRB10RG_1D, DOLRB10RG_DT_1D
    real,    allocatable, dimension(:)     :: OLRB11RG_1D, DOLRB11RG_DT_1D
@@ -3284,6 +3317,8 @@ contains
       allocate(HRC(IM*JM,LM+1),__STAT__)
       allocate(CLOUDFLAG(IM*JM,4),__STAT__)
       allocate(ALAT(IM*JM),__STAT__)
+      allocate(OLRB06RG_1D(IM*JM),__STAT__)
+      allocate(DOLRB06RG_DT_1D(IM*JM),__STAT__)
       allocate(OLRB09RG_1D(IM*JM),__STAT__)
       allocate(DOLRB09RG_DT_1D(IM*JM),__STAT__)
       allocate(OLRB10RG_1D(IM*JM),__STAT__)
@@ -3410,7 +3445,8 @@ contains
               TAUCLD ,CICEWP ,CLIQWP ,REICE ,RELIQ , &
               TAUAER  , ZL_R, LCLDLM, LCLDMH, &
               UFLX, DFLX, HR, UFLXC, DFLXC, HRC, DUFLX_DT, DUFLXC_DT, CLOUDFLAG, &
-              OLRB09RG_1D, DOLRB09RG_DT_1D, OLRB10RG_1D, DOLRB10RG_DT_1D, OLRB11RG_1D, DOLRB11RG_DT_1D, &
+              OLRB06RG_1D, DOLRB06RG_DT_1D, OLRB09RG_1D, DOLRB09RG_DT_1D, &
+              OLRB10RG_1D, DOLRB10RG_DT_1D, OLRB11RG_1D, DOLRB11RG_DT_1D, &
               DOY, ALAT, CoresPerNode, PARTITION_SIZE)
 
       call MAPL_TimerOff(MAPL,"---RRTMG_RUN",RC=STATUS)
@@ -3456,7 +3492,9 @@ contains
 
          SFCEM_INT(i,j) = -UFLX(IJ,1) + DFLX(IJ,1)*(1.0-EMISS(IJ,1))
 
-         ! band 9-11 water vapor products
+         ! band 6 window and band 9-11 water vapor products
+         OLRB06RG_INT(i,j) = OLRB06RG_1D(IJ)
+         DOLRB06RG_DT(i,j) = DOLRB06RG_DT_1D(IJ)
          OLRB09RG_INT(i,j) = OLRB09RG_1D(IJ)
          DOLRB09RG_DT(i,j) = DOLRB09RG_DT_1D(IJ)
          OLRB10RG_INT(i,j) = OLRB10RG_1D(IJ)
@@ -3510,6 +3548,8 @@ contains
       deallocate(HRC,__STAT__)
       deallocate(CLOUDFLAG,__STAT__)
       deallocate(ALAT,__STAT__)
+      deallocate(OLRB06RG_1D,__STAT__)
+      deallocate(DOLRB06RG_DT_1D,__STAT__)
       deallocate(OLRB09RG_1D,__STAT__)
       deallocate(DOLRB09RG_DT_1D,__STAT__)
       deallocate(OLRB10RG_1D,__STAT__)
@@ -3654,6 +3694,7 @@ contains
    real, pointer, dimension(:,:  )   :: OLC
    real, pointer, dimension(:,:  )   :: OLCC5
    real, pointer, dimension(:,:  )   :: OLA
+   real, pointer, dimension(:,:  )   :: OLRB06RG, TBRB06RG
    real, pointer, dimension(:,:  )   :: OLRB09RG, TBRB09RG
    real, pointer, dimension(:,:  )   :: OLRB10RG, TBRB10RG
    real, pointer, dimension(:,:  )   :: OLRB11RG, TBRB11RG
@@ -3703,6 +3744,8 @@ contains
    call MAPL_GetPointer(EXPORT,   OLC   ,    'OLC'   ,RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT,   OLCC5 ,    'OLCC5' ,RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT,   OLA   ,    'OLA'   ,RC=STATUS); VERIFY_(STATUS)
+   call MAPL_GetPointer(EXPORT, OLRB06RG,  'OLRB06RG',RC=STATUS); VERIFY_(STATUS)
+   call MAPL_GetPointer(EXPORT, TBRB06RG,  'TBRB06RG',RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT, OLRB09RG,  'OLRB09RG',RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT, TBRB09RG,  'TBRB09RG',RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT, OLRB10RG,  'OLRB10RG',RC=STATUS); VERIFY_(STATUS)
@@ -3854,6 +3897,8 @@ contains
        if(associated(FLNSC )) FLNSC  =  FLC_INT(:,:,LM) + DFDTSC  (:,:,LM) * DELT
        if(associated(FLNSA )) FLNSA  =  FLA_INT(:,:,LM) + DFDTSCNA(:,:,LM) * DELT
 
+       if(associated(OLRB06RG)) OLRB06RG = MAPL_UNDEF
+       if(associated(TBRB06RG)) TBRB06RG = MAPL_UNDEF
        if(associated(OLRB09RG)) OLRB09RG = MAPL_UNDEF
        if(associated(TBRB09RG)) TBRB09RG = MAPL_UNDEF
        if(associated(OLRB10RG)) OLRB10RG = MAPL_UNDEF
@@ -3926,6 +3971,18 @@ contains
        if(associated(FLNSNA)) FLNSNA = MAPL_UNDEF
        if(associated(FLNSC )) FLNSC  = FLC_INT(:,:,LM) + DFDTSC(:,:,LM) * DELT
        if(associated(FLNSA )) FLNSA  = MAPL_UNDEF
+
+       if(associated(OLRB06RG).or.associated(TBRB06RG)) then
+         allocate(OLRBNN(IM,JM),__STAT__)
+         OLRBNN = OLRB06RG_INT + DOLRB06RG_DT * DELT
+         if(associated(OLRB06RG)) OLRB06RG = OLRBNN
+         if(associated(TBRB06RG)) then
+           ! brightness temperature for RRTMG band 06
+           wn1 = 820.e2; wn2 = 980.e2  ! NB: [m-1]
+           call Tbr_from_band_flux(IM, JM, OLRBNN, wn1, wn2, TBRB06RG, __RC__)
+         end if
+         deallocate(OLRBNN)
+       end if
 
        if(associated(OLRB09RG).or.associated(TBRB09RG)) then
          allocate(OLRBNN(IM,JM),__STAT__)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/gpu_rrtmg_lw_rtrnmc.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/gpu_rrtmg_lw_rtrnmc.F90
@@ -93,7 +93,9 @@
                                               ! with respect to surface temperature
       real , allocatable _gpudev :: dplankbnd_dtd(:,:) 
      
-      ! TOA OLR in bands 9-11 and their derivatives with surface temp
+      ! TOA OLR in bands 6 & 9-11 and their derivatives with surface temp
+      real , allocatable _gpudev :: olrb06d(:)     ! (W/m2)
+      real , allocatable _gpudev :: dolrb06_dtd(:) ! (W/m2/K)
       real , allocatable _gpudev :: olrb09d(:)     ! (W/m2)
       real , allocatable _gpudev :: dolrb09_dtd(:) ! (W/m2/K)
       real , allocatable _gpudev :: olrb10d(:)     ! (W/m2)
@@ -657,6 +659,7 @@
                totuclfld(iplon, ilay)=totuclfld(iplon, ilay)+gclrurad(iplon, igp, ilay)
                totdclfld(iplon, ilay)=totdclfld(iplon, ilay)+gclrdrad(iplon, igp, ilay)
                if (ilay .eq. nlay) then
+                 if (ngb(igp) .eq.  6) olrb06d(iplon) = olrb06d(iplon) + gurad(iplon, igp, nlay)
                  if (ngb(igp) .eq.  9) olrb09d(iplon) = olrb09d(iplon) + gurad(iplon, igp, nlay)
                  if (ngb(igp) .eq. 10) olrb10d(iplon) = olrb10d(iplon) + gurad(iplon, igp, nlay)
                  if (ngb(igp) .eq. 11) olrb11d(iplon) = olrb11d(iplon) + gurad(iplon, igp, nlay)
@@ -670,6 +673,7 @@
                 dtotuflux_dtd(iplon, ilay) = dtotuflux_dtd(iplon, ilay) + gdtotuflux_dtd( iplon, igp, ilay)
                 dtotuclfl_dtd(iplon, ilay) = dtotuclfl_dtd(iplon, ilay) + gdtotuclfl_dtd( iplon, igp, ilay)
                 if (ilay .eq. nlay) then
+                  if (ngb(igp) .eq.  6) dolrb06_dtd(iplon) = dolrb06_dtd(iplon) + gdtotuflux_dtd(iplon, igp, nlay)
                   if (ngb(igp) .eq.  9) dolrb09_dtd(iplon) = dolrb09_dtd(iplon) + gdtotuflux_dtd(iplon, igp, nlay)
                   if (ngb(igp) .eq. 10) dolrb10_dtd(iplon) = dolrb10_dtd(iplon) + gdtotuflux_dtd(iplon, igp, nlay)
                   if (ngb(igp) .eq. 11) dolrb11_dtd(iplon) = dolrb11_dtd(iplon) + gdtotuflux_dtd(iplon, igp, nlay)
@@ -781,6 +785,8 @@
           allocate (dtotuclfl_dtd(ncol, 0:nlay))
           allocate (dplankbnd_dtd(ncol,nbndlw)) 
 
+          allocate (olrb06d(ncol))
+          allocate (dolrb06_dtd(ncol))
           allocate (olrb09d(ncol))
           allocate (dolrb09_dtd(ncol))
           allocate (olrb10d(ncol))
@@ -821,6 +827,7 @@
             deallocate( gdtotuflux_dtd, gdtotuclfl_dtd )
           end if
 
+          deallocate (olrb06d, dolrb06_dtd)
           deallocate (olrb09d, dolrb09_dtd)
           deallocate (olrb10d, dolrb10_dtd)
           deallocate (olrb11d, dolrb11_dtd)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_rad.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_rad.F90
@@ -52,7 +52,8 @@
             tauaer  , zm, cloudMH, cloudHH, &
             uflx    ,dflx    ,hr      ,uflxc   ,dflxc,  hrc, &
             duflx_dt, duflxc_dt, cloudFlag, &
-            olrb09, dolrb09_dt, olrb10, dolrb10_dt, olrb11, dolrb11_dt, &
+            olrb06, dolrb06_dt, olrb09, dolrb09_dt, &
+            olrb10, dolrb10_dt, olrb11, dolrb11_dt, &
             dyofyr, alat, numCPUs, partition_size)
          ! -------- Description --------
 
@@ -288,6 +289,7 @@
          !    Dimensions: (ncol,nlay)
          integer , intent(out), optional :: cloudFlag(:,:)
 
+         real, intent(out), dimension(:), optional :: olrb06, dolrb06_dt
          real, intent(out), dimension(:), optional :: olrb09, dolrb09_dt
          real, intent(out), dimension(:), optional :: olrb10, dolrb10_dt
          real, intent(out), dimension(:), optional :: olrb11, dolrb11_dt
@@ -396,7 +398,8 @@
                   tauaer  , zm, cloudMH, cloudHH, &
                   uflx    ,dflx    ,hr      ,uflxc   ,dflxc,  hrc, &
                   duflx_dt, duflxc_dt, cloudFlag, &
-                  olrb09, dolrb09_dt, olrb10, dolrb10_dt, olrb11, dolrb11_dt, &
+                  olrb06, dolrb06_dt, olrb09, dolrb09_dt, &
+                  olrb10, dolrb10_dt, olrb11, dolrb11_dt, &
                   dyofyr,alat)    
          end do
 
@@ -420,7 +423,8 @@
             tauaer  , zm, cloudMH, cloudHH, &
             uflx    ,dflx    ,hr      ,uflxc   ,dflxc,  hrc, &
             duflx_dt, duflxc_dt, cloudFlag, &
-            olrb09, dolrb09_dt, olrb10, dolrb10_dt, olrb11, dolrb11_dt, &
+            olrb06, dolrb06_dt, olrb09, dolrb09_dt, &
+            olrb10, dolrb10_dt, olrb11, dolrb11_dt, &
             dyofyr,alat)
 
 
@@ -551,10 +555,11 @@
          !    Dimensions: (ncol,nlay)
          integer , intent(out), optional :: cloudFlag(:,:)
 
+         real, intent(out), dimension(:), optional :: olrb06, dolrb06_dt
          real, intent(out), dimension(:), optional :: olrb09, dolrb09_dt
          real, intent(out), dimension(:), optional :: olrb10, dolrb10_dt
          real, intent(out), dimension(:), optional :: olrb11, dolrb11_dt
-         ! OLR for bands 9-11 and temperature derivatives (W/m2, W/m2/K)
+         ! OLR for bands 6 & 9-11 and temperature derivatives (W/m2, W/m2/K)
          !    Dimensions: (ncol)
 
          real  _gpudeva :: cldfmcd(:,:,:)         ! layer cloud fraction [mcica]
@@ -1020,6 +1025,8 @@
          htrcd = 0.0
          dtotuflux_dtd = 0.0
          dtotuclfl_dtd = 0.0
+         olrb06d = 0.0
+         dolrb06_dtd = 0.0
          olrb09d = 0.0
          dolrb09_dtd = 0.0
          olrb10d = 0.0
@@ -1055,6 +1062,7 @@
          dflxc(colstart:(colstart+pncol-1), 1:(nlayers+1)) = totdclfld(:,0:nlayers)
          hr(colstart:(colstart+pncol-1), 1:(nlayers+1)) = htrd(:,0:nlayers)
          hrc(colstart:(colstart+pncol-1), 1:(nlayers+1)) = htrcd(:,0:nlayers)
+         olrb06(colstart:(colstart+pncol-1)) = olrb06d(:)
          olrb09(colstart:(colstart+pncol-1)) = olrb09d(:)
          olrb10(colstart:(colstart+pncol-1)) = olrb10d(:)
          olrb11(colstart:(colstart+pncol-1)) = olrb11d(:)
@@ -1063,6 +1071,7 @@
 
             duflx_dt(colstart:(colstart+pncol-1), 1:(nlayers+1)) = dtotuflux_dtd(:,0:nlayers)
             duflxc_dt(colstart:(colstart+pncol-1), 1:(nlayers+1)) = dtotuclfl_dtd(:,0:nlayers)
+            dolrb06_dt(colstart:(colstart+pncol-1)) = dolrb06_dtd(:)
             dolrb09_dt(colstart:(colstart+pncol-1)) = dolrb09_dtd(:)
             dolrb10_dt(colstart:(colstart+pncol-1)) = dolrb10_dtd(:)
             dolrb11_dt(colstart:(colstart+pncol-1)) = dolrb11_dtd(:)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_rtrn.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_rtrn.F90
@@ -34,9 +34,9 @@
                       pwvcm, fracs, taut, & 
                       totuflux, totdflux, fnet, htr, &
                       totuclfl, totdclfl, fnetc, htrc, &
-                      olrb09, olrb10, olrb11, &
+                      olrb06, olrb09, olrb10, olrb11, &
                       idrv, dplankbnd_dt, dtotuflux_dt, dtotuclfl_dt, &
-                      dolrb09_dt, dolrb10_dt, dolrb11_dt )
+                      dolrb06_dt, dolrb09_dt, dolrb10_dt, dolrb11_dt )
 !-----------------------------------------------------------------------------
 !
 !  Original version:   E. J. Mlawer, et al. RRTM_V3.0
@@ -121,9 +121,9 @@
                                                       ! with respect to surface temperature
                                                       !    Dimensions: (0:nlayers)
 
-      ! TOA OLR in bands 9-11 and their derivatives with surface temp
-      real, intent(out) :: olrb09,     olrb10,     olrb11       ! W/m2
-      real, intent(out) :: dolrb09_dt, dolrb10_dt, dolrb11_dt   ! W/m2/K
+      ! TOA OLR in bands 6 & 9-11 and their derivatives with surface temp
+      real, intent(out) :: olrb06,     olrb09,     olrb10,     olrb11       ! W/m2
+      real, intent(out) :: dolrb06_dt, dolrb09_dt, dolrb10_dt, dolrb11_dt   ! W/m2/K
 
 ! ----- Local -----
 ! Declarations for radiative transfer
@@ -291,11 +291,13 @@
          dtotuclfl_dt(0) = 0.0 
       endif
 
-      ! default to zero if bands 9-11 not included
+      ! default to zero if bands 6 & 9-11 not included
+      olrb06 = 0.0
       olrb09 = 0.0
       olrb10 = 0.0
       olrb11 = 0.0
       if (idrv .eq. 1) then
+         dolrb06_dt = 0.0
          dolrb09_dt = 0.0
          dolrb10_dt = 0.0
          dolrb11_dt = 0.0
@@ -574,7 +576,13 @@
             enddo
          endif
 
-         ! bands 9-11 TOA OLR
+         ! bands 6 & 9-11 TOA OLR
+         if (iband .eq.  6) then
+            olrb06 = uflux(nlayers) * delwave(iband)
+            if (idrv .eq. 1) then
+               dolrb06_dt = duflux_dt(nlayers) * delwave(iband)
+            end if
+         end if
          if (iband .eq.  9) then
             olrb09 = uflux(nlayers) * delwave(iband)
             if (idrv .eq. 1) then
@@ -624,11 +632,13 @@
       htr(nlayers) = 0.0 
       htrc(nlayers) = 0.0 
 
-      ! bands 9-11 TOA OLR (convert to flux)
+      ! bands 6 & 9-11 TOA OLR (convert to flux)
+      olrb06 = olrb06 * fluxfac
       olrb09 = olrb09 * fluxfac
       olrb10 = olrb10 * fluxfac
       olrb11 = olrb11 * fluxfac
       if (idrv .eq. 1) then
+        dolrb06_dt = dolrb06_dt * fluxfac
         dolrb09_dt = dolrb09_dt * fluxfac
         dolrb10_dt = dolrb10_dt * fluxfac
         dolrb11_dt = dolrb11_dt * fluxfac

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_rtrnmr.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_rtrnmr.F90
@@ -34,9 +34,9 @@
                         pwvcm, fracs, taut, & 
                         totuflux, totdflux, fnet, htr, &
                         totuclfl, totdclfl, fnetc, htrc, &
-                        olrb09, olrb10, olrb11, &
+                        olrb06, olrb09, olrb10, olrb11, &
                         idrv, dplankbnd_dt, dtotuflux_dt, dtotuclfl_dt, &
-                        dolrb09_dt, dolrb10_dt, dolrb11_dt )
+                        dolrb06_dt, dolrb09_dt, dolrb10_dt, dolrb11_dt )
 !-----------------------------------------------------------------------------
 !
 !  Original version:   E. J. Mlawer, et al. RRTM_V3.0
@@ -121,9 +121,9 @@
                                                       ! with respect to surface temperature
                                                       !    Dimensions: (0:nlayers)
 
-      ! TOA OLR in bands 9-11 and their derivatives with surface temp
-      real, intent(out) :: olrb09,     olrb10,     olrb11       ! W/m2
-      real, intent(out) :: dolrb09_dt, dolrb10_dt, dolrb11_dt   ! W/m2/K
+      ! TOA OLR in bands 6 & 9-11 and their derivatives with surface temp
+      real, intent(out) :: olrb06,     olrb09,     olrb10,     olrb11       ! W/m2
+      real, intent(out) :: dolrb06_dt, dolrb09_dt, dolrb10_dt, dolrb11_dt   ! W/m2/K
 
 ! ----- Local -----
 ! Declarations for radiative transfer
@@ -303,11 +303,13 @@
          dtotuclfl_dt(0) = 0.0 
       endif
 
-      ! default to zero if bands 9-11 not included
+      ! default to zero if bands 6 & 9-11 not included
+      olrb06 = 0.0
       olrb09 = 0.0
       olrb10 = 0.0
       olrb11 = 0.0
       if (idrv .eq. 1) then
+         dolrb06_dt = 0.0
          dolrb09_dt = 0.0
          dolrb10_dt = 0.0
          dolrb11_dt = 0.0
@@ -762,7 +764,13 @@
             enddo
          endif
 
-         ! bands 9-11 TOA OLR
+         ! bands 6 & 9-11 TOA OLR
+         if (iband .eq.  6) then
+            olrb06 = uflux(nlayers) * delwave(iband)
+            if (idrv .eq. 1) then
+               dolrb06_dt = duflux_dt(nlayers) * delwave(iband)
+            end if
+         end if
          if (iband .eq.  9) then
             olrb09 = uflux(nlayers) * delwave(iband)
             if (idrv .eq. 1) then
@@ -813,11 +821,13 @@
       htr(nlayers) = 0.0 
       htrc(nlayers) = 0.0 
 
-      ! bands 9-11 TOA OLR (convert to flux)
+      ! bands 6 & 9-11 TOA OLR (convert to flux)
+      olrb06 = olrb06 * fluxfac
       olrb09 = olrb09 * fluxfac
       olrb10 = olrb10 * fluxfac
       olrb11 = olrb11 * fluxfac
       if (idrv .eq. 1) then
+        dolrb06_dt = dolrb06_dt * fluxfac
         dolrb09_dt = dolrb09_dt * fluxfac
         dolrb10_dt = dolrb10_dt * fluxfac
         dolrb11_dt = dolrb11_dt * fluxfac


### PR DESCRIPTION
zero-diff because addition of diagnostic only
plus already did test runs to prove zero-diff
new diagnostics are OLRB06RG and TBRB06RG (OLR and Tbr in Band 6 of RRTMG)