### PR TITLE
Feature/san akel/aoil v2.0 dev

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2354,7 +2354,6 @@ contains
    real,    dimension(NT)              :: PUF
    real,    dimension(NT)              :: PPR
    real,    dimension(NT)              :: PPF
-   real,    dimension(NT)              :: PENICE
    real,    dimension(NT)              :: LHF
    real,    dimension(NT)              :: ZTH
    real,    dimension(NT)              :: SLR
@@ -2833,10 +2832,8 @@ contains
     ! DTY accounts for ice on top of water. Part of Shortwave is absorbed by ice and rest goes to warm water.
     ! Skin layer only absorbs the portion of SW radiation passing thru the bottom of ice MINUS
     ! the portion passing thru the skin layer    
-
-    ! penetrated shortwave from sea ice bottom + associated ocean/ice heat flux
-!    DTY = DT / (SALTWATERCAP*HW) * (PENICE * FI + FHOCN)
-     DTY = 0. ! SA: revisit above with CICE6 [Nov, 2019]
+    ! Penetrated shortwave from sea ice bottom + associated ocean/ice heat flux
+    DTY = 0. ! Revisit above with CICE6 [Nov, 2019] and compute DTY = DT / (SALTWATERCAP*HW) * (PENICE * FI + FHOCN)
 
     DTS = DTX * ( DTS + SWN - EVP*MAPL_ALHL - MAPL_ALHF*SNO ) + DTY
     DTS = DTS   / ( 1.0 + DTX*(BLW + SHD + EVD*MAPL_ALHL) )

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2825,9 +2825,11 @@ contains
 
     FRESHATM    = FRWATER*(SNO - EVP) + PCU + PLS
     FRESH       = 0.
+    HH(:,N) = HH(:,N) + DT*(FRESHATM + FRESH)
 
-    if( trim(AOIL_COMP_SWITCH) == "ON") then
-      HH(:,N) = HH(:,N) + DT*(FRESHATM + FRESH)
+    if (DO_DATASEA == 0) then               ! coupled   mode
+      HH(:,N) = max( min(HH(:,N), (MaxWaterDepth*water_RHO('salt_water'))),  (MinWaterDepth*water_RHO('salt_water')))
+    else                                    ! uncoupled mode
       HH(:,N) = max( min(HH(:,N), (MaxWaterDepth*water_RHO('fresh_water'))), (MinWaterDepth*water_RHO('fresh_water')))
     endif
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -1557,10 +1557,10 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
 
    real, pointer, dimension(:  )  :: TW  => null()
    real, pointer, dimension(:  )  :: HW  => null()
-
    real, pointer, dimension(:  )  :: TWMTS => null()
    real, pointer, dimension(:  )  :: TWMTF => null()
    real, pointer, dimension(:  )  :: DELTC => null()
+
    real, pointer, dimension(:,:)  :: QS  => null()
    real, pointer, dimension(:,:)  :: CH  => null()
    real, pointer, dimension(:,:)  :: CM  => null()
@@ -2635,7 +2635,15 @@ contains
     call MAPL_GetResource ( MAPL, MINSALINITY,   Label="MIN_SALINITY:" ,    DEFAULT=5.0  ,   RC=STATUS)
     VERIFY_(STATUS)
 
-    if(DO_SKIN_LAYER==0) TWMTS = 0.
+    if(DO_SKIN_LAYER==0) then                ! inactive AOIL (OFF)
+      HH(:,WATER) = AOIL_depth * water_RHO('salt_water')
+      SS(:,WATER) = SS_FOUNDi*HW
+      TS(:,WATER) = TS_FOUNDi
+
+      TWMTS = 0.
+      TWMTF = 0.
+      DELTC = 0.
+    endif
 
     if( trim(AOIL_COMP_SWITCH) == "ON") then ! as close as possible to "x0039", while keeping everything as in "x0040"
 
@@ -2649,13 +2657,7 @@ contains
 
 !   Get TS from internal state exactly as in Run1
 !   ---------------------------------------------
-       if (DO_SKIN_LAYER==0) then 
-         HH(:,WATER) = 1.e+15    ! infinite heat capacity with TS = SST (from data)
-         TS(:,WATER) = TS_FOUNDi
-         SS(:,WATER) = SS_FOUNDi
-         TWMTF       = 0.
-         DELTC       = 0.
-       else 
+       if (DO_SKIN_LAYER/=0) then 
          HH(:,WATER) = AOIL_depth * water_RHO('salt_water')
          SS(:,WATER) = SS_FOUNDi*HH(:,WATER)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -64,23 +64,6 @@ module GEOS_OpenwaterGridCompMod
 !      $$ \frac{\partial \sigma_T}{\partial t}= \frac{Q_{\sigma}}{d\,\rho_w\,c_w} - \frac{1}{\tau_{\sigma}} \sigma_T.$$
 !      \noindent For complete details, please see Akella and Suarez, 2018, 
 !      "The Atmosphere-Ocean Interface Layer of the NASA Goddard Earth Observing System Model and Data Assimilation System." GMAO Tech Memo, Vol 51. 
-!
-!      \noindent COMPATIBILITY: 
-!
-!      **************************************************************************
-!      Set Services:
-!      enables ability to run old and/or new interface(s) by setting compatibility: ON
-!      -- this feature adds (back) "old" stuff when set ON
-!
-!      Whereas Run(1,2) will execute either 
-!      -----------      -------------------
-!      interface 
-!       version        compatibility
-!     -----------      -------------------
-!        old:               ON
-!        new:               OFF
-!      **************************************************************************
-!
 !      ----------------------------------------------------------------------------
 !
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -114,7 +114,7 @@ module GEOS_OpenwaterGridCompMod
   character(len=7)   :: AOIL_COMP_SWITCH  ! Atmosphere-Ocean Interface Layer, compatibility: on/off
                                           ! defualt: OFF, so AOIL is incompatible with "old" interface
                                           ! when it is ON, set servives provides what is needed for both versions
-                                          ! whereas RUN(1,2) will use one or other (OFF: AOIL; ON: old interface)
+                                          ! whereas RUN(2) will use one or other (OFF: AOIL; ON: old interface)
 
   contains
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -96,7 +96,6 @@ module GEOS_OpenwaterGridCompMod
   integer, parameter            :: WATER        = 1      
   integer, parameter            :: NUM_SUBTILES = 1             ! number of sub-tiles
   real,    parameter            :: KUVR         = 0.09
-  real,    parameter            :: SALTWATERCAP  = MAPL_CAPWTR
 
   contains
 
@@ -2308,16 +2307,12 @@ contains
    real,    dimension(NT)              :: FRWATER
    real,    dimension(NT)              :: SHF
    real,    dimension(NT)              :: EVP
-   real,    dimension(NT)              :: SHD
-   real,    dimension(NT)              :: EVD
    real,    dimension(NT)              :: CFQ
    real,    dimension(NT)              :: CFT
    real,    dimension(NT)              :: TXW
    real,    dimension(NT)              :: TYW
    real,    dimension(NT)              :: DQS
    real,    dimension(NT)              :: DTS
-   real,    dimension(NT)              :: DTX
-   real,    dimension(NT)              :: DTY
    real,    dimension(NT)              :: SWN
    real,    dimension(NT)              :: PEN
    real,    dimension(NT)              :: PEN_ocean
@@ -2740,52 +2735,6 @@ contains
     call surf_hflux_update (NT,DO_SKIN_LAYER,DO_DATASEA,MUSKIN,DT,epsilon_d,  &
              CFT,CFQ,SH,EVAP,DSH,DEV,THATM,QHATM,PS,FRWATER,HH(:,N),SNO,      &
              LWDNSRF,SWN,ALW,BLW,SHF,LHF,EVP,DTS,DQS,TS(:,N),QS(:,N),TWMTS,TWMTF)
-
-!   EVP = CFQ*(EVAP + DEV*(QS(:,N)-QHATM))
-!   SHF = CFT*(SH   + DSH*(TS(:,N)-THATM))
-!   SHD = CFT*DSH
-!   EVD = CFQ*DEV*GEOS_DQSAT(TS(:,N), PS, RAMP=0.0, PASCALS=.TRUE.)
-!   DTS = LWDNSRF - (ALW + BLW*TS(:,N)) - SHF
-
-!   ! FR accounts for skin under ice
-!   DTX = DT*FRWATER / (SALTWATERCAP*HH(:,N))
-
-!   if (DO_SKIN_LAYER == 0) then
-!     DTX = 0.
-!   else
-!     DTX = DTX*((MUSKIN+1.-MUSKIN*epsilon_d)/MUSKIN) ! note: epsilon_d is = 0. in uncoupled mode (DO_DATASEA == 1)
-!   endif
-
-!   ! DTY accounts for ice on top of water. Part of Shortwave is absorbed by ice and rest goes to warm water.
-!   ! Skin layer only absorbs the portion of SW radiation passing thru the bottom of ice MINUS
-!   ! the portion passing thru the skin layer    
-!   ! Penetrated shortwave from sea ice bottom + associated ocean/ice heat flux
-!   DTY = 0. ! Revisit above with CICE6 [Nov, 2019] and compute DTY = DT / (SALTWATERCAP*HW) * (PENICE * FI + FHOCN)
-
-!   DTS = DTX * ( DTS + SWN - EVP*MAPL_ALHL - MAPL_ALHF*SNO ) + DTY
-!   DTS = DTS   / ( 1.0 + DTX*(BLW + SHD + EVD*MAPL_ALHL) )
-!   EVP = EVP + EVD * DTS
-!   SHF = SHF + SHD * DTS
-!   LHF = EVP * MAPL_ALHL
-
-! Update WATER surface temperature, moisture and mass
-!----------------------------------------------------
-!   TS(:,N) = TS(:,N) + DTS
-!   DQS     = GEOS_QSAT(TS(:,N), PS, RAMP=0.0, PASCALS=.TRUE.) - QS(:,N)
-!   QS(:,N) = QS(:,N) + DQS
-
-!   if(DO_SKIN_LAYER == 0) then
-!     TWMTS = 0.
-!     TWMTF = 0.
-!   else
-!     TWMTS = TWMTS - (1.0/(MUSKIN+1.0))*DTS
-!     if (DO_DATASEA == 0) then            ! coupled   mode
-!        TWMTF = TWMTF + (MUSKIN/(1.+MUSKIN-MUSKIN*epsilon_d))*DTS
-!     else                                 ! uncoupled mode
-!        TWMTF = 0.
-!!       TWMTF = TWMTF + (MUSKIN/(1.+MUSKIN))*DTS ! This will cause non-zero diff in internal/checkpoint, but ZERO DIFF in OUTPUT.
-!     end if
-!   end if
 
     call AOIL_v0_HW ( NT, DT, DO_DATASEA, MaxWaterDepth, MinWaterDepth, &
                       FRWATER, SNO, EVP, PCU+PLS, HH(:,WATER))

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -22,6 +22,7 @@ module GEOS_OpenwaterGridCompMod
 !      by passing back an effective surface value of the exchanged quantity.
 !      ----------------------------------------------------------------------------
 !
+!      --------- rewrite ---------
 !      \noindent The "OPENWATERCORE" implements following AOIL.
 !      \noindent If the AOIL is OFF, near-surface temperature variations are neglected, 
 !      $T_s = T_o$ from the ocean model, or $=T_f$ from boundary conditions.\\~\\

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2797,21 +2797,6 @@ contains
     SHF = SHF + SHD * DTS
     LHF = EVP * MAPL_ALHL
 
-    if(associated(HLATWTR)) then
-          WHERE( FRWATER>0.0 )
-             HLATWTR = LHF
-          ELSEWHERE
-             HLATWTR = MAPL_UNDEF
-          ENDWHERE
-    endif
-    if(associated(  SHWTR)) then
-          WHERE( FRWATER>0.0 )
-             SHWTR   = SHF
-          ELSEWHERE
-             SHWTR   = MAPL_UNDEF
-          ENDWHERE
-    endif
-
 ! Update WATER surface temperature and moisture
 !----------------------------------------
 
@@ -2844,6 +2829,21 @@ contains
     if( trim(AOIL_COMP_SWITCH) == "ON") then
       HH(:,N) = HH(:,N) + DT*(FRESHATM + FRESH)
       HH(:,N) = max( min(HH(:,N), (MaxWaterDepth*water_RHO('fresh_water'))), (MinWaterDepth*water_RHO('fresh_water')))
+    endif
+
+    if(associated(HLATWTR)) then
+          WHERE( FRWATER>0.0 )
+             HLATWTR = LHF
+          ELSEWHERE
+             HLATWTR = MAPL_UNDEF
+          ENDWHERE
+    endif
+    if(associated(  SHWTR)) then
+          WHERE( FRWATER>0.0 )
+             SHWTR   = SHF
+          ELSEWHERE
+             SHWTR   = MAPL_UNDEF
+          ENDWHERE
     endif
 
     if(associated(EVAPOUT)) EVAPOUT = EVP    *FR(:,N)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2801,27 +2801,6 @@ contains
       HH(:,N) = max( min(HH(:,N), (MaxWaterDepth*water_RHO('fresh_water'))), (MinWaterDepth*water_RHO('fresh_water')))
     endif
 
-    if(associated(HLATWTR)) then
-          WHERE( FRWATER>0.0 )
-             HLATWTR = LHF
-          ELSEWHERE
-             HLATWTR = MAPL_UNDEF
-          ENDWHERE
-    endif
-    if(associated(  SHWTR)) then
-          WHERE( FRWATER>0.0 )
-             SHWTR   = SHF
-          ELSEWHERE
-             SHWTR   = MAPL_UNDEF
-          ENDWHERE
-    endif
-
-    if(associated(EVAPOUT)) EVAPOUT = EVP    *FR(:,N)
-    if(associated(SHOUT  )) SHOUT   = SHF    *FR(:,N)
-    if(associated(HLATN  )) HLATN   = LHF    *FR(:,N)
-    if(associated(DELTS  )) DELTS   = DTS*CFT*FR(:,N)
-    if(associated(DELQS  )) DELQS   = DQS*CFQ*FR(:,N)
-
 !   Copy back to internal variables
 !   -----------------------------------------
     TW = TS(:,WATER) + TWMTS
@@ -2850,6 +2829,30 @@ contains
                      fr_ice_thresh)
       deallocate(tmp2)
 
+! Copies for export
+!------------------
+
+    if(associated(HLATWTR)) then
+          WHERE( FRWATER>0.0 )
+             HLATWTR = LHF
+          ELSEWHERE
+             HLATWTR = MAPL_UNDEF
+          ENDWHERE
+    endif
+    if(associated(  SHWTR)) then
+          WHERE( FRWATER>0.0 )
+             SHWTR   = SHF
+          ELSEWHERE
+             SHWTR   = MAPL_UNDEF
+          ENDWHERE
+    endif
+
+    if(associated(EVAPOUT)) EVAPOUT = EVP    *FR(:,N)
+    if(associated(SHOUT  )) SHOUT   = SHF    *FR(:,N)
+    if(associated(HLATN  )) HLATN   = LHF    *FR(:,N)
+    if(associated(DELTS  )) DELTS   = DTS*CFT*FR(:,N)
+    if(associated(DELQS  )) DELQS   = DQS*CFQ*FR(:,N)
+
     if(associated(SWcool)) SWcool = SWCOOL_
     if(associated(SWWARM)) SWWARM = SWWARM_
     if(associated(Qcool )) Qcool  = QCOOL_
@@ -2872,9 +2875,6 @@ contains
 
     if(associated(TAUXW)) TAUXW = TXW
     if(associated(TAUYW)) TAUYW = TYW
-
-! Copies for export
-!------------------
 
     if(associated(SNOWOCN)) SNOWOCN = SNO*FR(:,WATER)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2602,6 +2602,8 @@ contains
 !   Hence reverting to option (ii). The final option (iii) has not been tested, just proposed for the sake of completeness.
 !   In any case, probably, (iii) will also degrade forecast skill, just as (i) did, because (what SA thinks) -1.7C, set for water temperature is TOO COLD!
 !   Unless we understand and model all the processes, we may have to just let diurnal variability (cool-skin+diurnal warming) pick up the tab!
+!
+!   In Marginal Ice Zone, threshold on fraction: if no LANL CICE, SST IS ALLOWED TO VARY WITHIN ICE EXTENT.
 !   
 !   ** Revisit when coupled to ocean+sea-ice ** July, 2019.
 !   --------------------------------------------------------------------------------------------------------
@@ -2852,12 +2854,6 @@ contains
 
     SWN = (1.-ALBVRO)*VSUVR + (1.-ALBVFO)*VSUVF + &
           (1.-ALBNRO)*DRNIR + (1.-ALBNFO)*DFNIR
-
-!   Marginal Ice Zone- threshold on fraction: if no LANL CICE, SST IS ALLOWED TO VARY WITHIN ICE EXTENT.
-!   -------------------------------------------------------------------------------------------------
-    ! Following default for coupled (with cice) needs to be revisited 
-    call MAPL_GetResource ( MAPL, fr_ice_thresh, Label="THRESHOLD_ICE_FR_SST:" , DEFAULT=0.0,    RC=STATUS)
-    VERIFY_(STATUS)
 
 !   Cool-skin and diurnal warm layer. It changes TS, TWMTS, TW if DO_SKIN_LAYER = 1
 !   --------------------------------------------------------------------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -838,26 +838,6 @@ module GEOS_OpenwaterGridCompMod
                                                RC=STATUS  ) 
      VERIFY_(STATUS)
 
-     if( trim(AOIL_COMP_SWITCH) == "OFF") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-        call MAPL_AddExportSpec(GC,                    &
-             LONG_NAME          = 'saturation_specific_humidity_using_geos_formula',&
-             UNITS              = 'kg kg-1'                   ,&
-             SHORT_NAME         = 'QSAT1'                     ,&
-             DIMS               = MAPL_DimsTileOnly           ,&
-             VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
-        VERIFY_(STATUS)
- 
-        call MAPL_AddExportSpec(GC,                    &
-             LONG_NAME          = 'saturation_specific_humidity_using_bulk_formula',&
-             UNITS              = 'kg kg-1'                   ,&
-             SHORT_NAME         = 'QSAT2'                     ,&
-             DIMS               = MAPL_DimsTileOnly           ,&
-             VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
-        VERIFY_(STATUS)
-     endif
-
      ! Atmosphere-ocean fluxes
      call MAPL_AddExportSpec(GC,                     &
         LONG_NAME          = 'atmosphere_ocean_sensible_heat_flux' ,&
@@ -1575,8 +1555,6 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
    real, pointer, dimension(:  )  :: MOV50M => null()
    real, pointer, dimension(:  )  :: GST    => null()
    real, pointer, dimension(:  )  :: VNT    => null()
-   real, pointer, dimension(:  )  :: QSAT1  => null()
-   real, pointer, dimension(:  )  :: QSAT2  => null()
 
 ! pointers to internal
 
@@ -1864,14 +1842,6 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
    call MAPL_GetPointer(EXPORT,VNT   , 'VENT'    ,    RC=STATUS)
    VERIFY_(STATUS)
 
-   if( trim(AOIL_COMP_SWITCH) == "OFF") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-     call MAPL_GetPointer(EXPORT,QSAT1 , 'QSAT1'   ,    RC=STATUS)
-     VERIFY_(STATUS)
-
-     call MAPL_GetPointer(EXPORT,QSAT2 , 'QSAT2'   ,    RC=STATUS)
-     VERIFY_(STATUS)
-   endif
-
    NT = size(TA)
    if(NT == 0) then
       call MAPL_TimerOff(MAPL,"RUN1" )
@@ -1989,18 +1959,7 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
        TS(:,WATER) = TF
    endwhere
 
-   if( trim(AOIL_COMP_SWITCH) == "ON") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-     TW = TS(:,WATER)
-   endif
-
-   if( trim(AOIL_COMP_SWITCH) == "OFF") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-
-     call MAPL_GetResource ( MAPL, QSAT_SCL, Label="QSAT_SALTWATER_SCALING:" , DEFAULT=1.0, RC=STATUS)
-     VERIFY_(STATUS)
-     QS(:,WATER) = QSAT_SCL*GEOS_QSAT(TS(:,WATER), PS, RAMP=2.0, PASCALS=.TRUE.) 
-
-     if(associated(QSAT1)) QSAT1 = QS(:,WATER)
-   endif
+   TW = TS(:,WATER)
 
 !  Clear the output tile accumulators
 !------------------------------------
@@ -2063,10 +2022,7 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
          ZQ = Z0(:,N)
          RE = 0.
          UUU = UU
-
-         if( trim(AOIL_COMP_SWITCH) == "ON") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-           UCN = 0.
-         endif
+         UCN = 0.
 
          !  Aggregate to tiles for MO only diagnostics
          !--------------------------------------------
@@ -2081,9 +2037,6 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
          if(associated(MOU2M ))MOU2M  = U2M (:)*FR(:,N)
          if(associated(MOV2M ))MOV2M  = V2M (:)*FR(:,N)
 
-         if( trim(AOIL_COMP_SWITCH) == "OFF") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-           if(associated(QSAT2)) QSAT2 = 1.0/RHO*0.98*640380.0*exp(-5107.4/TS(:,WATER))
-         endif
    endif sfc_layer
 
       !  Aggregate to tiles

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2756,7 +2756,7 @@ contains
       call SKIN_SST (DO_SKIN_LAYER, DO_DATASEA, NT,CM(:,WATER),UUA,VVA,UW,VW,HW,SWN_surf,LHF,SHF,LWDNSRF,     &
                      ALW,BLW,PEN, PEN_OCEAN, STOKES_SPEED,DT,MUSKIN,TS_FOUNDi,DWARM_,TBAR_,TXW,TYW,USTARW_,   &
                      DCOOL_,TDROP_,SWCOOL_,QCOOL_,BCOOL_,LCOOL_,TDEL_,SWWARM_,QWARM_,ZETA_W_,                 &
-                     PHIW_,LANGM_,TAUTW_,uStokes_,TS(:,WATER),TWMTS,TW,FRWATER,n_iter_cool,                   &
+                     PHIW_,LANGM_,TAUTW_,uStokes_,TS(:,WATER),TWMTS,TWMTF,DELTC,TW,FRWATER,n_iter_cool,       &
                      fr_ice_thresh, epsilon_d, trim(DO_GRAD_DECAY_warmLayer))
 
 ! Copies for export

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2769,7 +2769,6 @@ contains
 
 ! Update WATER surface temperature and moisture
 !----------------------------------------
-
     TS(:,N) = TS(:,N) + DTS
     DQS     = GEOS_QSAT(TS(:,N), PS, RAMP=0.0, PASCALS=.TRUE.) - QS(:,N)
     QS(:,N) = QS(:,N) + DQS
@@ -2811,9 +2810,8 @@ contains
        SW = max(min(SW,MAXSALINITY),MINSALINITY)
     endwhere
 
-! Net Solar insolation (including UV & IR, direct & diffuse) in interface layer 
-!------------------------------------------------------------------------------
-
+! Net Solar insolation (including UV & IR, direct & diffuse) in interface layer  (Recomputed)
+!--------------------------------------------------------------------------------------------
     SWN = (1.-ALBVRO)*VSUVR + (1.-ALBVFO)*VSUVF + &
           (1.-ALBNRO)*DRNIR + (1.-ALBNFO)*DFNIR
 
@@ -2831,7 +2829,6 @@ contains
 
 ! Copies for export
 !------------------
-
     if(associated(HLATWTR)) then
           WHERE( FRWATER>0.0 )
              HLATWTR = LHF
@@ -2876,8 +2873,6 @@ contains
     if(associated(TAUXW)) TAUXW = TXW
     if(associated(TAUYW)) TAUYW = TYW
 
-    if(associated(SNOWOCN)) SNOWOCN = SNO*FR(:,WATER)
-
     if(associated(AOSHFLX)) AOSHFLX = SHF    *FRWATER
     if(associated(AOQFLUX)) AOQFLUX = EVP    *FRWATER
     if(associated(AOLWFLX)) AOLWFLX = (LWDNSRF-ALW-BLW*TS(:,WATER))*FRWATER
@@ -2888,6 +2883,7 @@ contains
     if(associated(FSURF  )) FSURF   = SWN+LWDNSRF-(ALW+BLW*TS(:,WATER))-SHF-LHF
     if(associated(PENOCNe)) PENOCNe = PEN_ocean * FRWATER
 
+    if(associated(SNOWOCN)) SNOWOCN = SNO*FR(:,WATER)
     if(associated(RAINOCN)) RAINOCN = PCU + PLS
     if(associated(HLWUP  )) HLWUP   = ALW*FR(:,WATER) 
     if(associated(LWNDSRF)) LWNDSRF = (LWDNSRF - ALW)*FR(:,WATER)
@@ -2932,6 +2928,7 @@ contains
     endif
 
     call MAPL_TimerOff(MAPL,   "-OpenWater")
+!------------------------------------------------------
 
     call MAPL_TimerOn(MAPL,    "-Albedo")
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2809,11 +2809,11 @@ contains
       allocate(tmp2(NT, NUM_SUBTILES), STAT=STATUS); VERIFY_(STATUS)
       tmp2(:,WATER) = FRWATER
 
-      call SKIN_SST (DO_SKIN_LAYER,NT,CM,UUA,VVA,UW,VW,HW,SWN,LHF,SHF,LWDNSRF,                   &
-                     ALW,BLW,PEN,STOKES_SPEED,DT,MUSKIN,TS_FOUNDi,DWARM_,TBAR_,TXW,TYW,USTARW_,  &
-                     DCOOL_,TDROP_,SWCOOL_,QCOOL_,BCOOL_,LCOOL_,TDEL_,SWWARM_,QWARM_,ZETA_W_,    &
-                     PHIW_,LANGM_,TAUTW_,uStokes_,TS,TWMTS,TW,WATER,tmp2,n_iter_cool,&
-                     fr_ice_thresh)
+      call SKIN_SST (DO_SKIN_LAYER, DO_DATASEA, NT,CM,UUA,VVA,UW,VW,HW,SWN,LHF,SHF,LWDNSRF,                   &
+                     ALW,BLW,PEN, PEN_OCEAN, STOKES_SPEED,DT,MUSKIN,TS_FOUNDi,DWARM_,TBAR_,TXW,TYW,USTARW_,   &
+                     DCOOL_,TDROP_,SWCOOL_,QCOOL_,BCOOL_,LCOOL_,TDEL_,SWWARM_,QWARM_,ZETA_W_,                 &
+                     PHIW_,LANGM_,TAUTW_,uStokes_,TS,TWMTS,TW,WATER,tmp2,n_iter_cool,                         &
+                     fr_ice_thresh, epsilon_d)
       deallocate(tmp2)
 
 ! Copies for export

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2767,8 +2767,8 @@ contains
     SHF = SHF + SHD * DTS
     LHF = EVP * MAPL_ALHL
 
-! Update WATER surface temperature and moisture
-!----------------------------------------
+! Update WATER surface temperature, moisture and mass
+!----------------------------------------------------
     TS(:,N) = TS(:,N) + DTS
     DQS     = GEOS_QSAT(TS(:,N), PS, RAMP=0.0, PASCALS=.TRUE.) - QS(:,N)
     QS(:,N) = QS(:,N) + DQS

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2635,41 +2635,21 @@ contains
     call MAPL_GetResource ( MAPL, MINSALINITY,   Label="MIN_SALINITY:" ,    DEFAULT=5.0  ,   RC=STATUS)
     VERIFY_(STATUS)
 
+!   Copy internals into local variables
+!   ------------------------------------
     if(DO_SKIN_LAYER==0) then                ! inactive AOIL (OFF)
       HH(:,WATER) = AOIL_depth * water_RHO('salt_water')
-      SS(:,WATER) = SS_FOUNDi*HW
-      TS(:,WATER) = TS_FOUNDi
+      SS(:,WATER) = SW*HW
+      TS(:,WATER) = TW
 
       TWMTS = 0.
       TWMTF = 0.
       DELTC = 0.
-    endif
-
-    if( trim(AOIL_COMP_SWITCH) == "ON") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-
-!     Copy internals into local variables
-!     ------------------------------------
+    else
       HH(:,WATER) = HW
       SS(:,WATER) = SW*HW
       TS(:,WATER) = TW - TWMTS
-
-    else
-
-!   Get TS from internal state exactly as in Run1
-!   ---------------------------------------------
-       if (DO_SKIN_LAYER/=0) then 
-         HH(:,WATER) = AOIL_depth * water_RHO('salt_water')
-         SS(:,WATER) = SS_FOUNDi*HH(:,WATER)
-
-
-         if (DO_DATASEA == 1) then                                          ! Ocean is from "data"
-           TS(:,WATER)= TS_FOUNDi + ((1.+MUSKIN)/MUSKIN) * TWMTF            ! Eqn.(14) of AS2018
-         else                                                               ! Ocean is from a model
-           TS(:,WATER)= TS_FOUNDi + (1./MUSKIN + (1.-epsilon_d)) * TWMTF    ! RHS is from Eqn.(15) of AS2018; (here) abuse of notation: T_o is from OGCM.
-         endif
-         TS(:,WATER) = TS(:,WATER) - DELTC                                  ! Eqn.(16) of AS2018
-       endif
-    endif ! if( trim(AOIL_COMP_SWITCH) == "ON")
+    endif
 
     FR(:,WATER) = 1.0
     FRWATER     = max(1.0 - FI, 0.0)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -1619,6 +1619,7 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
    character(len=ESMF_MAXSTR)     :: SURFRC
    type(ESMF_Config)              :: SCF 
    character(len=100)             :: WHICH_T_TO_SFCLAYER    ! what temperature does the sfclayer get from AOIL?
+   real                           :: DEPTH_T_TO_SFCLAYER    ! temperature (at what depth) does the sfclayer get from AOIL?
 
 !=============================================================================
 
@@ -1904,8 +1905,16 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
    call MAPL_GetResource( MAPL, WHICH_T_TO_SFCLAYER, Label="T_from_AOIL_to_SFCLAYER:", DEFAULT="TW_from_internal", RC=STATUS)
    VERIFY_(STATUS)
 
-   call AOIL_sfcLayer_T( WHICH_T_TO_SFCLAYER, DO_DATASEA, MUSKIN, epsilon_d, &
-                          TW, TS_FOUNDi, TWMTF, DELTC, TS(:,WATER))
+   call MAPL_GetResource( MAPL, DEPTH_T_TO_SFCLAYER, Label="DEPTH_T_AOIL_to_SFCLAYER:", DEFAULT=0.,                RC=STATUS)
+   VERIFY_(STATUS)
+
+   if ( DEPTH_T_TO_SFCLAYER > AOIL_depth) then
+     print *, " DEPTH_T_AOIL_to_SFCLAYER must not be greater than the depth of the AOIL, which is currently set =", AOIL_depth, "Exiting!"
+     ASSERT_(.false.)
+   endif
+
+   call AOIL_sfcLayer_T( WHICH_T_TO_SFCLAYER, DEPTH_T_TO_SFCLAYER, DO_DATASEA, MUSKIN, epsilon_d, &
+                          AOIL_depth, TW, TS_FOUNDi, TWMTF, DELTC, TS(:,WATER))
 
    FR(:,WATER) = 1.0 ! parent(saltwater) will aggregate based on water/ice fraction 
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -932,7 +932,7 @@ module GEOS_OpenwaterGridCompMod
         UNITS              = 'kg m-2',                            &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
-        FRIENDLYTO         = 'OCEAN:SEAICE',                      & ! must go away. Connectivity needs fixing.
+        FRIENDLYTO         = trim(COMP_NAME),                     & ! friendly are a pain to get rid of!
         DEFAULT            = 5.0*MAPL_RHO_SEAWATER,               &
                                                        RC=STATUS  )
     VERIFY_(STATUS)
@@ -943,7 +943,7 @@ module GEOS_OpenwaterGridCompMod
         UNITS              = 'K',                                 &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
-        FRIENDLYTO         = 'OCEAN:SEAICE',                      & ! must go away. Connectivity needs fixing.
+        FRIENDLYTO         = trim(COMP_NAME),                     & ! friendly are a pain to get rid of!
         DEFAULT            = 280.0,                               &
                                                        RC=STATUS  )
     VERIFY_(STATUS)
@@ -954,7 +954,7 @@ module GEOS_OpenwaterGridCompMod
         UNITS              = 'psu',                               &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
-        FRIENDLYTO         = 'OCEAN:SEAICE',                      & ! must go away. Connectivity needs fixing.
+        FRIENDLYTO         = trim(COMP_NAME),                     & ! friendly are a pain to get rid of!
         DEFAULT            = 30.0,                                &
                                                        RC=STATUS  )
     VERIFY_(STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2757,7 +2757,7 @@ contains
       call SKIN_SST (DO_SKIN_LAYER, DO_DATASEA, NT,CM,UUA,VVA,UW,VW,HW,SWN,LHF,SHF,LWDNSRF,                   &
                      ALW,BLW,PEN, PEN_OCEAN, STOKES_SPEED,DT,MUSKIN,TS_FOUNDi,DWARM_,TBAR_,TXW,TYW,USTARW_,   &
                      DCOOL_,TDROP_,SWCOOL_,QCOOL_,BCOOL_,LCOOL_,TDEL_,SWWARM_,QWARM_,ZETA_W_,                 &
-                     PHIW_,LANGM_,TAUTW_,uStokes_,TS,TWMTS,TW,WATER,FRWATER,n_iter_cool,                         &
+                     PHIW_,LANGM_,TAUTW_,uStokes_,TS(:,WATER),TWMTS,TW,WATER,FRWATER,n_iter_cool,                         &
                      fr_ice_thresh, epsilon_d, trim(DO_GRAD_DECAY_warmLayer))
 
 ! Copies for export

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -79,7 +79,8 @@ module GEOS_OpenwaterGridCompMod
                                 AOIL_sfcLayer_T,   &
                                 water_RHO,         &
                                 AOIL_Shortwave_abs,&
-                                AOIL_v0_S
+                                AOIL_v0_S,         &
+                                AOIL_v0_HW
 
   implicit none
   private
@@ -2785,19 +2786,8 @@ contains
       end if
     end if
 
-! Layer thickness; liquid precip goes right thru ice.
-! FRESHATM is useful for mass flux balance.
-! freshwater flux from atmosphere needs to be added to HW here since it carries zero enthalpy 
-!---------------------------------------------------------------------------------------------
-    FRESHATM    = FRWATER*(SNO - EVP) + PCU + PLS
-    FRESH       = 0.
-    HH(:,N) = HH(:,N) + DT*(FRESHATM + FRESH)
-
-    if (DO_DATASEA == 0) then               ! coupled   mode
-      HH(:,N) = max( min(HH(:,N), (MaxWaterDepth*water_RHO('salt_water'))),  (MinWaterDepth*water_RHO('salt_water')))
-    else                                    ! uncoupled mode
-      HH(:,N) = max( min(HH(:,N), (MaxWaterDepth*water_RHO('fresh_water'))), (MinWaterDepth*water_RHO('fresh_water')))
-    endif
+    call AOIL_v0_HW ( NT, DT, DO_DATASEA, MaxWaterDepth, MinWaterDepth, &
+                      FRWATER, SNO, EVP, PCU+PLS, HH(:,WATER))
 
 !   Copy back to internal variables
 !   -----------------------------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -1615,7 +1615,6 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
    real            :: MaxWaterDepth
    real            :: MinWaterDepth
    real            :: OGCM_top_thickness        ! thickness of OGCM top layer (D) in AS2018
-   real            :: QSAT_SCL
 
    character(len=ESMF_MAXSTR)     :: SURFRC
    type(ESMF_Config)              :: SCF 
@@ -2348,9 +2347,6 @@ contains
    real,    dimension(NT)              :: TAUTW_
    real,    dimension(NT)              :: ZETA_W_
    real,    dimension(NT)              :: uStokes_                  ! Stokes velocity should be an import from Wave Watch
-   real,    dimension(NT)              :: FRESHATM                  ! fresh water flux from atmosphere
-
-   real,    dimension(NT)              :: ALPH
 
    integer                             :: N
    real                                :: DT
@@ -2366,15 +2362,11 @@ contains
    real                                :: AOIL_depth                ! thickness of atmosphere-ocean interface layer (AOIL) denoted by d in Akella & Suarez, 2018
    real                                :: OGCM_top_thickness        ! thickness of OGCM top layer (D) in AS2018
    real                                :: epsilon_d                 ! ratio: (thickness of AOIL)/(thickness of OGCM top level) = epsilon_d in AS2018
-   real                                :: F_PHI                     ! tunable parameter, used to calculate stability function in AS2018
-   real                                :: QSAT_SCL 
-   real                                :: fLA
-   character(len=10)                   :: diurnal_warming_scheme    ! which formulation of diurnal warming model? AS2018 or AT2017 (DOI:10.1002/qj.2988)
+   character(len=3)                    :: DO_GRAD_DECAY_warmLayer   ! simulate gradual decay of warm layer: yes or no. Follows Zeng and Beljaars, 2005.
 
 ! following are related  to CICE
 
    integer                             :: NSUB, I, K, L
-   real                                :: FRESH
 !  -------------------------------------------------------------------
 
    type (ESMF_TimeInterval)            :: DELT
@@ -2602,6 +2594,9 @@ contains
     call MAPL_GetResource ( MAPL, MINSALINITY,   Label="MIN_SALINITY:" ,    DEFAULT=5.0  ,   RC=STATUS)
     VERIFY_(STATUS)
 
+    call MAPL_GetResource ( MAPL, DO_GRAD_DECAY_warmLayer,   Label="WARM_LAYER_GRAD_DECAY:" ,  DEFAULT="no"  ,   RC=STATUS)
+    VERIFY_(STATUS)
+
 !   Copy internals into local variables
 !   ------------------------------------
     if(DO_SKIN_LAYER==0) then                ! inactive AOIL (OFF)
@@ -2813,7 +2808,7 @@ contains
                      ALW,BLW,PEN, PEN_OCEAN, STOKES_SPEED,DT,MUSKIN,TS_FOUNDi,DWARM_,TBAR_,TXW,TYW,USTARW_,   &
                      DCOOL_,TDROP_,SWCOOL_,QCOOL_,BCOOL_,LCOOL_,TDEL_,SWWARM_,QWARM_,ZETA_W_,                 &
                      PHIW_,LANGM_,TAUTW_,uStokes_,TS,TWMTS,TW,WATER,tmp2,n_iter_cool,                         &
-                     fr_ice_thresh, epsilon_d)
+                     fr_ice_thresh, epsilon_d, trim(DO_GRAD_DECAY_warmLayer))
       deallocate(tmp2)
 
 ! Copies for export

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2303,7 +2303,6 @@ contains
    real, allocatable                   :: HH (:,:)                  ! allocatable because NUM_SUBTILES is NOT a parameter
    real, allocatable                   :: SS (:,:)
    real, allocatable                   :: FR (:,:)
-   real, allocatable                   :: tmp2 (:,:)
    real,    dimension(NT)              :: FRWATER
    real,    dimension(NT)              :: SHF
    real,    dimension(NT)              :: EVP
@@ -2755,15 +2754,11 @@ contains
 
 !   Cool-skin and diurnal warm layer. It changes TS, TWMTS, TW if DO_SKIN_LAYER = 1
 !   --------------------------------------------------------------------------------
-      allocate(tmp2(NT, NUM_SUBTILES), STAT=STATUS); VERIFY_(STATUS)
-      tmp2(:,WATER) = FRWATER
-
       call SKIN_SST (DO_SKIN_LAYER, DO_DATASEA, NT,CM,UUA,VVA,UW,VW,HW,SWN,LHF,SHF,LWDNSRF,                   &
                      ALW,BLW,PEN, PEN_OCEAN, STOKES_SPEED,DT,MUSKIN,TS_FOUNDi,DWARM_,TBAR_,TXW,TYW,USTARW_,   &
                      DCOOL_,TDROP_,SWCOOL_,QCOOL_,BCOOL_,LCOOL_,TDEL_,SWWARM_,QWARM_,ZETA_W_,                 &
-                     PHIW_,LANGM_,TAUTW_,uStokes_,TS,TWMTS,TW,WATER,tmp2,n_iter_cool,                         &
+                     PHIW_,LANGM_,TAUTW_,uStokes_,TS,TWMTS,TW,WATER,FRWATER,n_iter_cool,                         &
                      fr_ice_thresh, epsilon_d, trim(DO_GRAD_DECAY_warmLayer))
-      deallocate(tmp2)
 
 ! Copies for export
 !------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2754,10 +2754,10 @@ contains
 
 !   Cool-skin and diurnal warm layer. It changes TS, TWMTS, TW if DO_SKIN_LAYER = 1
 !   --------------------------------------------------------------------------------
-      call SKIN_SST (DO_SKIN_LAYER, DO_DATASEA, NT,CM,UUA,VVA,UW,VW,HW,SWN,LHF,SHF,LWDNSRF,                   &
+      call SKIN_SST (DO_SKIN_LAYER, DO_DATASEA, NT,CM(:,WATER),UUA,VVA,UW,VW,HW,SWN,LHF,SHF,LWDNSRF,          &
                      ALW,BLW,PEN, PEN_OCEAN, STOKES_SPEED,DT,MUSKIN,TS_FOUNDi,DWARM_,TBAR_,TXW,TYW,USTARW_,   &
                      DCOOL_,TDROP_,SWCOOL_,QCOOL_,BCOOL_,LCOOL_,TDEL_,SWWARM_,QWARM_,ZETA_W_,                 &
-                     PHIW_,LANGM_,TAUTW_,uStokes_,TS(:,WATER),TWMTS,TW,WATER,FRWATER,n_iter_cool,                         &
+                     PHIW_,LANGM_,TAUTW_,uStokes_,TS(:,WATER),TWMTS,TW,FRWATER,n_iter_cool,                   &
                      fr_ice_thresh, epsilon_d, trim(DO_GRAD_DECAY_warmLayer))
 
 ! Copies for export

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -80,7 +80,8 @@ module GEOS_OpenwaterGridCompMod
                                 water_RHO,         &
                                 AOIL_Shortwave_abs,&
                                 AOIL_v0_S,         &
-                                AOIL_v0_HW
+                                AOIL_v0_HW,        &
+                                surf_hflux_update
 
   implicit none
   private
@@ -2735,51 +2736,56 @@ contains
     N   = WATER
     CFT = (CH(:,N)/CTATM)
     CFQ = (CQ(:,N)/CQATM)
-    EVP = CFQ*(EVAP + DEV*(QS(:,N)-QHATM))
-    SHF = CFT*(SH   + DSH*(TS(:,N)-THATM))
-    SHD = CFT*DSH
-    EVD = CFQ*DEV*GEOS_DQSAT(TS(:,N), PS, RAMP=0.0, PASCALS=.TRUE.)
-    DTS = LWDNSRF - (ALW + BLW*TS(:,N)) - SHF
 
-    ! FR accounts for skin under ice
-    DTX = DT*FRWATER / (SALTWATERCAP*HH(:,N))
+    call surf_hflux_update (NT,DO_SKIN_LAYER,DO_DATASEA,MUSKIN,DT,epsilon_d,  &
+             CFT,CFQ,SH,EVAP,DSH,DEV,THATM,QHATM,PS,FRWATER,HH(:,N),SNO,      &
+             LWDNSRF,SWN,ALW,BLW,SHF,LHF,EVP,DTS,DQS,TS(:,N),QS(:,N),TWMTS,TWMTF)
 
-    if (DO_SKIN_LAYER == 0) then
-      DTX = 0.
-    else
-      DTX = DTX*((MUSKIN+1.-MUSKIN*epsilon_d)/MUSKIN) ! note: epsilon_d is = 0. in uncoupled mode (DO_DATASEA == 1)
-    endif
+!   EVP = CFQ*(EVAP + DEV*(QS(:,N)-QHATM))
+!   SHF = CFT*(SH   + DSH*(TS(:,N)-THATM))
+!   SHD = CFT*DSH
+!   EVD = CFQ*DEV*GEOS_DQSAT(TS(:,N), PS, RAMP=0.0, PASCALS=.TRUE.)
+!   DTS = LWDNSRF - (ALW + BLW*TS(:,N)) - SHF
 
-    ! DTY accounts for ice on top of water. Part of Shortwave is absorbed by ice and rest goes to warm water.
-    ! Skin layer only absorbs the portion of SW radiation passing thru the bottom of ice MINUS
-    ! the portion passing thru the skin layer    
-    ! Penetrated shortwave from sea ice bottom + associated ocean/ice heat flux
-    DTY = 0. ! Revisit above with CICE6 [Nov, 2019] and compute DTY = DT / (SALTWATERCAP*HW) * (PENICE * FI + FHOCN)
+!   ! FR accounts for skin under ice
+!   DTX = DT*FRWATER / (SALTWATERCAP*HH(:,N))
 
-    DTS = DTX * ( DTS + SWN - EVP*MAPL_ALHL - MAPL_ALHF*SNO ) + DTY
-    DTS = DTS   / ( 1.0 + DTX*(BLW + SHD + EVD*MAPL_ALHL) )
-    EVP = EVP + EVD * DTS
-    SHF = SHF + SHD * DTS
-    LHF = EVP * MAPL_ALHL
+!   if (DO_SKIN_LAYER == 0) then
+!     DTX = 0.
+!   else
+!     DTX = DTX*((MUSKIN+1.-MUSKIN*epsilon_d)/MUSKIN) ! note: epsilon_d is = 0. in uncoupled mode (DO_DATASEA == 1)
+!   endif
+
+!   ! DTY accounts for ice on top of water. Part of Shortwave is absorbed by ice and rest goes to warm water.
+!   ! Skin layer only absorbs the portion of SW radiation passing thru the bottom of ice MINUS
+!   ! the portion passing thru the skin layer    
+!   ! Penetrated shortwave from sea ice bottom + associated ocean/ice heat flux
+!   DTY = 0. ! Revisit above with CICE6 [Nov, 2019] and compute DTY = DT / (SALTWATERCAP*HW) * (PENICE * FI + FHOCN)
+
+!   DTS = DTX * ( DTS + SWN - EVP*MAPL_ALHL - MAPL_ALHF*SNO ) + DTY
+!   DTS = DTS   / ( 1.0 + DTX*(BLW + SHD + EVD*MAPL_ALHL) )
+!   EVP = EVP + EVD * DTS
+!   SHF = SHF + SHD * DTS
+!   LHF = EVP * MAPL_ALHL
 
 ! Update WATER surface temperature, moisture and mass
 !----------------------------------------------------
-    TS(:,N) = TS(:,N) + DTS
-    DQS     = GEOS_QSAT(TS(:,N), PS, RAMP=0.0, PASCALS=.TRUE.) - QS(:,N)
-    QS(:,N) = QS(:,N) + DQS
+!   TS(:,N) = TS(:,N) + DTS
+!   DQS     = GEOS_QSAT(TS(:,N), PS, RAMP=0.0, PASCALS=.TRUE.) - QS(:,N)
+!   QS(:,N) = QS(:,N) + DQS
 
-    if(DO_SKIN_LAYER == 0) then
-      TWMTS = 0.
-      TWMTF = 0.
-    else
-      TWMTS = TWMTS - (1.0/(MUSKIN+1.0))*DTS
-      if (DO_DATASEA == 0) then            ! coupled   mode
-         TWMTF = TWMTF + (MUSKIN/(1.+MUSKIN-MUSKIN*epsilon_d))*DTS
-      else                                 ! uncoupled mode
-         TWMTF = 0.
-!        TWMTF = TWMTF + (MUSKIN/(1.+MUSKIN))*DTS ! This will cause non-zero diff in internal/checkpoint, but ZERO DIFF in OUTPUT.
-      end if
-    end if
+!   if(DO_SKIN_LAYER == 0) then
+!     TWMTS = 0.
+!     TWMTF = 0.
+!   else
+!     TWMTS = TWMTS - (1.0/(MUSKIN+1.0))*DTS
+!     if (DO_DATASEA == 0) then            ! coupled   mode
+!        TWMTF = TWMTF + (MUSKIN/(1.+MUSKIN-MUSKIN*epsilon_d))*DTS
+!     else                                 ! uncoupled mode
+!        TWMTF = 0.
+!!       TWMTF = TWMTF + (MUSKIN/(1.+MUSKIN))*DTS ! This will cause non-zero diff in internal/checkpoint, but ZERO DIFF in OUTPUT.
+!     end if
+!   end if
 
     call AOIL_v0_HW ( NT, DT, DO_DATASEA, MaxWaterDepth, MinWaterDepth, &
                       FRWATER, SNO, EVP, PCU+PLS, HH(:,WATER))

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -1646,6 +1646,7 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
    character(len=ESMF_MAXSTR)     :: SURFRC
    type(ESMF_Config)              :: SCF 
    character(len=100)             :: WHICH_T_TO_SFCLAYER    ! what temperature does the sfclayer get from AOIL?
+   real, parameter                :: puny = 1.e-11
 
 !=============================================================================
 
@@ -1729,7 +1730,7 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
        epsilon_d  = AOIL_depth/OGCM_top_thickness ! < 1. If that is NOT true, AOIL formulation would need revisit; see AS2018
     else
        OGCM_top_thickness = MAPL_UNDEF
-       epsilon_d          = MAPL_UNDEF
+       epsilon_d          = puny
     end if
 
 ! Pointers to inputs
@@ -2603,7 +2604,7 @@ contains
        epsilon_d  = AOIL_depth/OGCM_top_thickness ! < 1. If that is NOT true, AOIL formulation would need revisit; see AS2018
     else
        OGCM_top_thickness = MAPL_UNDEF
-       epsilon_d          = MAPL_UNDEF
+       epsilon_d          = puny
     end if
 
 !   --------------------------------------------------------------------------------------------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2818,7 +2818,6 @@ contains
 ! FRESHATM is useful for mass flux balance.
 ! freshwater flux from atmosphere needs to be added to HW here since it carries zero enthalpy 
 !---------------------------------------------------------------------------------------------
-
     FRESHATM    = FRWATER*(SNO - EVP) + PCU + PLS
     FRESH       = 0.
     HH(:,N) = HH(:,N) + DT*(FRESHATM + FRESH)
@@ -2850,19 +2849,15 @@ contains
     if(associated(DELTS  )) DELTS   = DTS*CFT*FR(:,N)
     if(associated(DELQS  )) DELQS   = DQS*CFQ*FR(:,N)
 
-    if( trim(AOIL_COMP_SWITCH) == "ON") then
-!    Copy back to internal variables
-!    -----------------------------------------
-
-     TW = TS(:,WATER) + TWMTS
-     HW = HH(:,WATER)               ! The same skin layer interaction as in GEOS CICE
-     ! multiply by 1000 to account for g->kg conversion
-     FSALT = 0.  ! for compatibility (when it is "ON")
-     SW = (SS(:,WATER)+DT*1.e3*FSALT)/HW
-     where (.not. (abs(UW) > 0.0 .or. abs(VW) > 0.0))
-        SW = max(min(SW,MAXSALINITY),MINSALINITY)
-     endwhere
-    endif
+!   Copy back to internal variables
+!   -----------------------------------------
+    TW = TS(:,WATER) + TWMTS
+    HW = HH(:,WATER)
+    FSALT = 0.
+    SW = (SS(:,WATER)+DT*1.e3*FSALT)/HW ! multiply by 1000 to account for g->kg conversion
+    where (.not. (abs(UW) > 0.0 .or. abs(VW) > 0.0))
+       SW = max(min(SW,MAXSALINITY),MINSALINITY)
+    endwhere
 
 ! Net Solar insolation (including UV & IR, direct & diffuse) in interface layer 
 !------------------------------------------------------------------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -2313,6 +2313,7 @@ contains
    real,    dimension(NT)              :: DQS
    real,    dimension(NT)              :: DTS
    real,    dimension(NT)              :: SWN
+   real,    dimension(NT)              :: SWN_surf
    real,    dimension(NT)              :: PEN
    real,    dimension(NT)              :: PEN_ocean
    real,    dimension(NT)              :: LHF
@@ -2714,15 +2715,18 @@ contains
     if(associated(DELTS  )) DELTS   = 0.0
     if(associated(DELQS  )) DELQS   = 0.0
 
-    SWN = (1.-ALBVRO)*VSUVR + (1.-ALBVFO)*VSUVF + &
-          (1.-ALBNRO)*DRNIR + (1.-ALBNFO)*DFNIR
-
     CFT = (CH(:,WATER)/CTATM)
     CFQ = (CQ(:,WATER)/CQATM)
 
+! Net Solar insolation (including UV & IR, direct & diffuse) in interface layer
+!------------------------------------------------------------------------------
+    SWN = (1.-ALBVRO)*VSUVR + (1.-ALBVFO)*VSUVF + &
+          (1.-ALBNRO)*DRNIR + (1.-ALBNFO)*DFNIR
+    SWN_surf = SWN
+
     call AOIL_Shortwave_abs (NT, DO_SKIN_LAYER, DO_DATASEA, &
                              AOIL_depth, OGCM_top_thickness, HW, KUVR, KPAR, &
-                             ALBVRO, ALBVFO, DRUVR, DFUVR, DRPAR, DFPAR, &
+                             ALBVRO, ALBVFO, DRUVR, DFUVR, DRPAR, DFPAR,     &
                              PEN, PEN_ocean)
 
     SWN   = SWN - PEN
@@ -2747,14 +2751,9 @@ contains
        SW = max(min(SW,MAXSALINITY),MINSALINITY)
     endwhere
 
-! Net Solar insolation (including UV & IR, direct & diffuse) in interface layer  (Recomputed)
-!--------------------------------------------------------------------------------------------
-    SWN = (1.-ALBVRO)*VSUVR + (1.-ALBVFO)*VSUVF + &
-          (1.-ALBNRO)*DRNIR + (1.-ALBNFO)*DFNIR
-
 !   Cool-skin and diurnal warm layer. It changes TS, TWMTS, TW if DO_SKIN_LAYER = 1
 !   --------------------------------------------------------------------------------
-      call SKIN_SST (DO_SKIN_LAYER, DO_DATASEA, NT,CM(:,WATER),UUA,VVA,UW,VW,HW,SWN,LHF,SHF,LWDNSRF,          &
+      call SKIN_SST (DO_SKIN_LAYER, DO_DATASEA, NT,CM(:,WATER),UUA,VVA,UW,VW,HW,SWN_surf,LHF,SHF,LWDNSRF,     &
                      ALW,BLW,PEN, PEN_OCEAN, STOKES_SPEED,DT,MUSKIN,TS_FOUNDi,DWARM_,TBAR_,TXW,TYW,USTARW_,   &
                      DCOOL_,TDROP_,SWCOOL_,QCOOL_,BCOOL_,LCOOL_,TDEL_,SWWARM_,QWARM_,ZETA_W_,                 &
                      PHIW_,LANGM_,TAUTW_,uStokes_,TS(:,WATER),TWMTS,TW,FRWATER,n_iter_cool,                   &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -78,7 +78,8 @@ module GEOS_OpenwaterGridCompMod
                                 SKIN_SST,          &
                                 AOIL_sfcLayer_T,   &
                                 water_RHO,         &
-                                AOIL_Shortwave_abs
+                                AOIL_Shortwave_abs,&
+                                AOIL_v0_S
 
   implicit none
   private
@@ -2372,9 +2373,7 @@ contains
 ! following are related  to CICE
 
    integer                             :: NSUB, I, K, L
-
-   real                                :: FSALT, FRESH
-
+   real                                :: FRESH
 !  -------------------------------------------------------------------
 
    type (ESMF_TimeInterval)            :: DELT
@@ -2752,7 +2751,7 @@ contains
     if (DO_SKIN_LAYER == 0) then
       DTX = 0.
     else
-      DTX = DTX*((MUSKIN+1.-MUSKIN*epsilon_d)/MUSKIN)
+      DTX = DTX*((MUSKIN+1.-MUSKIN*epsilon_d)/MUSKIN) ! note: epsilon_d is = 0. in uncoupled mode (DO_DATASEA == 1)
     endif
 
     ! DTY accounts for ice on top of water. Part of Shortwave is absorbed by ice and rest goes to warm water.
@@ -2804,8 +2803,8 @@ contains
 !   -----------------------------------------
     TW = TS(:,WATER) + TWMTS
     HW = HH(:,WATER)
-    FSALT = 0.
-    SW = (SS(:,WATER)+DT*1.e3*FSALT)/HW ! multiply by 1000 to account for g->kg conversion
+
+    call AOIL_v0_S (DT, HW, SS(:,WATER), SW)
     where (.not. (abs(UW) > 0.0 .or. abs(VW) > 0.0))
        SW = max(min(SW,MAXSALINITY),MINSALINITY)
     endwhere

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SaltWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SaltWaterGridComp.F90
@@ -64,9 +64,6 @@ module GEOS_SaltwaterGridCompMod
   integer, parameter :: NB_CHOU_NIR = 3                        ! number of near-IR bands
   integer, parameter :: NB_CHOU     = NB_CHOU_UV + NB_CHOU_NIR ! total number of bands
 
-  character(len=7)   :: AOIL_COMP_SWITCH                       ! Atmosphere-Ocean Interface Layer, compatibility: on/off
-                                                               ! defualt: OFF, so AOIL is incompatible with "old" interface
-
    contains
 
 !BOP
@@ -131,12 +128,6 @@ module GEOS_SaltwaterGridCompMod
 !-------------------------------------------------------
 
     call MAPL_GetResource ( MAPL, DO_CICE_THERMO,     Label="USE_CICE_Thermo:" ,    DEFAULT=0, RC=STATUS)
-    VERIFY_(STATUS)
-
-! Atmosphere-Ocean Interface Layer compatibility: on/off?
-!-------------------------------------------------------
-
-    call MAPL_GetResource( MAPL,  AOIL_COMP_SWITCH,   Label="AOIL_COMP_SWITCH:",     DEFAULT="ON", RC=STATUS)
     VERIFY_(STATUS)
 
 ! Ocean biology and chemistry: using OBIO or not?
@@ -942,20 +933,18 @@ module GEOS_SaltwaterGridCompMod
 
   endif !DO_OBIO
 
-  if( trim(AOIL_COMP_SWITCH) == "ON") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-    call MAPL_AddExportSpec(GC, SHORT_NAME = 'TSKINW'    , CHILD_ID = WATER, RC=STATUS)
-    VERIFY_(STATUS)
-    call MAPL_AddExportSpec(GC, SHORT_NAME = 'HSKINW'    , CHILD_ID = WATER, RC=STATUS)
-    VERIFY_(STATUS)
-    call MAPL_AddExportSpec(GC, SHORT_NAME = 'SSKINW'    , CHILD_ID = WATER, RC=STATUS)
-    VERIFY_(STATUS)  
-  end if
+  call MAPL_AddExportSpec(GC, SHORT_NAME = 'TSKINW'    , CHILD_ID = WATER, RC=STATUS)
+  VERIFY_(STATUS)
+  call MAPL_AddExportSpec(GC, SHORT_NAME = 'HSKINW'    , CHILD_ID = WATER, RC=STATUS)
+  VERIFY_(STATUS)
+  call MAPL_AddExportSpec(GC, SHORT_NAME = 'SSKINW'    , CHILD_ID = WATER, RC=STATUS)
+  VERIFY_(STATUS)  
 
-  call MAPL_AddExportSpec(GC, SHORT_NAME = 'TSKINI'    , CHILD_ID =   ICE, RC=STATUS)
+  call MAPL_AddExportSpec(GC, SHORT_NAME = 'TSKINI'    , CHILD_ID = ICE,   RC=STATUS)
   VERIFY_(STATUS)
-  call MAPL_AddExportSpec(GC, SHORT_NAME = 'HSKINI'    , CHILD_ID =   ICE, RC=STATUS)
+  call MAPL_AddExportSpec(GC, SHORT_NAME = 'HSKINI'    , CHILD_ID = ICE,   RC=STATUS)
   VERIFY_(STATUS)
-  call MAPL_AddExportSpec(GC, SHORT_NAME = 'SSKINI'    , CHILD_ID =   ICE, RC=STATUS)
+  call MAPL_AddExportSpec(GC, SHORT_NAME = 'SSKINI'    , CHILD_ID = ICE,   RC=STATUS)
   VERIFY_(STATUS)
      
   if(DO_CICE_THERMO /= 0) then ! additional exports from CICE4 sea ice thermodynamics
@@ -1069,14 +1058,12 @@ module GEOS_SaltwaterGridCompMod
 
 !EOS
 
-  if( trim(AOIL_COMP_SWITCH) == "ON") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-    call MAPL_AddConnectivity ( GC,   &
-         SHORT_NAME  = (/'TSKINW','SSKINW'/),  &
-         DST_ID = ICE,                &
-         SRC_ID = WATER,              &
-         RC=STATUS  )
-    VERIFY_(STATUS)
-  endif
+  call MAPL_AddConnectivity ( GC,   &
+       SHORT_NAME  = (/'TSKINW','SSKINW'/),  &
+       DST_ID = ICE,                &
+       SRC_ID = WATER,              &
+       RC=STATUS  )
+  VERIFY_(STATUS)
 
   call MAPL_AddConnectivity ( GC,   &
        SHORT_NAME  = [character(len=8) :: 'FRACI', 'FRACINEW','TFREEZE'],     & 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SaltWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SaltWaterGridComp.F90
@@ -32,6 +32,7 @@ module GEOS_SaltwaterGridCompMod
   use ESMF
   use MAPL
   use GEOS_UtilsMod
+  use atmOcnIntlayer,     only: water_RHO
 
   use GEOS_OpenwaterGridCompMod,            only : OpenWaterSetServices       => SetServices
   use GEOS_SimpleSeaiceGridCompMod,         only : SimpleSeaiceSetServices    => SetServices
@@ -2143,7 +2144,7 @@ contains
     if(associated(TAUYO)) TAUYO = TYO
 
     if(associated(PSEX )) PSEX  = PS 
-    if(associated(USTR3)) USTR3 = sqrt(sqrt(TXO*TXO+TYO*TYO)/MAPL_RHO_SEAWATER)**3
+    if(associated(USTR3)) USTR3 = sqrt(sqrt(TXO*TXO+TYO*TYO)/water_RHO('salt_water'))**3
     if(associated(UUEX))  UUEX  = UU
 
     if(DO_OBIO/=0) then

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
@@ -43,9 +43,6 @@ module GEOS_SimpleSeaiceGridCompMod
   integer, parameter    :: ICE = 1  
   integer, parameter    :: NUM_SUBTILES = 1       
 
-  character(len=7)   :: AOIL_COMP_SWITCH                       ! Atmosphere-Ocean Interface Layer, compatibility: on/off
-                                                               ! defualt: OFF, so AOIL is incompatible with "old" interface
-
   contains
 
 !BOP
@@ -101,13 +98,6 @@ module GEOS_SimpleSeaiceGridCompMod
 !--------------------------
 
     call MAPL_GetObjectFromGC ( GC, MAPL, RC=STATUS)
-    VERIFY_(STATUS)
-
-
-! Atmosphere-Ocean Interface Layer compatibility: on/off?
-!-------------------------------------------------------
-
-    call MAPL_GetResource( MAPL,  AOIL_COMP_SWITCH,        Label="AOIL_COMP_SWITCH:",     DEFAULT="ON", RC=STATUS)
     VERIFY_(STATUS)
 
 ! Sea-Ice Thermodynamics computation: using CICE or not?
@@ -1096,9 +1086,8 @@ module GEOS_SimpleSeaiceGridCompMod
                                                        RC=STATUS  )
    VERIFY_(STATUS)
 
-   if( trim(AOIL_COMP_SWITCH) == "ON") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-      call MAPL_AddImportSpec(GC,                                  &
-        SHORT_NAME         = 'SSKINW',                           &
+   call MAPL_AddImportSpec(GC,                                    &
+        SHORT_NAME         = 'SSKINW',                            &
         LONG_NAME          = 'water_skin_salinity',               &
         UNITS              = 'psu',                               &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -1106,10 +1095,10 @@ module GEOS_SimpleSeaiceGridCompMod
         DEFAULT            = 30.0,                                &
 
                                                        RC=STATUS  )
-      VERIFY_(STATUS)
+   VERIFY_(STATUS)
 
-      call MAPL_AddImportSpec(GC,                                  &
-        SHORT_NAME         = 'TSKINW',                           &
+   call MAPL_AddImportSpec(GC,                                    &
+        SHORT_NAME         = 'TSKINW',                            &
         LONG_NAME          = 'water_skin_temperature',            &
         UNITS              = 'K',                                 &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -1117,9 +1106,7 @@ module GEOS_SimpleSeaiceGridCompMod
         DEFAULT            = 280.0,                               &
 
                                                        RC=STATUS  )
-      VERIFY_(STATUS)
-
-   endif
+   VERIFY_(STATUS)
 
    call MAPL_AddImportSpec(GC,                                  &
         SHORT_NAME         = 'SS_FOUND',                          &
@@ -1606,11 +1593,6 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
 
    US(:,ICE  ) = UI
    VS(:,ICE  ) = VI
-
-!  SA -- reconcile old (x39) and new (x40)
-   if( trim(AOIL_COMP_SWITCH) == "OFF") then ! as close as possible to "x0039", while keeping everything as in "x0040"
-     QS(:,ICE  ) = GEOS_QSAT(TS(:,ICE), PS, RAMP=0.0, PASCALS=.TRUE.) 
-   endif
 
 !  Clear the output tile accumulators
 !------------------------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
@@ -30,6 +30,7 @@ module GEOS_SimpleSeaiceGridCompMod
   use MAPL
   use GEOS_UtilsMod
   use DragCoefficientsMod
+  use atmOcnIntlayer,     only: water_RHO
 
   implicit none
   private
@@ -2131,8 +2132,8 @@ contains
     call MAPL_GetResource ( MAPL, EMSICE,        Label="CICE_EMSICE:",      DEFAULT=0.99999, RC=STATUS)
     VERIFY_(STATUS)
 
-    MAXICEDEPTH     = MAXICEDEPTH  *MAPL_RHOWTR
-    MINICEDEPTH     = MINICEDEPTH  *MAPL_RHOWTR
+    MAXICEDEPTH     = MAXICEDEPTH  * water_RHO('fresh_water')
+    MINICEDEPTH     = MINICEDEPTH  * water_RHO('fresh_water')
 
 
 ! Copy friendly internals into tile-tile local variables


### PR DESCRIPTION
Resolves GEOS-ESM/GEOSgcm_GridComp#356

- It is `zero-diff` for `uncoupled model`.
- Since it is a bug fix for coupled model, it is `non-zero` diff for (both MOM5 and MOM6) `coupled models`. 


Few details beyond the issue (GEOS-ESM/GEOSgcm_GridComp#356):
- All the computations to update the state variables (TW, SW, HW and other internals) are now performed via a call to `AOIL_v0` which has an associated `PR`: https://github.com/GEOS-ESM/GMAO_Shared/pull/126 <-- **hence the contingency**
- Above mentioned `AOIL_v0` also provides following two options that are turned `OFF` by default:
  + provide a more gradual decay of diurnal warming as observed in nature: `WARM_LAYER_GRAD_DECAY`
  + update turbulent heat fluxes after the state variables have been updated: `UPDATE_FLUXES_AOIL_SECOND_STEP`

Future PRs will address the issue(s) of changing above resource file defaults from `OFF` to `ON`.

