### PR TITLE
Add Docker authentication for pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: gmao/ubuntu20-geos-env-mkl:6.0.16-openmpi_4.0.5-gcc_10.2.0
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_AUTH_TOKEN
     resource_class: xlarge
     working_directory: /root/project
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,7 +9,11 @@ jobs:
     name: Build GEOSgcm
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
-    container: gmao/ubuntu20-geos-env-mkl:6.0.16-openmpi_4.0.5-gcc_10.2.0
+    container: 
+      image: gmao/ubuntu20-geos-env-mkl:6.0.16-openmpi_4.0.5-gcc_10.2.0
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     env:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8


### PR DESCRIPTION
Per Docker, soon there will be [limits on unauthenticated pulls](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/). CircleCI recommends using contexts to authenticate. This PR adds the authentication