### PR TITLE
Fix for C99 compliance for raster/util.c

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/util.c
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/util.c
@@ -4,8 +4,11 @@
 #include "stdarg.h"
 #include "fcntl.h"
 #include "string.h"
+#include <unistd.h>
 
 int Open=0,Form=0,Close=0,Write=1,Read=0;
+
+void ZIPBUFF(char *fname, int *Buff, int *nbytes, int *form, int *Write);
 
 void WRITERST(int *rst, int *nx, int *ny, char *filename, int *zip)
 {


### PR DESCRIPTION
On macOS when Clang is used as the C compiler, it now expects string C99 compliance. As `util.c` is at present it is not:
```
[ 87%] Building C object src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/CMakeFiles/raster.dir/util.c.o
/Users/mathomp4/Models/GEOSgcm-Intel1913/GEOSgcm/src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/util.c:27:11: error:
      implicit declaration of function 'ZIPBUFF' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    (void)ZIPBUFF(filename,rst,&Open,&Form,&Write);
          ^
/Users/mathomp4/Models/GEOSgcm-Intel1913/GEOSgcm/src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/util.c:41:13: error:
      implicit declaration of function 'ZIPBUFF' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      (void)ZIPBUFF(filename,buf,&reclen,&Form,&Write);
            ^
```
So, this PR does two things:

1. Declares ZIPBUFF
2. Adds `unistd.h` for `read()` and `close()`

Note, though, that as I'm not running this code, I don't know if I broke anything. I might need @smahanam or @atrayano to test this.