### PR TITLE
Change Intel Debug flags for MOM6

### DIFF
--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
@@ -456,6 +456,14 @@ esma_add_library (${this}
 
 target_compile_definitions (${this} PRIVATE use_netCDF)
 
+# This 'resets' the Intel DEBUG flags for MOM6. The stock debug flags use
+# 'all,noarg_temp_created' which seem to be too aggressive for FMS/MOM6. This
+# moves them back to the 'bounds,uninit' GEOS used to build with.
+if (CMAKE_Fortran_COMPILER_ID MATCHES "Intel" AND CMAKE_BUILD_TYPE MATCHES Debug)
+   string(REPLACE "all,noarg_temp_created" "bounds,uninit" _tmp "${GEOS_Fortran_FLAGS_DEBUG}")
+   set (CMAKE_Fortran_FLAGS_DEBUG "${_tmp}")
+endif ()
+
 # Specs for r8 version
 string(REPLACE " " ";" tmp ${FREAL8})
 foreach (flag ${tmp})


### PR DESCRIPTION
This PR changes the Intel Debug flags for MOM6 (and FMS). The issue seems to be that `-check all,noarg_temp_created` is "too much" for MOM6 (and FMS). So, this change "degrades" the Intel flags to be `-check bounds,uninit` which matches the Intel Debug flags GEOS used to use before [ESMA_cmake v.3.14](https://github.com/GEOS-ESM/ESMA_cmake/tree/v3.1.4).

Note this has a companion PR in FMS as both need to degrade: https://github.com/GEOS-ESM/FMS/pull/16