### PR TITLE
bugfix for running Catchment-CN with constant CO2 (issue #403)

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOS_CatchCNGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOS_CatchCNGridComp.F90
@@ -5138,7 +5138,7 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
     logical, save :: first = .true.
     integer*8, save :: istep = 1 ! gkw: legacy variable from offline
 
-    real :: co2
+   ! real :: co2
     real, external :: getco2
 
     ! temporaries for call to SIBALB for each type


### PR DESCRIPTION
This PR addresses issue #403 discussing the overwriting of user-defined constant CO2. Bug fix implemented here removes the redundant declaration of variable 'co2' in GEOS_CatchCNGridComp.F90, which overwrites the user-defined CO2 value.

cc: @gmao-rreichle @biljanaorescanin @rdkoster 