### PR TITLE
Fixed a bug in rotation angle for surface ocean stress.

### DIFF
--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/MOM6_GEOSPlug.F90
@@ -1180,8 +1180,8 @@ contains
 !---------------------------------------------------------------------------------------------
     Boundary%U_flux = 0.0;  Boundary%V_flux = 0.0 ! Initialize stress
 
-    Boundary%U_flux  (isc:iec,jsc:jec)= real( (U*cos_rot + V*sin_rot), kind=KIND(Boundary%p))
-    Boundary%V_flux  (isc:iec,jsc:jec)= real((-U*sin_rot + V*cos_rot), kind=KIND(Boundary%p))
+    Boundary%U_flux  (isc:iec,jsc:jec)= real( (U*cos_rot - V*sin_rot), kind=KIND(Boundary%p))
+    Boundary%V_flux  (isc:iec,jsc:jec)= real( (U*sin_rot + V*cos_rot), kind=KIND(Boundary%p))
 
 ! Set the time for MOM
 !---------------------


### PR DESCRIPTION
Apparently, MOM6 uses a different definition of rotation angle on tripolar grid than CICE or MOM5 (clockwise positive vs counter clockwise positive). If sign is incorrect, this causes a buildup of sea ice along the tripolar zipper line. This PR fixes this issue. 

**This PR affects only the coupled model with MOM6.**