### PR TITLE
Remove unneeded gfortran ifdefs

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
@@ -519,10 +519,6 @@ contains
     call ESMF_FieldDestroy(field0, rc=status)
     VERIFY_(STATUS)
 
-#ifdef __GFORTRAN__
-    deallocate(tile_area_src)
-#endif
-    
     ! redist pfaf (NOTE: me might need a second routehandle for integers)
 
     route%pfaf => arbSeq

--- a/GEOSogcm_GridComp/GEOS_OgcmGridComp.F90
+++ b/GEOSogcm_GridComp/GEOS_OgcmGridComp.F90
@@ -1380,10 +1380,6 @@ contains
        ORES = 4*(ORES/6)
     end if
 
-#ifdef __GFORTRAN__
-    deallocate(gnames, gridim, gridjm)
-#endif
-
     if (ARES > ORES) then
        ! Ocean grid is coarser; we should interpolate
        iInterp = 1


### PR DESCRIPTION
The OGCM GC and the Route GC have a small chunk of code when using gfortran as a compiler. My guess is myself or @atrayano or someone added this because of issues with GNU and MAPL. 

This code needs to be removed so that the @GEOS-ESM/mapl-team can remove some no-longer-needed GNU workarounds currently in MAPL (see https://github.com/GEOS-ESM/MAPL/pull/716). But, if you remove the workarounds in MAPL, these deallocates will cause a crash!

Testing seems to indicate that this code isn't "necessary" at present, though it probably does cause a slight memory leak with GNU without this but with the workaround in MAPL. But GNU is not our operational compiler, so for testing at low-res, this isn't a problem.