### PR TITLE
Fixed MOM6 dianostics options

### DIFF
--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/mom6_app/360x210/diag_table
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/mom6_app/360x210/diag_table
@@ -1,5 +1,5 @@
 "Global ALE Experiment"
-1 1 1 0 0 0
+1900 1 1 0 0 0
 #"scalar",   1,"days",1,"days","Time",
 #"layer",    1,"days",1,"days","Time",
 #"prog",     1,"days",1,"days","Time",

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/mom6_app/360x320/diag_table
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/mom6_app/360x320/diag_table
@@ -1,5 +1,5 @@
 "Global ALE Experiment"
-1 1 1 0 0 0
+1900 1 1 0 0 0
 #"scalar",   1,"days",1,"days","Time",
 #"layer",    1,"days",1,"days","Time",
 #"prog",     1,"days",1,"days","Time",


### PR DESCRIPTION
This is necessary to make netcdf tools stop complaining about time in MOM6 diagnostics files.
