### PR TITLE
Fixes to enable mepo variant styles.

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
@@ -1,7 +1,7 @@
 esma_set_this ()
 
 set (alldirs
-  @GEOSchem_GridComp
+  GEOSchem_GridComp
   GEOSmoist_GridComp
   GEOSsurface_GridComp
   GEOSturbulence_GridComp

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/CMakeLists.txt
@@ -1,7 +1,7 @@
 esma_set_this ()
 
 set (alldirs
-  @FVdycoreCubed_GridComp
+  FVdycoreCubed_GridComp
   FVdycore_GridComp
   GEOSdatmodyn_GridComp
   ARIESg3_GridComp

--- a/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
@@ -459,7 +459,10 @@ list( APPEND MOM6_SRCS
    config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90
 )
 
-set (MOM6_path ${CMAKE_CURRENT_SOURCE_DIR}/../@mom6)
+
+esma_mepo_style(mom6 MOM6_rel_path REL_PATH ..)
+set (MOM6_path ${CMAKE_CURRENT_SOURCE_DIR}/${MOM6_rel_path})
+
 set (SRCS)
 foreach (file ${MOM6_SRCS})
   list (APPEND SRCS ${MOM6_path}/${file})


### PR DESCRIPTION
ETA by @mathomp4: Requires ESMA_cmake v3.5.6+