### PR TITLE
Fixes #473 - cmake stub bug

### DIFF
--- a/GEOSogcm_GridComp/GEOS_OceanGridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOS_OceanGridComp/CMakeLists.txt
@@ -1,10 +1,7 @@
 esma_set_this ()
 
-add_subdirectory(MOM6_GEOSPlug)
-add_subdirectory(MOM_GEOS5PlugMod)
-add_subdirectory(GEOSdatasea_GridComp)
-
 esma_add_library (${this}
   SRCS GEOS_OceanGridComp.F90
+  SUBCOMPONENTS MOM6_GEOSPlug MOM_GEOS5PlugMod GEOSdatasea_GridComp
   DEPENDENCIES GEOSdatasea_GridComp MAPL
   INCLUDES ${INC_ESMF})


### PR DESCRIPTION
This logic will allow guest oceans to be stubbed.  Should that ever be
desired.

To be fair, minimal testing was done just to make sure that cmake did not break.   But it really should not impact anything.   @mathomp4 can test if there is concern.
