### PR TITLE
Update CODEOWNERS for Surface Move

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,7 @@
 /GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/OASIMalbedoMod.f @GEOS-ESM/ocean-team
 
 # The surface preproc team owns these
-/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/ @GEOS-ESM/surface-preproc-team
+/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/ @GEOS-ESM/surface-preproc-team
 
 # Landice Team owns Landice
 /GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/ @GEOS-ESM/landice-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 # Some files are shared
 /GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/StieglitzSnow.F90 @GEOS-ESM/land-team @GEOS-ESM/landice-team
 /GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/SurfParams.F90    @GEOS-ESM/land-team @GEOS-ESM/landice-team
+/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90 @GEOS-ESM/land-team @GEOS-ESM/landice-team @GEOS-ESM/ocean-team
 
 # The Python Transition Team will own Python files
 # until the Python 3 transition is completed

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,13 +19,13 @@
 /GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/ @GEOS-ESM/land-team
 /GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlake_GridComp/ @GEOS-ESM/land-team
 /GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/            @GEOS-ESM/land-team
+/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/             @GEOS-ESM/land-team
 
 # But the OAsim file is ocean
 /GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/OASIMalbedoMod.f @GEOS-ESM/ocean-team
 
 # The surface preproc team owns these
-/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/mk_restarts/ @GEOS-ESM/surface-preproc-team
-/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/Raster/                                    @GEOS-ESM/surface-preproc-team
+/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/ @GEOS-ESM/surface-preproc-team
 
 # Landice Team owns Landice
 /GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/ @GEOS-ESM/landice-team


### PR DESCRIPTION
@gmao-rreichle pointed out that the `CODEOWNERS` file is a bit out of date due to changes in the Surface GridComp where files like `mk_restarts` got moved to `Utils/`.  This PR updates this.