### PR TITLE
Fixes #506. Initialize uninitialized part of selffac array

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_setcoef.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_setcoef.F90
@@ -507,6 +507,18 @@ contains
                indfor(lay,icol) = 3
                forfrac(lay,icol) = factor - 1.
 
+               !  Set up factors needed to separately include the water vapor
+               !  self-continuum in the calculation of absorption coefficient.
+               !  In the old code this was set as:
+               !
+               !     selffac(lay,icol) = water * forfac(lay,icol)
+               !
+               !  However, selffac is never used outside of this routine in 
+               !  the upper atmosphere. So to save operations we just set to zero.
+               !  Tests confirm that this is zero-diff to actually filling the
+               !  array with the product above.
+               selffac(lay,icol) = 0.0
+
                ! factors needed to separately include the minor gases
                ! in the calculation of absorption coefficient
                scaleminor(lay,icol) = pavel(lay,icol)/tavel(lay,icol)         

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_setcoef.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_setcoef.F90
@@ -507,16 +507,17 @@ contains
                indfor(lay,icol) = 3
                forfrac(lay,icol) = factor - 1.
 
-               !  Set up factors needed to separately include the water vapor
-               !  self-continuum in the calculation of absorption coefficient.
-               !  In the old code this was set as:
+               !  Initialize selffac in upper atmosphere
                !
-               !     selffac(lay,icol) = water * forfac(lay,icol)
+               !  In the old code this was set as:
+               !  ! Set up factors needed to separately include the water vapor
+               !  ! self-continuum in the calculation of absorption coefficient.
+               !  selffac(lay,icol) = water * forfac(lay,icol)
                !
                !  However, selffac is never used outside of this routine in 
                !  the upper atmosphere. So to save operations we just set to zero.
                !  Tests confirm that this is zero-diff to actually filling the
-               !  array with the product above.
+               !  array with the product above in both optimized and debug runs.
                selffac(lay,icol) = 0.0
 
                ! factors needed to separately include the minor gases


### PR DESCRIPTION
Per #506, the `selffac` array is only partially-filled, when the code then tries to run over the entire array, a crash occurs in debugging mode.

In the old code (v10.13.1 and older), this was set by:
```fortran
!  Set up factors needed to separately include the water vapor
!  self-continuum in the calculation of absorption coefficient.
         selffac(lay) = water * forfac(lay)
```
in the upper atmosphere. However, code analysis by @dr0cloud found that `selffac` isn't actually ever *accessed* in RRTMG LW in the upper atmosphere. So in the PR we instead set `selffac` to zero in the upper atmosphere to save on unneeded operations.

Runs with both Release and Debug builds show that this is indeed true and is zero-diff. 

Closes #506 