### PR TITLE
fix mk_GEOSldasRestart for catchcnclm45

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_GEOSldasRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_GEOSldasRestarts.F90
@@ -201,7 +201,11 @@ PROGRAM mk_GEOSldasRestarts
         stop
      endif
 
-     if (index(model,'45') /=0) clm45 = .true.
+     if (index(model,'45') /=0) then
+       clm45 = .true.
+       VAR_COL = VAR_COL_CLM45
+       VAR_PFT = VAR_PFT_CLM45
+     endif
      catch_scaler = 'Scale_CatchCN'
   else
      catch_scaler = 'Scale_Catch'


### PR DESCRIPTION
When using CatchCNCLM45 with RESTART =0 or 2, the variables VAR_PFT and VAR_COL are wrong and fixed in this PR.