### PR TITLE
removed redundant code: DQS calc, QC constraint, RA calc

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/GEOS_CatchCNCLM40GridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/GEOS_CatchCNCLM40GridComp.F90
@@ -6251,13 +6251,17 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
            end do
         end if
 
+        ! Compute DQS; make sure QC is between QA and QSAT; compute RA.
+        !
+        !   Some 1,000 lines below, duplicate code was present and removed in Jan 2022. 
+        !   - reichle, 14 Jan 2022.
+        
         do N=1,NUM_SUBTILES
            DQS(:,N) = GEOS_DQSAT ( TC(:,N), PS, QSAT=QSAT(:,N), PASCALS=.true., RAMP=0.0 )
            QC (:,N) = min(max(QA(:),QSAT(:,N)),QC(:,N))
            QC (:,N) = max(min(QA(:),QSAT(:,N)),QC(:,N))
            RA (:,N) = RHO/CH(:,N)
         end do
-
 
         QC(:,FSNW) = QSAT(:,FSNW)
 
@@ -7302,17 +7306,7 @@ call catch_calc_soil_moist( ntiles, veg1, dzsf, vgwmax, cdcr1, cdcr2, psis, bee,
        PLSIN = PLS + IRRIGRATE
        
     ENDIF
-
-
-! Andrea Molod (Oct 21, 2016):
- 
-        do N=1,NUM_SUBTILES
-           DQS(:,N) = GEOS_DQSAT ( TC(:,N), PS, QSAT=QSAT(:,N),PASCALS=.true., RAMP=0.0 )
-           QC (:,N) = min(max(QA(:),QSAT(:,N)),QC(:,N))
-           QC (:,N) = max(min(QA(:),QSAT(:,N)),QC(:,N))
-           RA (:,N) = RHO/CH(:,N)
-        end do
-
+    
 #ifdef DBG_CNLSM_INPUTS
         call MAPL_Get(MAPL, LocStream=LOCSTREAM, RC=STATUS)
         VERIFY_(STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/GEOS_CatchCNCLM45GridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/GEOS_CatchCNCLM45GridComp.F90
@@ -6246,6 +6246,11 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
            end do
         end if
 
+        ! Compute DQS; make sure QC is between QA and QSAT; compute RA.
+        !
+        !   Some 1,000 lines below, duplicate code was present and removed in Jan 2022. 
+        !   - reichle, 14 Jan 2022.
+
         do N=1,NUM_SUBTILES
            DQS(:,N) = GEOS_DQSAT ( TC(:,N), PS, QSAT=QSAT(:,N), PASCALS=.true., RAMP=0.0 )
            QC (:,N) = min(max(QA(:),QSAT(:,N)),QC(:,N))
@@ -7547,16 +7552,6 @@ call catch_calc_soil_moist( ntiles, veg1, dzsf, vgwmax, cdcr1, cdcr2, psis, bee,
        PLSIN = PLS + IRRIGRATE
        
     ENDIF
-
-
-! Andrea Molod (Oct 21, 2016):
- 
-        do N=1,NUM_SUBTILES
-           DQS(:,N) = GEOS_DQSAT ( TC(:,N), PS, QSAT=QSAT(:,N),PASCALS=.true., RAMP=0.0 )
-           QC (:,N) = min(max(QA(:),QSAT(:,N)),QC(:,N))
-           QC (:,N) = max(min(QA(:),QSAT(:,N)),QC(:,N))
-           RA (:,N) = RHO/CH(:,N)
-        end do
 
 #ifdef DBG_CNLSM_INPUTS
         call MAPL_Get(MAPL, LocStream=LOCSTREAM, RC=STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
@@ -55,10 +55,10 @@
 !                        ../Shared/lsm_routines.F90 
 !                      - moved SHR, EPSILON, SCONST, CSOIL_1,  CSOIL_2, N_sm, and SATCAPFR to
 !                        ../Shared/catch_constants.f90
-! Justin , 19 Apr 2018  - removed LAND_UPD ifdefs, use SurfParams
-! Justin , 11 Dec 2018  - put in ASNOW fix affecting AGCM only
-! Sarith , 20 Apr 2020  - introducing USE_FWET_FOR_RUNOFF and passing FWETL and FWETC via GEOS_SurfaceGridComp.rc
-
+! Justin, 19 Apr 2018  - removed LAND_UPD ifdefs, use SurfParams
+! Justin, 11 Dec 2018  - put in ASNOW fix affecting AGCM only
+! Sarith, 20 Apr 2020  - introducing USE_FWET_FOR_RUNOFF and passing FWETL and FWETC via GEOS_SurfaceGridComp.rc
+! Reichle, 14 Jan 2022 - removed redundant qa constraint; removed commented-out #ifdef LAND_UPD directives
 
       MODULE CATCHMENT_MODEL
 
@@ -530,18 +530,14 @@
         tc1_orig(n)=tc1(n)
         tc2_orig(n)=tc2(n)
         tc4_orig(n)=tc4(n)
-
-!#ifdef LAND_UPD
-	if (LAND_FIX) then
-           ! Andrea Molod (Oct 21, 2016):
-	   qa1(n) = min(max(qm(N),qsat1(N)),qa1(N))
-           qa1(n) = max(min(qm(N),qsat1(N)),qa1(N))
-           qa2(n) = min(max(qm(N),qsat2(N)),qa2(N))
-           qa2(n) = max(min(qm(N),qsat2(N)),qa2(N))
-           qa4(n) = min(max(qm(N),qsat4(N)),qa4(N))
-	   qa4(n) = max(min(qm(N),qsat4(N)),qa4(N))
-	end if 
-!#endif
+        
+        ! Removed an #ifdef LAND_UPD [if (LAND_FIX)] block from here that constrained qa
+        ! between qm and qsat.
+        ! For energy conservation reasons, the same code was added in GEOS_CatchGridComp.F90 
+        ! by Andrea Molod ca. 2016.
+        ! Because the legacy LDASsa did not use GEOS_CatchGridComp.F90, the constraint was
+        ! still needed here until the offline land software migrated to GEOSldas in 2020.
+        ! - reichle, 14 Jan 2022
 
         if(ityp(n) .ge. 7) potfrc(n)=0.
 !$$$        RA1(N)     = ONE / ( CD1(N) * max(UM(N),1.) )
@@ -679,14 +675,13 @@
         else
            phi=PHIGT
         end if
-!#ifdef LAND_UPD
+
 	if (LAND_FIX) then
            ZBAR =-SQRT(1.e-20+catdef(n)/bf1(n))+bf2(n)  ! zbar bug fix, - reichle, 16 Nov 2015
 	else
-!#else
 	   ZBAR=-SQRT(1.e-20+catdef(n)/bf1(n))-bf2(n)
 	end if
-!#endif
+
         THETAF=.5
         DO LAYER=1,6
           HT(LAYER)=GHTCNT(LAYER,N)
@@ -1300,12 +1295,6 @@
        ! Apply engineering fix for all vegetation classes.
        ! - reichle, 24 Nov 2015
 
-! #ifdef LAND_UPD
-!        !IF (ityp(N) .ne. 1) THEN
-!        IF (.true.) THEN
-! #else
-!        IF (ityp(N) .ne. 1) THEN 
-! #endif
        IF (LAND_FIX .OR. (ityp(N) .ne. 1)) THEN           
           call dampen_tc_oscillations(dtstep,tm(N),tc1_orig(N),tc1(N),     &
                tc1_00(N),dtc1)
@@ -1710,11 +1699,7 @@
 	else
 	   rzavemin = 0.
 	end if
-! #ifdef LAND_UPD
-!         if (rzave .le. 1.e-4) then
-! #else
-!         if (rzave .le. 0.) then
-! #endif
+
         if (rzave .le. rzavemin) then  ! JP: could put rzavemin in catch_constants
           rzave=1.e-4
           print*,'problem: rzave <= 1.e-4 in catchment',n
@@ -1731,9 +1716,7 @@
 ! ---------------------------------------------------------------------
 
         SRFLW=SRFEXC(N)*DTSTEP/TSC0
-! #ifdef LAND_UPD
-!         IF(SRFLW < 0.    ) SRFLW = 0.04 * SRFLW ! C05 change
-! #endif
+
         IF(SRFLW < 0.    ) SRFLW = FLWALPHA * SRFLW ! C05 change
 
 !rr   following inserted by koster Sep 22, 2003
@@ -2122,16 +2105,6 @@
 !      REAL DELTC, DELEA, STEXP, ATRANS, ASTRFR
       REAL DELTC, DELEA, ATRANS
 
-! Removed ifdef -JP
-! !!#ifdef LAND_UPD      
-! !      ! C05 change - SM
-! !      PARAMETER (ASTRFR=1.)  ! STRESS TRANSITION POINT
-! !      PARAMETER (STEXP=2.)  ! STRESS RAMPING
-! !!#else
-!       ! keep the GCM values starting from GEOSldas_m4-17_6 -- WJ
-!       PARAMETER (ASTRFR=0.333)  ! STRESS TRANSITION POINT
-!       PARAMETER (STEXP=1.)  ! STRESS RAMPING
-! !!#endif
       DATA DELTC /0.01/, DELEA /0.001/
 
 
@@ -2919,13 +2892,7 @@
 
 ! RDK 04/04/06
 !  VALUES OF BARE SOIL SURFACE RESISTANCE AT WILTING POINT, SATURATION
-! Removed ifdef - JP
-! !!#ifdef LAND_UPD
-! !      PARAMETER (RSWILT=2000., RSSAT=25.) ! C05 Change -SM
-! !!#else
-!       !keep GCM values starting from GEOSldas_m4-17_6 - WJ
-!       PARAMETER (RSWILT= 500., RSSAT=25.) 
-! !!#endif
+
      PARAMETER (RSSAT=25.)
 
 !****


### PR DESCRIPTION
This PR cleans up presumably redundant code (DQS calc, QC constraint, RA calc) that occurred twice in each Catch[CN] GridComp F90 file.  The QC constraint was also removed from catchment.F90 (where QC is known as "qa").
 
The PR was prompted by @amolod's observation that the code in question should not have been placed within an `if (LAND_FIX)` block.  After further investigation, it was discovered that if block code in question already occurs verbatim earlier in the subroutine and thus looks to be redundant.  

@amolod reports that Mike Manyin successfully ran a 0-diff test for the S2S model after removing the if (LAND_FIX) condition.

In the CatchCN GridComp F90 files, the two identical blocks of code are separated by ~1,000 lines.  An inspection of these lines suggests that the code blocks are redundant, but it is difficult to say from just going through the source code.
 
@biljanaorescanin: When you get a chance, please run the standard 0-diff tests for both the AGCM and GEOSldas.

cc: @rdkoster @wmputman @sdrabenh 