### PR TITLE
Feature/pnorris/#512 add additional radiation rrtmg tau and water path diagnostics

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -3345,7 +3345,7 @@ contains
       do I = 1,IM
          IJ = IJ + 1
 
-         ! convert super-band clearCounts to cloud fractions
+         ! convert super-layer clearCounts to cloud fractions
          if(associated(CLDTTLW)) then
             CLDTTLW(I,J) = 1.0 - CLEARCOUNTS(IJ,1)/float(NGPTLW)
          endif

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -783,6 +783,14 @@ contains
         DIMS       = MAPL_DimsHorzOnly,                           &
         VLOCATION  = MAPL_VLocationNone,                   __RC__ )
 
+! Note: the four CLDxxLW diagnostics below represent super-layer cloud
+! fractions based on the subcolumn cloud generation called in RRTMG LW.
+! They are global fields but generated only at the LW REFRESH frequency,
+! NOT at the heartbeat. As such, they are useful for diagnostic comparisons
+! with CLDTT above and with the full CLDxx set from the Solar GC. But they
+! should NOT be used to subsample fields that are produced on the model
+! heartbeat (e.g. subsampling for cloud presence).
+
     call MAPL_AddExportSpec(GC,                                         &
         SHORT_NAME = 'CLDTTLW',                                         &
         LONG_NAME  = 'total_cloud_area_fraction_rrtmg_lw_REFRESH',      &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -783,33 +783,33 @@ contains
         DIMS       = MAPL_DimsHorzOnly,                           &
         VLOCATION  = MAPL_VLocationNone,                   __RC__ )
 
-    call MAPL_AddExportSpec(GC,                                   &
-        SHORT_NAME = 'CLDTTLW',                                   &
-        LONG_NAME  = 'total_cloud_area_fraction_rrtmg_lw',        &
-        UNITS      = '1',                                         &
-        DIMS       = MAPL_DimsHorzOnly,                           &
-        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+    call MAPL_AddExportSpec(GC,                                         &
+        SHORT_NAME = 'CLDTTLW',                                         &
+        LONG_NAME  = 'total_cloud_area_fraction_rrtmg_lw_REFRESH',      &
+        UNITS      = '1',                                               &
+        DIMS       = MAPL_DimsHorzOnly,                                 &
+        VLOCATION  = MAPL_VLocationNone,                         __RC__ )
 
-    call MAPL_AddExportSpec(GC,                                   &
-        SHORT_NAME = 'CLDHILW',                                   &
-        LONG_NAME  = 'high-level_cloud_area_fraction_rrtmg_lw',   &
-        UNITS      = '1',                                         &
-        DIMS       = MAPL_DimsHorzOnly,                           &
-        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+    call MAPL_AddExportSpec(GC,                                         &
+        SHORT_NAME = 'CLDHILW',                                         &
+        LONG_NAME  = 'high-level_cloud_area_fraction_rrtmg_lw_REFRESH', &
+        UNITS      = '1',                                               &
+        DIMS       = MAPL_DimsHorzOnly,                                 &
+        VLOCATION  = MAPL_VLocationNone,                         __RC__ )
 
-    call MAPL_AddExportSpec(GC,                                   &
-        SHORT_NAME = 'CLDMDLW',                                   &
-        LONG_NAME  = 'mid-level_cloud_area_fraction_rrtmg_lw',    &
-        UNITS      = '1',                                         &
-        DIMS       = MAPL_DimsHorzOnly,                           &
-        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+    call MAPL_AddExportSpec(GC,                                         &
+        SHORT_NAME = 'CLDMDLW',                                         &
+        LONG_NAME  = 'mid-level_cloud_area_fraction_rrtmg_lw_REFRESH',  &
+        UNITS      = '1',                                               &
+        DIMS       = MAPL_DimsHorzOnly,                                 &
+        VLOCATION  = MAPL_VLocationNone,                         __RC__ )
 
-    call MAPL_AddExportSpec(GC,                                   &
-        SHORT_NAME = 'CLDLOLW',                                   &
-        LONG_NAME  = 'low_level_cloud_area_fraction_rrtmg_lw',    &
-        UNITS      = '1',                                         &
-        DIMS       = MAPL_DimsHorzOnly,                           &
-        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+    call MAPL_AddExportSpec(GC,                                         &
+        SHORT_NAME = 'CLDLOLW',                                         &
+        LONG_NAME  = 'low_level_cloud_area_fraction_rrtmg_lw_REFRESH',  &
+        UNITS      = '1',                                               &
+        DIMS       = MAPL_DimsHorzOnly,                                 &
+        VLOCATION  = MAPL_VLocationNone,                         __RC__ )
 
 !  Irrad does not have a "real" internal state. To update the net_longwave_flux
 !  due to the change of surface temperature every time step, we keep 
@@ -1701,27 +1701,39 @@ contains
    REFF(:,:,:,KRAIN  ) = RR * 1.0e6
    REFF(:,:,:,KSNOW  ) = RS * 1.0e6
 
-! Determine the model level seperating high and middle clouds
-!------------------------------------------------------------
+! Determine the model level separating high-middle and low-middle clouds
+!-----------------------------------------------------------------------
 
-   LCLDMH = 1
-   do K = 1, LM
-      if( PREF(K) >= PRS_MID_HIGH ) then
-         LCLDMH = K
-         exit
-      end if
+   _ASSERT(PRS_MID_HIGH > PREF(1)     , 'mid-high pressure band boundary too high!')
+   _ASSERT(PRS_LOW_MID  > PRS_MID_HIGH, 'pressure band misordering!')
+   _ASSERT(PRS_LOW_MID  < PREF(LM)    , 'low-mid pressure band boundary too low!')
+
+   ! find mid-high interface level
+   k = 1
+   do while ( PREF(k) < PRS_MID_HIGH )
+     k=k+1
    end do
+   LCLDMH = k
+   ! Guaranteed that LCLDMH > 1 (by first ASSERT above)
+   !    and that PREF(LCLDMH) >= PRS_MID_HIGH (by while loop)
 
-! Determine the model level seperating low and middle clouds
-!-----------------------------------------------------------
-
-   LCLDLM = LM
-   do K = 1, LM
-      if( PREF(K) >= PRS_LOW_MID  ) then
-         LCLDLM = K
-         exit
-      end if
+   ! find low-mid interface level
+   do while ( PREF(k) < PRS_LOW_MID )
+     k=k+1
    end do
+   LCLDLM = k
+   ! Guaranteed that LCLDLM <= LM (by third assert above)
+   !    and that PREF(LCLDLM) >= PRS_LOW_MID (by while loop)
+
+   ! But it's still possible that LCLDLM == LCLDMH if the
+   ! interface pressures are too close. We now ASSERT to
+   ! prevent this.
+   _ASSERT(LCLDMH < LCLDLM, 'PRS_LOW_MID and PRS_MID_HIGH are too close!')
+
+   ! now we have 1 < LCLDMH < LCLDLM <= LM and can use:
+   !    layers [1,      LCLDMH-1] are in high pressure band
+   !    layers [LCLDMH, LCLDLM-1] are in mid  pressure band
+   !    layers [LCLDLM, LM      ] are in low  pressure band
 
    call MAPL_GetPointer(EXPORT, CLDTTLW, 'CLDTTLW', RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT, CLDHILW, 'CLDHILW', RC=STATUS); VERIFY_(STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_rad.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/RRTMG/rrtmg_lw/gcm_model/src/rrtmg_lw_rad.F90
@@ -181,7 +181,7 @@ contains
 
       ! ----- Output -----
 
-      ! subcolumn clear counts for Tot|High|Mid|Low bands
+      ! subcolumn clear counts for Tot|High|Mid|Low super-layers
       integer, intent(out) :: clearCounts(ncol,4)
 
       real, intent(out) :: uflx  (ncol,nlay+1)  ! Total sky LW upward flux [W/m2]
@@ -426,7 +426,7 @@ contains
 
       ! ----- Output -----
 
-      ! subcolumn clear counts for Tot|High|Mid|Low bands
+      ! subcolumn clear counts for Tot|High|Mid|Low super-layers
       integer, intent(out) :: clearCounts(ncol,4)
 
       real, intent(out) :: uflx  (ncol,nlay+1)  ! Total sky LW upward flux [W/m2]
@@ -484,7 +484,7 @@ contains
       real    :: ciwpmc (nlay,ngptlw,pncol)  ! cloud ice water path [g/m2]
       real    :: clwpmc (nlay,ngptlw,pncol)  ! cloud liq water path [g/m2]
       real    :: taucmc (nlay,ngptlw,pncol)  ! cloud optical depth
-      integer :: p_clearCounts (4,pncol)     ! for super-band cld fractions
+      integer :: p_clearCounts (4,pncol)     ! for super-layer cld fractions
 
       ! cloudy for ANY subcol/gpoint of column?
       logical :: cloudy (nlay,pncol)
@@ -554,7 +554,7 @@ contains
          cldymc, ciwpmc, clwpmc, &
          seed_order=[1,2,3,4])
 
-      ! for super-band cloud fractions
+      ! for super-layer cloud fractions
 
       call clearCounts_threeBand( &
          pncol, pncol, ngptlw, nlay, cloudLM, cloudMH, cldymc, &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -4765,12 +4765,10 @@ contains
                ! nothing to process yet?
                if (ncld == 0) cycle
 
-               ! process the partition?
-               if (ncld == pncol               & ! partition is full so process
-                   .or. i == IM .and. j == JM  & ! partition is partially full
-                                               & !   but no more gridcolumns
-                                               & !   so process what have.
-                  ) then
+               ! process the partition if its full or if its partially
+               !   full but there are no more gridcolumns left.
+
+               if (ncld == pncol .or. i == IM .and. j == JM) then
 
                   ! McICA subcolumn generation
                   call generate_stochastic_clouds( &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -1256,6 +1256,13 @@ contains
        VLOCATION  = MAPL_VLocationNone,                                __RC__)
 
     call MAPL_AddExportSpec(GC,                                              &
+       LONG_NAME  = 'cosine_of_the_solar_zenith_angle_of_Solar_REFRESH',     &
+       UNITS      = '1',                                                     &
+       SHORT_NAME = 'COSZSW',                                                &
+       DIMS       = MAPL_DimsHorzOnly,                                       &
+       VLOCATION  = MAPL_VLocationNone,                                __RC__)
+
+    call MAPL_AddExportSpec(GC,                                              &
         SHORT_NAME = 'CLDTMP',                                               &
         LONG_NAME  = 'cloud_top_temperature',                                &
         UNITS      = 'K',                                                    &
@@ -2022,6 +2029,9 @@ contains
       real, pointer, dimension(:,:)   :: TAUMDPAR
       real, pointer, dimension(:,:)   :: TAULOPAR
 
+      ! cosine solar zenith angle used by REFRESH
+      real, pointer, dimension(:,:)   :: COSZSW
+
 !  DAYTIME ONLY COPY OF VARIABLES
 
       real, pointer, dimension(:  )   :: ALBNR,ALBNF,ALBVR,ALBVF,ZT,SLR1D, &
@@ -2232,6 +2242,9 @@ contains
         end do
       end do
 
+      ! cosine solar zenith angle used by REFRESH
+      call MAPL_GetPointer(EXPORT, COSZSW, 'COSZSW', __RC__)
+
       ! super-layer RRTMG cloud fraction exports
       call MAPL_GetPointer(EXPORT, CLDTTSW, 'CLDTTSW', __RC__)
       call MAPL_GetPointer(EXPORT, CLDHISW, 'CLDHISW', __RC__)
@@ -2269,6 +2282,9 @@ contains
          daytime = .true.
          NumLit  = size(ZTH)
       end if
+
+      ! write out the cosine solar zenith angle actually used by REFRESH
+      if (associated(COSZSW)) COSZSW = ZTH
 
 !  Create a balancing strategy. This is a collective call on the communicator
 !  of the current VM. The original, unbalanced local work consists of (OrgLen)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -4786,22 +4786,22 @@ contains
                   ! convert super-layer clearCounts to cloud fractions
                   if (associated(CLDTTSWHB)) then
                      do n = 1,ncld
-                        CLDTTSWHB(icld(n),jcld(n)) = 1. - clearCounts(n,1)/float(ngptsw)
+                        CLDTTSWHB(icld(n),jcld(n)) = 1. - clearCounts(1,n)/float(ngptsw)
                      end do
                   end if
                   if (associated(CLDHISWHB)) then
                      do n = 1,ncld
-                        CLDHISWHB(icld(n),jcld(n)) = 1. - clearCounts(n,2)/float(ngptsw)
+                        CLDHISWHB(icld(n),jcld(n)) = 1. - clearCounts(2,n)/float(ngptsw)
                      end do
                   end if
                   if (associated(CLDMDSWHB)) then
                      do n = 1,ncld
-                        CLDMDSWHB(icld(n),jcld(n)) = 1. - clearCounts(n,3)/float(ngptsw)
+                        CLDMDSWHB(icld(n),jcld(n)) = 1. - clearCounts(3,n)/float(ngptsw)
                      end do
                   end if
                   if (associated(CLDLOSWHB)) then
                      do n = 1,ncld
-                        CLDLOSWHB(icld(n),jcld(n)) = 1. - clearCounts(n,4)/float(ngptsw)
+                        CLDLOSWHB(icld(n),jcld(n)) = 1. - clearCounts(4,n)/float(ngptsw)
                      end do
                   end if
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -4768,8 +4768,8 @@ contains
                ! process the partition?
                if (ncld == pncol               & ! partition is full so process
                    .or. i == IM .and. j == JM  & ! partition is partially full
-                                               &     but no more gridcolumns
-                                               &     so process what have.
+                                               & !   but no more gridcolumns
+                                               & !   so process what have.
                   ) then
 
                   ! McICA subcolumn generation

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -4714,7 +4714,7 @@ contains
             do i = 1,IM
 
                ! load up cloudy columns to partition
-               if (any(CLIN(i,j,:) > 0.) then
+               if (any(CLIN(i,j,:) > 0.)) then
 
                   ! cloudy column
                   ncld = ncld + 1
@@ -4812,8 +4812,8 @@ contains
 
                end if  ! process partition
 
-            end do ! i
-         end do ! j
+            end do  ! i
+         end do  ! j
 
          ! clean up
          deallocate(icld,jcld,__STAT__)
@@ -4821,7 +4821,7 @@ contains
          deallocate(cldymcl,ciwpmcl,clwpmcl,__STAT__)
          deallocate(clearCounts,__STAT__)
 
-      end if
+      end if  ! CLD??SWHB
 
       if (associated(TAUI) .or. associated(TAUW) .or. associated(TAUR) .or. associated(TAUS).or. &
           associated(TAUL) .or. associated(TAUM) .or. associated(TAUH) .or. &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -938,33 +938,61 @@ contains
        DIMS       = MAPL_DimsHorzOnly,                                       &
        VLOCATION  = MAPL_VLocationNone,                                __RC__)
 
-    call MAPL_AddExportSpec(GC,                                   &
-        SHORT_NAME = 'CLDTTSW',                                   &
-        LONG_NAME  = 'total_cloud_area_fraction_rrtmg_sw',        &
-        UNITS      = '1',                                         &
-        DIMS       = MAPL_DimsHorzOnly,                           &
-        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+    call MAPL_AddExportSpec(GC,                                              &
+        SHORT_NAME = 'CLDTTSW',                                              &
+        LONG_NAME  = 'total_cloud_area_fraction_rrtmg_sw_REFRESH',           &
+        UNITS      = '1',                                                    &
+        DIMS       = MAPL_DimsHorzOnly,                                      &
+        VLOCATION  = MAPL_VLocationNone,                              __RC__ )
 
-    call MAPL_AddExportSpec(GC,                                   &
-        SHORT_NAME = 'CLDHISW',                                   &
-        LONG_NAME  = 'high-level_cloud_area_fraction_rrtmg_sw',   &
-        UNITS      = '1',                                         &
-        DIMS       = MAPL_DimsHorzOnly,                           &
-        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+    call MAPL_AddExportSpec(GC,                                              &
+        SHORT_NAME = 'CLDHISW',                                              &
+        LONG_NAME  = 'high-level_cloud_area_fraction_rrtmg_sw_REFRESH',      &
+        UNITS      = '1',                                                    &
+        DIMS       = MAPL_DimsHorzOnly,                                      &
+        VLOCATION  = MAPL_VLocationNone,                              __RC__ )
 
-    call MAPL_AddExportSpec(GC,                                   &
-        SHORT_NAME = 'CLDMDSW',                                   &
-        LONG_NAME  = 'mid-level_cloud_area_fraction_rrtmg_sw',    &
-        UNITS      = '1',                                         &
-        DIMS       = MAPL_DimsHorzOnly,                           &
-        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+    call MAPL_AddExportSpec(GC,                                              &
+        SHORT_NAME = 'CLDMDSW',                                              &
+        LONG_NAME  = 'mid-level_cloud_area_fraction_rrtmg_sw_REFRESH',       &
+        UNITS      = '1',                                                    &
+        DIMS       = MAPL_DimsHorzOnly,                                      &
+        VLOCATION  = MAPL_VLocationNone,                              __RC__ )
 
-    call MAPL_AddExportSpec(GC,                                   &
-        SHORT_NAME = 'CLDLOSW',                                   &
-        LONG_NAME  = 'low-level_cloud_area_fraction_rrtmg_sw',    &
-        UNITS      = '1',                                         &
-        DIMS       = MAPL_DimsHorzOnly,                           &
-        VLOCATION  = MAPL_VLocationNone,                   __RC__ )
+    call MAPL_AddExportSpec(GC,                                              &
+        SHORT_NAME = 'CLDLOSW',                                              &
+        LONG_NAME  = 'low-level_cloud_area_fraction_rrtmg_sw_REFRESH',       &
+        UNITS      = '1',                                                    &
+        DIMS       = MAPL_DimsHorzOnly,                                      &
+        VLOCATION  = MAPL_VLocationNone,                              __RC__ )
+
+    call MAPL_AddExportSpec(GC,                                              &
+        SHORT_NAME = 'CLDTTSWHB',                                            &
+        LONG_NAME  = 'total_cloud_area_fraction_rrtmg_sw_HEARTBEAT',         &
+        UNITS      = '1',                                                    &
+        DIMS       = MAPL_DimsHorzOnly,                                      &
+        VLOCATION  = MAPL_VLocationNone,                              __RC__ )
+
+    call MAPL_AddExportSpec(GC,                                              &
+        SHORT_NAME = 'CLDHISWHB',                                            &
+        LONG_NAME  = 'high-level_cloud_area_fraction_rrtmg_sw_HEARTBEAT',    &
+        UNITS      = '1',                                                    &
+        DIMS       = MAPL_DimsHorzOnly,                                      &
+        VLOCATION  = MAPL_VLocationNone,                              __RC__ )
+
+    call MAPL_AddExportSpec(GC,                                              &
+        SHORT_NAME = 'CLDMDSWHB',                                            &
+        LONG_NAME  = 'mid-level_cloud_area_fraction_rrtmg_sw_HEARTBEAT',     &
+        UNITS      = '1',                                                    &
+        DIMS       = MAPL_DimsHorzOnly,                                      &
+        VLOCATION  = MAPL_VLocationNone,                              __RC__ )
+
+    call MAPL_AddExportSpec(GC,                                              &
+        SHORT_NAME = 'CLDLOSWHB',                                            &
+        LONG_NAME  = 'low-level_cloud_area_fraction_rrtmg_sw_HEARTBEAT',     &
+        UNITS      = '1',                                                    &
+        DIMS       = MAPL_DimsHorzOnly,                                      &
+        VLOCATION  = MAPL_VLocationNone,                              __RC__ )
 
     call MAPL_AddExportSpec(GC,                                              &
        LONG_NAME  = 'in_cloud_optical_thickness_of_low_clouds',              &
@@ -1029,33 +1057,33 @@ contains
        DIMS       = MAPL_DimsHorzVert,                                       &
        VLOCATION  = MAPL_VLocationCenter,                              __RC__)
 
-    call MAPL_AddExportSpec(GC,                                              &
-       LONG_NAME  = 'in_cloud_optical_thickness_of_low_clouds_RRTMG_PAR',    &
-       UNITS      = '1' ,                                                    &
-       SHORT_NAME = 'TAULOPAR',                                              &
-       DIMS       = MAPL_DimsHorzOnly,                                       &
-       VLOCATION  = MAPL_VLocationNone,                                __RC__)
+    call MAPL_AddExportSpec(GC,                                                      &
+       LONG_NAME  = 'in_cloud_optical_thickness_of_low_clouds_RRTMG_PAR_REFRESH',    &
+       UNITS      = '1' ,                                                            &
+       SHORT_NAME = 'TAULOPAR',                                                      &
+       DIMS       = MAPL_DimsHorzOnly,                                               &
+       VLOCATION  = MAPL_VLocationNone,                                        __RC__)
 
-    call MAPL_AddExportSpec(GC,                                              &
-       LONG_NAME  = 'in_cloud_optical_thickness_of_middle_clouds_RRTMG_PAR', &
-       UNITS      = '1' ,                                                    &
-       SHORT_NAME = 'TAUMDPAR',                                              &
-       DIMS       = MAPL_DimsHorzOnly,                                       &
-       VLOCATION  = MAPL_VLocationNone,                                __RC__)
+    call MAPL_AddExportSpec(GC,                                                      &
+       LONG_NAME  = 'in_cloud_optical_thickness_of_middle_clouds_RRTMG_PAR_REFRESH', &
+       UNITS      = '1' ,                                                            &
+       SHORT_NAME = 'TAUMDPAR',                                                      &
+       DIMS       = MAPL_DimsHorzOnly,                                               &
+       VLOCATION  = MAPL_VLocationNone,                                        __RC__)
 
-    call MAPL_AddExportSpec(GC,                                              &
-       LONG_NAME  = 'in_cloud_optical_thickness_of_high_clouds_RRTMG_PAR',   &
-       UNITS      = '1' ,                                                    &
-       SHORT_NAME = 'TAUHIPAR',                                              &
-       DIMS       = MAPL_DimsHorzOnly,                                       &
-       VLOCATION  = MAPL_VLocationNone,                                __RC__)
+    call MAPL_AddExportSpec(GC,                                                      &
+       LONG_NAME  = 'in_cloud_optical_thickness_of_high_clouds_RRTMG_PAR_REFRESH',   &
+       UNITS      = '1' ,                                                            &
+       SHORT_NAME = 'TAUHIPAR',                                                      &
+       DIMS       = MAPL_DimsHorzOnly,                                               &
+       VLOCATION  = MAPL_VLocationNone,                                        __RC__)
 
-    call MAPL_AddExportSpec(GC,                                              &
-       LONG_NAME  = 'in_cloud_optical_thickness_of_all_clouds_RRTMG_PAR',    &
-       UNITS      = '1' ,                                                    &
-       SHORT_NAME = 'TAUTTPAR',                                              &
-       DIMS       = MAPL_DimsHorzOnly,                                       &
-       VLOCATION  = MAPL_VLocationNone,                                __RC__)
+    call MAPL_AddExportSpec(GC,                                                      &
+       LONG_NAME  = 'in_cloud_optical_thickness_of_all_clouds_RRTMG_PAR_REFRESH',    &
+       UNITS      = '1' ,                                                            &
+       SHORT_NAME = 'TAUTTPAR',                                                      &
+       DIMS       = MAPL_DimsHorzOnly,                                               &
+       VLOCATION  = MAPL_VLocationNone,                                        __RC__)
 
     call MAPL_AddExportSpec(GC,                                              &
        LONG_NAME  = 'surface_net_downward_shortwave_flux_assuming_clear_sky',&
@@ -1698,22 +1726,39 @@ contains
 
     call MAPL_GetPointer(IMPORT, PREF, 'PREF', __RC__)
 
-! Determine the model level seperating high-middle and low-middle clouds
+! Determine the model level separating high-middle and low-middle clouds
 !-----------------------------------------------------------------------
 
     _ASSERT(PRS_MID_HIGH > PREF(1)     , 'mid-high pressure band boundary too high!')
     _ASSERT(PRS_LOW_MID  > PRS_MID_HIGH, 'pressure band misordering!')
     _ASSERT(PRS_LOW_MID  < PREF(LM)    , 'low-mid pressure band boundary too low!')
     
+    ! find mid-high interface level
     k = 1
     do while ( PREF(k) < PRS_MID_HIGH )
       k=k+1
     end do
     LCLDMH = k
-    do while ( PREF(k) < PRS_LOW_MID  )
+    ! Guaranteed that LCLDMH > 1 (by first ASSERT above)
+    !    and that PREF(LCLDMH) >= PRS_MID_HIGH (by while loop)
+
+    ! find low-mid interface level
+    do while ( PREF(k) < PRS_LOW_MID )
       k=k+1
     end do
     LCLDLM = k
+    ! Guaranteed that LCLDLM <= LM (by third assert above)
+    !    and that PREF(LCLDLM) >= PRS_LOW_MID (by while loop)
+
+    ! But it's still possible that LCLDLM == LCLDMH if the
+    ! interface pressures are too close. We now ASSERT to
+    ! prevent this.
+    _ASSERT(LCLDMH < LCLDLM, 'PRS_LOW_MID and PRS_MID_HIGH are too close!')
+
+    ! now we have 1 < LCLDMH < LCLDLM <= LM and can use:
+    !    layers [1,      LCLDMH-1] are in high pressure band
+    !    layers [LCLDMH, LCLDLM-1] are in mid  pressure band
+    !    layers [LCLDLM, LM      ] are in low  pressure band
 
     call MAPL_TimerOff(MAPL,"PRELIMS",__RC__)
 
@@ -4428,6 +4473,22 @@ contains
                                          TAUH,TAUM,TAUL,TAUT,TAUTX, &
                                          CLDTMP,CLDPRS
 
+      ! super-layer RRTMG cloud fraction exports on heartbeat
+      real, pointer, dimension(:,:)   :: CLDTTSWHB
+      real, pointer, dimension(:,:)   :: CLDHISWHB
+      real, pointer, dimension(:,:)   :: CLDMDSWHB
+      real, pointer, dimension(:,:)   :: CLDLOSWHB
+
+      ! locals supporting CLD??SWHB
+      integer :: rpart, pncol, ncld
+      real    :: plmid(LM), tlev(LM-1), cfac(LM)
+      integer, allocatable, dimension(:)     :: icld, jcld
+      real,    allocatable, dimension(:)     :: alat
+      real,    allocatable, dimension(:,:)   :: zmid, play, cldfrac, ciwp, clwp
+      logical, allocatable, dimension(:,:,:) :: cldymcl
+      real,    allocatable, dimension(:,:,:) :: ciwpmcl, clwpmcl
+      integer, allocatable, dimension(:,:)   :: clearCounts
+
       type (ESMF_FieldBundle)         :: BUNDLE
       type (ESMF_Field)               :: FIELD
       type (ESMF_TimeInterval)        :: DELT
@@ -4557,6 +4618,11 @@ contains
       call MAPL_GetPointer(EXPORT  , CLDTMP,     'CLDTMP',     __RC__)
       call MAPL_GetPointer(EXPORT  , CLDPRS,     'CLDPRS',     __RC__)
 
+      call MAPL_GetPointer(EXPORT  , CLDLOSWHB,  'CLDLOSWHB',  __RC__)
+      call MAPL_GetPointer(EXPORT  , CLDMDSWHB,  'CLDMDSWHB',  __RC__)
+      call MAPL_GetPointer(EXPORT  , CLDHISWHB,  'CLDHISWHB',  __RC__)
+      call MAPL_GetPointer(EXPORT  , CLDTTSWHB,  'CLDTTSWHB',  __RC__)
+
       if (associated(FCLD)) FCLD = CLIN
 
       if (associated(CLDH) .or. associated(CLDT) .or. associated(TAUTX)) then
@@ -4590,6 +4656,171 @@ contains
          allocate(aCLDT(IM,JM),__STAT__)
          aCLDT = 1. - (1-aCLDH)*(1-aCLDM)*(1-aCLDL)
          if (associated(CLDT)) CLDT = aCLDT
+      end if
+
+      ! CLD??SWHB:
+      ! Special heartbeat versions of RRTMG generated cloud fractions ...
+      ! These are expensive because they require a call to the cloud generator,
+      ! which normally is only done inside the IRRAD and SOLAR REFRESHes (and
+      ! for the SOLAR case only on the sunlit portion of the globe). We provide
+      ! these here as a means of validation, but they should not be regularly
+      ! exported since they will slow down SOLAR considerably, and since the
+      ! equivalent REFRESH-generated versions (without the "HB" suffix), which
+      ! are updated only at the REFRESH frequency (~hourly), should be fine in
+      ! most cases (especially for longer term averages).
+      ! NB: Filled on all globe unlike the RESFRESH version CLD??SW.
+
+      if (associated(CLDLOSWHB) .or. associated(CLDMDSWHB) .or. &
+          associated(CLDHISWHB) .or. associated(CLDTTSWHB)) then
+
+         ! default to clear columns which do not need subcolumn generation
+         if (associated(CLDLOSWHB)) CLDLOSWHB = 0.
+         if (associated(CLDMDSWHB)) CLDMDSWHB = 0.
+         if (associated(CLDHISWHB)) CLDHISWHB = 0.
+         if (associated(CLDTTSWHB)) CLDTTSWHB = 0.
+
+         ! partition size pncol for cloudy columns to conserve memory & improve efficiency
+         call MAPL_GetResource(MAPL,rpart,'RRTMGSW_PARTITION_SIZE:',DEFAULT=0,__RC__)
+         if (rpart > 0) then
+            pncol = rpart
+         else
+            pncol = 2
+         end if
+
+         ! space for partition:
+         ! The partition stores up cloudy gridcolumns to process in batch
+         allocate(icld   (          pncol),__STAT__)
+         allocate(jcld   (          pncol),__STAT__)
+         allocate(zmid   (LM,       pncol),__STAT__)
+         allocate(alat   (          pncol),__STAT__)
+         allocate(play   (LM,       pncol),__STAT__)
+         allocate(cldfrac(LM,       pncol),__STAT__)
+         allocate(ciwp   (LM,       pncol),__STAT__)
+         allocate(clwp   (LM,       pncol),__STAT__)
+         allocate(cldymcl(LM,ngptsw,pncol),__STAT__)
+         allocate(ciwpmcl(LM,ngptsw,pncol),__STAT__)
+         allocate(clwpmcl(LM,ngptsw,pncol),__STAT__)
+         allocate(clearCounts(4,    pncol),__STAT__)
+
+         ! start with empty partition
+         ncld = 0
+
+! after this test ... make sure DOY used consistently by refresh and update in model
+! I guess its only now being used in update, but was its use in refresh really consistent?
+! this may be a non-zero-diff bug fix later ... co2 by DOY = hb but DOY for RRTMG should be for REFRESH style time
+
+         ! loop over domain
+         do j = 1,JM
+            do i = 1,IM
+
+               ! load up cloudy columns to partition
+               if (any(CLIN(i,j,:) > 0.) then
+
+                  ! cloudy column
+                  ncld = ncld + 1
+                  icld (ncld) = i
+                  jcld (ncld) = j
+                  alat (ncld) = LATS(i,j)
+
+                  ! Note: unlike RRTMG we do not reverse the levels. This is a
+                  ! technicality and will not alter the POPULATION stats of the
+                  ! generation and saves time (see notes under cloud_subcol_gen).
+                  ! If an exact replication of RRTMGSW is required, can reverse
+                  ! vertical ordering here ... but an exact replication will
+                  ! also require saving the exact cldfrac used by the REFRESH
+                  ! into the internal state for use here as well.
+
+                  plmid = 0.5 * (PLL(i,j,0:LM-1) + PLL(i,j,1:LM))
+                  play   (:,ncld) = plmid / 100.  ! hPa
+                  cldfrac(:,ncld) = CLIN(i,j,:)
+
+                  ! cloud water paths converted from g/g to g/m^2
+                  cfac = 1.02 * 100 * (PLL(i,j,1:LM)-PLL(i,j,0:LM-1))
+                  ciwp(:,ncld) = cfac * RQI(i,j,:)
+                  clwp(:,ncld) = cfac * RQL(i,j,:)
+
+                  ! interior interface temperatures
+                  ! * "0-based" but extema at 0 and LM not needed for zmid;
+                  ! * RRTMG call code uses layer delP (DPR) but any multiple
+                  ! of it, specifically cfac, is equivalent.
+
+                  tlev = (T(i,j,1:LM-1) * cfac(2:LM) + T(i,j,2:LM) * cfac(1:LM-1)) &
+                       / (                cfac(2:LM) +               cfac(1:LM-1))
+
+                  ! Calculate the LAYER (mid-point) heights.
+                  ! The interlayer distances are needed for the calculations
+                  ! of inter-layer correlation for cloud overlapping. Only
+                  ! *relative* distances matter, so wolog set zmid(LM) = 0.
+                  zmid(LM,ncld) = 0.
+                  do k = LM-1, 1, -1
+                     ! dz ~ RT/g x dp/p by hysrostatic eqn and ideal gas eqn.
+                     ! The jump from LAYER k+1 to k is centered on LEVEL k
+                     !   since the LEVEL indices are zero-based
+                     zmid(k,ncld) = zmid(k+1,ncld) + MAPL_RGAS * tlev(k) / MAPL_GRAV &
+                                        * (plmid(k+1) - plmid(k)) / PLL(i,j,k)
+                  end do
+
+               end if ! cloudy column
+               
+               ! nothing to process yet?
+               if (ncld == 0) cycle
+
+               ! process the partition?
+               if (ncld == pncol               & ! partition is full so process
+                   .or. i == IM .and. j == JM  & ! partition is partially full
+                                               &     but no more gridcolumns
+                                               &     so process what have.
+                  ) then
+
+                  ! McICA subcolumn generation
+                  call generate_stochastic_clouds( &
+                     pncol, ncld, ngptsw, LM, &
+                     zmid, alat, doy, &
+                     play, cldfrac, ciwp, clwp, 1.e-20, &
+                     cldymcl, ciwpmcl, clwpmcl, &
+                     seed_order=[4,3,2,1])
+
+                  ! for super-layer cloud fractions
+                  call clearCounts_threeBand( &
+                     pncol, ncld, ngptsw, LM, LCLDLM, LCLDMH, cldymcl, &
+                     clearCounts)
+
+                  ! convert super-layer clearCounts to cloud fractions
+                  if (associated(CLDTTSWHB)) then
+                     do n = 1,ncld
+                        CLDTTSWHB(icld(n),jcld(n)) = 1. - clearCounts(n,1)/float(ngptsw)
+                     end do
+                  end if
+                  if (associated(CLDHISWHB)) then
+                     do n = 1,ncld
+                        CLDHISWHB(icld(n),jcld(n)) = 1. - clearCounts(n,2)/float(ngptsw)
+                     end do
+                  end if
+                  if (associated(CLDMDSWHB)) then
+                     do n = 1,ncld
+                        CLDMDSWHB(icld(n),jcld(n)) = 1. - clearCounts(n,3)/float(ngptsw)
+                     end do
+                  end if
+                  if (associated(CLDLOSWHB)) then
+                     do n = 1,ncld
+                        CLDLOSWHB(icld(n),jcld(n)) = 1. - clearCounts(n,4)/float(ngptsw)
+                     end do
+                  end if
+
+                  ! restart partition
+                  ncld = 0
+
+               end if  ! process partition
+
+            end do ! i
+         end do ! j
+
+         ! clean up
+         deallocate(icld,jcld,__STAT__)
+         deallocate(zmid,alat,play,cldfrac,ciwp,clwp,__STAT__)
+         deallocate(cldymcl,ciwpmcl,clwpmcl,__STAT__)
+         deallocate(clearCounts,__STAT__)
+
       end if
 
       if (associated(TAUI) .or. associated(TAUW) .or. associated(TAUR) .or. associated(TAUS).or. &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -938,6 +938,20 @@ contains
        DIMS       = MAPL_DimsHorzOnly,                                       &
        VLOCATION  = MAPL_VLocationNone,                                __RC__)
 
+! Note: the four CLDxxSW diagnostics below represent super-layer cloud
+! fractions based on the subcolumn cloud generation called in RRTMG SW.
+! They are sunlit only fields and generated only at the SW REFRESH frequency,
+! NOT at the heartbeat. As such, they are useful for diagnostic comparisons
+! with with the full CLDxx set above. But they should NOT be used to subsample
+! fields that are produced on the model heartbeat (e.g. subsampling for cloud
+! presence). Note, also, that when comparing CLDxxSW with CLDxx, it is better
+! to subsample both with COSZSW >= cmin, (e.g., 0.25). This COSZSW is a 
+! REFRESH-frequency version of MCOSZ and, as such, is most appropriate for
+! subsampling REFRESH-frequency fields like CLDxxSW. Of course, you can also
+! subsample CLDxx with COSZSW since CLDxx are global. By sampling both
+! CLDxxSW and CLDxx with COSZSW you get a fair apples-to-apples comparison
+! between the two.
+
     call MAPL_AddExportSpec(GC,                                              &
         SHORT_NAME = 'CLDTTSW',                                              &
         LONG_NAME  = 'total_cloud_area_fraction_rrtmg_sw_REFRESH',           &
@@ -965,6 +979,22 @@ contains
         UNITS      = '1',                                                    &
         DIMS       = MAPL_DimsHorzOnly,                                      &
         VLOCATION  = MAPL_VLocationNone,                              __RC__ )
+
+! Note: the four CLDxxSWHB diagnostics below represent super-layer cloud
+! fractions based on essentially the same subcolumn cloud generation used
+! by RRTMG SW but called from within the SOLAR UPDATE at the HEARTBEAT.
+! They are GLOBAL (not just sunlit) fields and generated on the heartbeat.
+! But because subcolumn cloud generation is EXPENSIVE, asking for any of 
+! these exports will DOUBLE the cost of running the SOLAR GC. As such,
+! they are for SPECIAL VALIDATION PURPOSES ONLY. No cost is incurred if
+! they are not exported. Note, also, that they are NOT EXACTLY heartbeat
+! versions of CLDxxSW, since they sample the heartbeat cloud fractions
+! not the less frequent snapshots used at REFRESH-frequency, and also since
+! the generation inside UPDATE is on non-flipped vertical fields. This latter
+! difference should be statistically insignificant. A re-coding to use vert-
+! ically flipped fields as per RRTMG SW is possible but will be slightly
+! slower, and was deemed not necessary since the first cloud fraction
+! frequency difference will likely dominate.
 
     call MAPL_AddExportSpec(GC,                                              &
         SHORT_NAME = 'CLDTTSWHB',                                            &
@@ -1056,6 +1086,10 @@ contains
        SHORT_NAME = 'TAUCLS',                                                &
        DIMS       = MAPL_DimsHorzVert,                                       &
        VLOCATION  = MAPL_VLocationCenter,                              __RC__)
+
+! Note: The following four TAUxxPAR are REFRESH-frequency fields. As such, all
+! the important provisos given in the comment on CLDxxSW above apply to these
+! fields as well. Please read those provisos.
 
     call MAPL_AddExportSpec(GC,                                                      &
        LONG_NAME  = 'in_cloud_optical_thickness_of_low_clouds_RRTMG_PAR_REFRESH',    &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/RRTMG/rrtmg_sw/gcm_model/src/rrtmg_sw_cldprmc.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/RRTMG/rrtmg_sw/gcm_model/src/rrtmg_sw_cldprmc.F90
@@ -52,10 +52,10 @@ contains
       integer, intent(in) :: liqflag         ! see definitions
 
       logical, intent(in) :: cldymc (nlay,ngptsw,pncol)  ! cloudy or not? [mcica]
-      real,    intent(in) :: ciwpmc (nlay,ngptsw,pncol)  ! cloud ice water path [mcica]
-      real,    intent(in) :: clwpmc (nlay,ngptsw,pncol)  ! cloud liq water path [mcica]
-      real,    intent(in) :: relqmc (nlay,pncol)         ! cloud liq ptle eff radius (um)
-      real,    intent(in) :: reicmc (nlay,pncol)         ! cloud ice ptle eff radius (um)
+      real,    intent(in) :: ciwpmc (nlay,ngptsw,pncol)  ! cloud ice water path [mcica] [g/m2]
+      real,    intent(in) :: clwpmc (nlay,ngptsw,pncol)  ! cloud liq water path [mcica] [g/m2]
+      real,    intent(in) :: relqmc (nlay,pncol)         ! cloud liq ptle eff radius [um]
+      real,    intent(in) :: reicmc (nlay,pncol)         ! cloud ice ptle eff radius [um]
 
       ! Specific definition of reicmc depends on iceflag:
       ! iceflag = 1: ice effective radius, r_ec, (Ebert and Curry, 1992),
@@ -92,6 +92,16 @@ contains
       real, dimension (nlay,ngptsw,pncol) :: &
          extcoice, gice, ssacoice, forwice, &
          extcoliq, gliq, ssacoliq, forwliq
+
+      ! Notes by PMN:
+      ! The optical properties per unit ice (liquid) amount (e.g., extcoice)
+      ! are currently per band only but are redundantly re-calculated for
+      ! each g-point in the band that has non-zero mcica ice (liquid) amount.
+      ! This is inefficient if two or more band g-points have ice (liquid).
+      ! I have resisted the urge to remove this inefficiency because a future
+      ! improvement may well McICA-generate an ice (liquid) effective radius
+      ! that covaries with the condensate amount. In this more general case,
+      ! extcoice, etc., will vary with g-point within a band.
 
       ! ---------------------------------------------------------
       ! Calculation of absorption coefficients due to ice clouds.


### PR DESCRIPTION
This is a PR to add extra diagnostic cloud fractions and in-cloud optical depths  (on the column and the low/mid/high super-layers) that use the cloud sub-column generator actually called by RRTMG SW/LW rather than the MAX-RAN cloud overlap assumed by Chou-Suarez and ISCCP. There are important provisos noted in comments in the EXPORT definitions section of the Solar and Irrad Set_Services as to the use of these diagnostics.

The PR contains two main elements:
1. The existing TAUTT is marked as DEPRECATED since it is **in error** and an improved TAUTTX export is added and should replace use of TAUTT.
2.  As in the description above CLDxxLW, CLDxxSW, CLDxxSWHB, and TAUxxPAR are added as new diagnostic exports.

Note on 0-diff: These changes are essentially zero-diff. The only field that is non-zero-diff is TAUTT and it is only changed to roundoff level (~1e-5) for efficiency purposes. The model evolution is zero-diff since TAUTT is a diagnostic export only. The other new exports are also diagnostic and do not affect the model state.