### PR TITLE
Simple fix to prevent negative tauaer in RRTMG LW

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -3283,7 +3283,11 @@ contains
             ! aerosol system's *un*-normalized single scattering albedo,
             ! which is actually tau_ext * omega0 = tau_scat, and TAUA
             ! is the aerosol extinction optical thickness.
-            TAUAER(IJ,K,:) = TAUA(I,J,LV,:) - SSAA(I,J,LV,:)
+            ! PMN 2022-01-19 Added max(,0.) ... it shouldn't happen
+            !   that tau_ext < tau_scat, but since these TAUA and SSAA
+            !   come directly from the radiatively active aerosols
+            !   system, we provide a simple mitigation here.
+            TAUAER(IJ,K,:) = max(TAUA(I,J,LV,:) - SSAA(I,J,LV,:), 0.)
 
          enddo
 


### PR DESCRIPTION
RRTMG LW does not scatter and so it must extract the absorption aerosol optical depth. This should be taua_ext - taua_scat, which in the parlance of the un-normalized radiation variables in the RRTMG LW section is TAUA - SSAA.
Unfortunately this difference is sometimes a small negative value. **This is not the fault of the Radiation GC, since it gets these two variables directly by callback to the aerosol system. It should really be fixed on the aerosol side, but as a simple mitigation for now, we make the fix max(TAUA - SSAA, 0.).**