### PR TITLE
Update MOM6 after https://github.com/mom-ocean/MOM6/pull/1556 is merged

### DIFF
--- a/GEOSogcm_GridComp/GEOS_OceanGridComp/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOS_OceanGridComp/MOM6_GEOSPlug/mom6_cmake/CMakeLists.txt
@@ -61,6 +61,7 @@ list( APPEND MOM6_SRCS
    src/core/MOM_unit_tests.F90
    src/core/MOM_variables.F90
    src/core/MOM_verticalGrid.F90
+   src/core/MOM_porous_barriers.F90
    src/diagnostics/MOM_debugging.F90
    src/diagnostics/MOM_diagnostics.F90
    src/diagnostics/MOM_obsolete_diagnostics.F90
@@ -181,6 +182,7 @@ list( APPEND MOM6_SRCS
    src/parameterizations/vertical/MOM_sponge.F90
    src/parameterizations/vertical/MOM_tidal_mixing.F90
    src/parameterizations/vertical/MOM_vert_friction.F90
+   src/parameterizations/stochastic/MOM_stochastics.F90 
    src/tracer/advection_test_tracer.F90
    src/tracer/boundary_impulse_tracer.F90
    src/tracer/DOME_tracer.F90
@@ -481,6 +483,8 @@ list( APPEND MOM6_SRCS
    # drifters-particles
    config_src/external/drifters/MOM_particles.F90
    config_src/external/drifters/MOM_particles_types.F90
+   # stochastic physics
+   config_src/external/stochastic_physics/stochastic_physics.F90
 )
 
 


### PR DESCRIPTION
This is currently a note to myself (@sanAkel). 

It should be `undrafted` after: @marshallward and co. have finished merging https://github.com/mom-ocean/MOM6/pull/1556 into `dev/gfdl`

In order for [GEOS-ESM](https://github.com/GEOS-ESM) to use ⬆️ following sequence of steps need to happen in this order:
1. @sanAkel make a new release of [GEOS-MOM6](https://github.com/GEOS-ESM/MOM6) ✅ https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.3
3. Simultaneously **undraft** _this_ PR ➡️  this will update our `cMakeLists.txt` to build MOM6.
4. PR in [GEOSgcm](https://github.com/GEOS-ESM/GEOSgcm) to uptick MOM6 [version number](https://github.com/GEOS-ESM/GEOSgcm/blob/main/components.yaml)
5. Also for @sanAkel, all [configs of MOM6 for GEOS](https://github.com/GEOS-ESM/GEOSgcm_GridComp/tree/develop/GEOSogcm_GridComp/GEOS_OceanGridComp/MOM6_GEOSPlug/mom6_app) need to be updated/sync'ed in with the _right_ defaults.

@mathomp4 heads up: for _known_ reasons (bugfixes and improvements: changes in default values of parameters, see https://github.com/mom-ocean/MOM6/pull/1556) this code will be non-zero difference (from the way _we_ currently run). Affects **only** the MOM6 based GEOS AOGCM. I would certainly need your help with above 1 (maybe!) and 3 certainly! 🙏 