### PR TITLE
bug fix: units of RUNSRF in Catchment

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
@@ -1772,7 +1772,9 @@
           ENDIF
 
         IF(CATDEF(N) .LT. 0.) THEN
-          RUNSRF(N)=RUNSRF(N)-CATDEF(N)
+          ! bug fix: RUNSRF in flux units (kg m-2 s-1) for consistency with partition()
+          ! reichle, 5 Feb 2022
+          RUNSRF(N)=RUNSRF(N)-CATDEF(N)/DTSTEP   
           CATDEF(N)=0.
           ENDIF
 


### PR DESCRIPTION
Fixes units of RUNSRF and cleans up units of throughfall (THRU[x]) in catchment.F90 and lsm_routines.F90.

**Problem:**

Water fluxes in catchment() are in units of kg m-2 s-1 except RUNSRF:
RUNSRF is in [kg m-2 s-1] into and out of subroutine partition().
Next, RUNSRF is assumed to be in "volume" units [kg m-2] into and out of subroutine rzdrain().   
Finally, RUNSRF units going into subroutine srunoff() are [kg m-2] but returned in [kg m-2 s-1].

Also, subroutine interc() has precipitation inputs in flux units [kg m-2 s-1] and returns throughfall in as "volume" [kg m-2].

See attached Word docx for notes.

**Tentative Solution:**

This PR changes the units of RUNSRF and THRU[x] for all input and output arguments to be in flux units [kg m-2 s-1].   
The calculations within subroutine srunoff() remain in volume units.

The RUNSRF changes should be trivially zero-diff assuming roundoff changes in diagnostic outputs are still considered zero-diff.

The added THRU[x] unit conversions appear to be non-zero-diff.    (pending further investigation)

[WATER_FLUXES_UNITS_IN_CATCHMENT.docx](https://github.com/GEOS-ESM/GEOSgcm_GridComp/files/8009108/WATER_FLUXES_UNITS_IN_CATCHMENT.docx)

