### PR TITLE
Feature/jkolassa/gndtmp cn cleanup

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/GEOS_CatchCNCLM40GridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/GEOS_CatchCNCLM40GridComp.F90
@@ -61,7 +61,8 @@ module GEOS_CatchCNCLM40GridCompMod
   use MAPL_ConstantsMod,only: Tzero => MAPL_TICE, pi => MAPL_PI 
   use clm_time_manager, only: get_days_per_year, get_step_size
   use pftvarcon,        only: noveg
-  USE lsm_routines,     ONLY : sibalb, catch_calc_soil_moist, irrigation_rate
+  USE lsm_routines,     ONLY : sibalb, catch_calc_soil_moist, irrigation_rate, &
+                               gndtmp
 
 implicit none
 private
@@ -6547,7 +6548,7 @@ call catch_calc_soil_moist( ntiles, veg1, dzsf, vgwmax, cdcr1, cdcr2, psis, bee,
 ! -----------------
       zbar = -sqrt(1.e-20+catdef(n)/bf1(n))+bf2(n)
       HT(:)=GHTCNT(:,N)
-      CALL GNDTMP_CN(poros(n),zbar,ht,frice,tp,soilice)
+      CALL GNDTMP(poros(n),zbar,ht,frice,tp,soilice)
 
       ! At the CatchCNGridComp level, tp1, tp2, .., tp6 are export variables in units of Kelvin,
       ! - rreichle & borescan, 6 Nov 2020

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/GEOS_CatchCNCLM45GridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/GEOS_CatchCNCLM45GridComp.F90
@@ -61,7 +61,8 @@ module GEOS_CatchCNCLM45GridCompMod
   use MAPL_ConstantsMod,only: Tzero => MAPL_TICE, pi => MAPL_PI 
   use clm_time_manager, only: get_days_per_year, get_step_size
   use pftvarcon,        only: noveg
-  USE lsm_routines,     ONLY : sibalb, catch_calc_soil_moist, irrigation_rate
+  USE lsm_routines,     ONLY : sibalb, catch_calc_soil_moist, irrigation_rate, &
+                               gndtmp
   use update_model_para4cn, only : upd_curr_date_time
 
 implicit none
@@ -6622,7 +6623,7 @@ call catch_calc_soil_moist( ntiles, veg1, dzsf, vgwmax, cdcr1, cdcr2, psis, bee,
 ! -----------------
       zbar = -sqrt(1.e-20+catdef(n)/bf1(n))+bf2(n)
       HT(:)=GHTCNT(:,N)
-      CALL GNDTMP_CN(poros(n),zbar,ht,frice,tp,soilice)
+      CALL GNDTMP(poros(n),zbar,ht,frice,tp,soilice)
 
       ! At the CatchCNGridComp level, tp1, tp2, .., tp6 are export variables in units of Kelvin,
       ! - rreichle & borescan, 6 Nov 2020

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
@@ -1062,9 +1062,9 @@ CONTAINS
         FH21=-GHFLUX(N)
 
         CALL GNDTMP(                                                           &
-              DTS=dtstep,phi,zbar,THETAF=thetaf,FH21=fh21,                     &
+              phi,zbar,                                                        &
               ht,                                                              &
-              xfice,tp, soilice)
+              xfice,tp, soilice,DTS=dtstep,THETAF=thetaf,FH21=fh21)
 
         DO LAYER=1,6
           GHTCNT(LAYER,N)=HT(LAYER)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
@@ -1062,7 +1062,7 @@ CONTAINS
         FH21=-GHFLUX(N)
 
         CALL GNDTMP(                                                           &
-              dtstep,phi,zbar,thetaf,fh21,                                     &
+              DTS=dtstep,phi,zbar,THETAF=thetaf,FH21=fh21,                     &
               ht,                                                              &
               xfice,tp, soilice)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
@@ -121,7 +121,6 @@ MODULE CATCHMENT_CN_MODEL
   public :: catchcn_calc_tsurf
   public :: catchcn_calc_tsurf_excl_snow
   public :: catchcn_calc_etotl
-  public :: gndtmp_cn
 
   ! -----------------------------------------------------------------------------
   
@@ -2429,111 +2428,6 @@ CONTAINS
 !**** -----------------------------------------------------------------
 !**** /////////////////////////////////////////////////////////////////
 !**** -----------------------------------------------------------------
-
-      subroutine gndtmp_cn(poros, zbar, ht, xfice, tp, FICE)                                              
-
-      REAL, INTENT(IN) :: POROS, ZBAR
-
-      REAL, INTENT(IN), DIMENSION(*) :: HT
-
-      REAL, INTENT(OUT) :: XFICE
-      REAL, INTENT(OUT), DIMENSION(*) :: TP, FICE
-
-      INTEGER L, LSTART, K
-      REAL, DIMENSION(N_GT) :: SHC
-
-      REAL, DIMENSION(N_GT+1) :: FH, ZB
-      REAL SHW0, SHI0, SHR0, WS, XW, PHI
-
-      !data dz/0.0988,0.1952,0.3859,0.7626,1.5071,10.0/
-      !DATA PHI/0.45/, FSN/3.34e+8/, SHR/2.4E6/        
-
-! initialize parameters
-
-      shw0=SHW*1000. ! PER M RATHER THAN PER KG 
-      shi0=SHI*1000. ! PER M RATHER THAN PER KG 
-      shr0=SHR*1000. ! PER M RATHER THAN PER KG [kg of water equivalent density]
-
-      if (PHIGT<0.) then ! if statement for bkwd compatibility w/ off-line MERRA replay
-         phi=poros
-       else
-         phi=PHIGT
-      end if
-
-!----------------------------------
-! initialize fice in ALL components
-! reichle, July 8, 2002            
-
-      do l=1,N_GT
-        fice(l)=0.0  
-        enddo        
-!----------------------------------
-
-! calculate the boundaries, based on the layer thicknesses(DZGT)
-
-      zb(1)=-0.05    ! Bottom of surface layer, which is handled outside
-                    ! this routine.
-      do l=1,N_GT
-        zb(l+1)=zb(l)-DZGT(l)
-        shc(l)=SHR0*(1-phi)*DZGT(l)
-        enddo
-
- 
-! evaluates the temperatures in the soil layers based on the heat values.  
-!             ***********************************                          
-!             input:                                                       
-!             xw - water in soil layers, m                                 
-!             ht - heat in soil layers                                     
-!             fsn - heat of fusion of water   J/m                              
-!             shc - specific heat capacity of soil                         
-!             shi - specific heat capacity of ice                          
-!             shw - specific heat capcity of water                         
-!             snowd - snow depth, equivalent water m                       
-!             output:                                                      
-!             tp - temperature of layers, c                                
-!             fice - fraction of ice of layers                             
-!             pre - extra precipitation, i.e. snowmelt, m s-1              
-!             snowd - snow depth after melting, equivalent water m.        
-!             ***********************************                          
-! determine fraction of ice and temp of soil layers based on layer         
-! heat and water content                                                   
-
-      do 10 k=1,N_GT
-        ws=phi*DZGT(k)  ! PORE SPACE IN LAYER
-        xw=0.5*ws   ! ASSUME FOR THESE CALCULATIONS THAT THE PORE SPACE
-                    ! IS ALWAYS HALF FILLED WITH WATER.  XW IS THE     
-                    ! AMOUNT OF WATER IN THE LAYER.                    
-        tp(k)=0.                                                       
-        fice(k)= AMAX1( 0., AMIN1( 1., -ht(k)/(fsn*xw) ) )             
-
-        IF(FICE(K) .EQ. 1.) THEN
-            tp(k)=(ht(k)+xw*fsn)/(shc(k)+xw*shi0)
-          ELSEIF(FICE(K) .EQ. 0.) THEN           
-            tp(k)=ht(k)/(shc(k)+xw*shw0)         
-          ELSE                                   
-            TP(K)=0.                             
-          ENDIF                                  
-    10  continue
-
-! determine the value of xfice
-      xfice=0.0
-
-      lstart=N_GT
-      DO L=N_GT,1,-1
-         IF(ZBAR .GE. ZB(L+1))THEN
-            LSTART=L
-            ENDIF
-         ENDDO   
-
-      do l=lstart,N_GT
-         xfice=xfice+fice(l)
-         enddo
-      xfice=xfice/((N_GT+1)-lstart)      
-
-      Return
-      end subroutine gndtmp_cn
-  
-  
   ! *******************************************************************
 
   subroutine catchcn_calc_tsurf( NTILES, tc1, tc2, tc4, wesnn, htsnn,    &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
@@ -74,8 +74,6 @@ MODULE CATCHMENT_CN_MODEL
        TF                => MAPL_TICE,   &  ! K                       
        RGAS              => MAPL_RGAS,   &  ! J/(kg K)                
        CPAIR             => MAPL_CP,     &  ! J/(kg K)
-       SHW               => MAPL_CAPWTR, &  ! J/kg/K  spec heat of wat
-       SHI               => MAPL_CAPICE, &  ! J/kg/K  spec heat of ice
        EPSILON           => MAPL_EPSILON 
   
   USE CATCH_CONSTANTS,   ONLY:                   &
@@ -87,7 +85,6 @@ MODULE CATCHMENT_CN_MODEL
        SLOPE             => CATCH_SNWALB_SLOPE,  &
        MAXSNDEPTH        => CATCH_MAXSNDEPTH,    &
        DZ1MAX            => CATCH_DZ1MAX,        &  
-       SHR               => CATCH_SHR,           &
        SCONST            => CATCH_SCONST,        &
        C_CANOP           => CATCH_C_CANOP,       &
        N_sm              => CATCH_N_ZONES,       &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
@@ -1059,7 +1059,7 @@
         FH21=-GHFLUX(N)
 
         CALL GNDTMP(                                                           &
-              dtstep,phi,zbar,thetaf,fh21,                                     &
+              DTS=dtstep,phi,zbar,THETAF=thetaf,FH21=fh21,                     &
               ht,                                                              &
               xfice,tp, soilice)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
@@ -1059,9 +1059,9 @@
         FH21=-GHFLUX(N)
 
         CALL GNDTMP(                                                           &
-              DTS=dtstep,phi,zbar,THETAF=thetaf,FH21=fh21,                     &
+              phi,zbar,                                                        &
               ht,                                                              &
-              xfice,tp, soilice)
+              xfice,tp, soilice,DTS=dtstep,THETAF=thetaf,FH21=fh21)
 
         DO LAYER=1,6
           GHTCNT(LAYER,N)=HT(LAYER)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
@@ -1604,6 +1604,7 @@ CONTAINS
       REAL, DIMENSION(N_GT+1) :: FH, ZB
       REAL SHW0, SHI0, SHR0, WS, XW, A1, TK1, A2, TK2, TK3, TKSAT,      &
            XWI, XD1, XD2, XKTH, TKDRY
+      REAL :: phi
 
       !data dz/0.0988,0.1952,0.3859,0.7626,1.5071,10.0/
       !DATA PHI/0.45/, FSN/3.34e+8/, SHR/2.4E6/

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
@@ -1574,7 +1574,7 @@ CONTAINS
 
   ! *******************************************************************
 
-      subroutine gndtmp(dts,phi_in,zbar,thetaf,fh21,ht,xfice,tp, FICE)
+      subroutine gndtmp(phi_in,zbar,ht,xfice,tp,FICE,dts,thetaf,fh21)
 ! using a diffusion equation this code generates ground temperatures
 ! with depth given t1
 !            *****************************************

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
@@ -1574,26 +1574,24 @@ CONTAINS
 
   ! *******************************************************************
 
-      subroutine gndtmp(dts,phi,zbar,thetaf,fh21,ht,xfice,tp, FICE)
+      subroutine gndtmp(dts,phi_in,zbar,thetaf,fh21,ht,xfice,tp, FICE)
 ! using a diffusion equation this code generates ground temperatures
 ! with depth given t1
 !            *****************************************
 !        input
 !        dts     timestep in seconds
-!        phi     porosity
-!        t1      terrestrial (layer 1) temperature in deg C
+!        phi_in  porosity
 !        zbar    mean depth to the water table.
 !        thetaf  mean vadose zone soil moisture factor (0-1)
 !        output,
 !        ht      heat content in layers 2-7
 !        tp      ground temperatures in layers 2-7
-!        tdeep   the temperature of the "deep"
 !        f21     heat flux between layer 2 and the terrestrial layer (1)
-!        df21    derivative of f21 with respect to temperature
 !        xfice   a total soil column ice factor (0-1)
+!        FICE    soil ice
 !             ***********************************
 
-      REAL, INTENT(IN) :: phi, ZBAR
+      REAL, INTENT(IN) :: phi_in, ZBAR
       REAL, INTENT(IN), OPTIONAL :: DTS, THETAF, FH21
 
       REAL, INTENT(INOUT), DIMENSION(*) :: HT
@@ -1616,7 +1614,9 @@ CONTAINS
       shi0=SHI*1000. ! PER M RATHER THAN PER KG
       shr0=SHR*1000. ! PER M RATHER THAN PER KG [kg of water equivalent density]
 
-      if (.NOT. PRESENT (DTS)) then ! jkolassa Jan 2022: the following code block was previously only present in gndtmp_cn, so including it conditionally here
+      if (PRESENT (DTS)) then ! jkolassa Jan 2022: the bkwd compatibility code block was previously only present in gndtmp_cn, so including it conditionally here
+         phi = phi_in
+      else
          if (PHIGT<0.) then ! if statement for bkwd compatibility w/ off-line MERRA replay
             phi=poros
          else 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
@@ -1619,7 +1619,7 @@ CONTAINS
          phi = phi_in
       else
          if (PHIGT<0.) then ! if statement for bkwd compatibility w/ off-line MERRA replay
-            phi=poros
+            phi=phi_in
          else 
             phi=PHIGT
          end if


### PR DESCRIPTION
This PR addresses issue #530 and involves a cleanup of subroutines `gndtmp` and `gdntmp_cn`. 

Subroutine `gndtmp` was modified to make several input arguments optional and make parts of the code dependent on the presence of these optional input arguments. As a result `gndtmp` can now be called instead of `gndtmp_cn` while still retaining all previous functionality. The now obsolete subroutine `gndtmp_cn` was removed. 

Two points to note/discuss:

1. I had to change the order of the input arguments in `gndtmp` in order to avoid having to make all inputs keyword arguments. I have updated all calls to `gndtmp` accordingly. If the preference is that the input order remains the same, I can make the necessary changes, but it will mean that all input arguments have to be passed as keyword arguments.
2. This branch has been created from 'develop' and as a result it does not contain the changes to `gndtmp(_cn)` and the temperature variable names that have been implemented as part of the peat PR. Depending on when each PR is expected to be merged, I can include the changes that were made in the peat PR here.

I have tested this new branch in 3 one-month **offline** experiments using Catchment, Catchment-CN4.0 and Catchment-CN4.5. For all three experiments the model outputs after one month were zero-diff with respect to a simulation generated with 'develop'. I have not run any coupled simulations.