### PR TITLE
Hotfix to maintain backward compatibility for reading CatchmentCNCLM45 bcs file in generation of CatchmentCNCLM45 restarts

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_GEOSldasRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_GEOSldasRestarts.F90
@@ -1421,7 +1421,7 @@ contains
           if(clm45) then
             open(unit=30, file=trim(DataDir)//'CLM4.5_abm_peatf_gdp_hdm_fc' ,form='formatted')
             do n=1,ntiles
-              read (30,'(2I10, i3, f8.4, f8.2, f10.2, f8.4)' ) i, j, abm(n), peatf(n), &
+              read (30, *) i, j, abm(n), peatf(n), &
                      gdp(n), hdm(n), fc(n)
             end do
             CLOSE (30, STATUS = 'KEEP')
@@ -1478,7 +1478,7 @@ contains
                 read (29, *) i,j, CLMC45_pt1(n), CLMC45_pt2(n), CLMC45_st1(n), CLMC45_st2(n), &
                      CLMC45_pf1(n), CLMC45_pf2(n), CLMC45_sf1(n), CLMC45_sf2(n)
                 
-                read (30,'(2I10, i3, f8.4, f8.2, f10.2, f8.4)' ) i, j, abm(n), peatf(n), &
+                read (30, *) i, j, abm(n), peatf(n), &
                      gdp(n), hdm(n), fc(n)
              endif
           endif          


### PR DESCRIPTION
This PR  introduces a fix for a bug that impacts the generation of restart files for the Catchment-CN4.5 land model. The fix ensures backward compatibility of Catchment-CN4.5 with older boundary condition files, while preserving full functionality with new boundary condition files.

The change only impacts Catchment-CN4.5 and is trivially 0-diff for all other model configurations.

The new branch was tested with Catchment-CN4.5 to verify that restart files are now generated correctly. It was also tested using the GEOSldas nightly test suite and was able to pass all tests successfully.

cc: @gmao-rreichle , @biljanaorescanin , @weiyuan-jiang 


