### PR TITLE
Updates to support Spack

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
@@ -19,5 +19,4 @@ set (srcs
   ncar_gwd/gw_drag.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GEOS_Shared MAPL)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GEOS_Shared MAPL esmf NetCDF::NetCDF_Fortran)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/RRTMG/rrtmg_sw/gcm_model/src/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOSsolar_GridComp/RRTMG/rrtmg_sw/gcm_model/src/CMakeLists.txt
@@ -40,7 +40,6 @@ foreach (file ${k_g_srcs})
 endforeach ()
 
 esma_add_library (${this} SRCS ${srcs} ${k_g_srcs}
-   DEPENDENCIES GEOS_Shared MAPL RRTMG_SW_mods GEOS_RadiationShared)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+  DEPENDENCIES GEOS_Shared MAPL RRTMG_SW_mods GEOS_RadiationShared esmf NetCDF::NetCDF_Fortran)
 
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CLM40/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CLM40/CMakeLists.txt
@@ -39,9 +39,8 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared GEOS_CatchCNShared
+  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared GEOS_CatchCNShared esmf NetCDF::NetCDF_Fortran
   TYPE SHARED)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 if (is_openmp)
   target_compile_options(${this} PRIVATE ${OpenMP_Fortran_FLAGS})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CMakeLists.txt
@@ -10,9 +10,8 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared CLM40 GEOS_CatchCNShared
+  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared CLM40 GEOS_CatchCNShared esmf NetCDF::NetCDF_Fortran
   TYPE SHARED)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 if (is_openmp)
   target_compile_options(${this} PRIVATE ${OpenMP_Fortran_FLAGS})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CMakeLists.txt
@@ -30,8 +30,8 @@ set (srcs
   CNPrecisionControlMod.F90
   CNSetValueMod.F90
   CNVegStructUpdateMod.F90
-  CNVerticalProfileMod.F90    
-  CNSoilLittVertTranspMod.F90 
+  CNVerticalProfileMod.F90
+  CNSoilLittVertTranspMod.F90
   CNWoodProductsMod.F90
   CNSummaryMod.F90
   CNEcosystemDynMod.F90
@@ -46,9 +46,8 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_LandShared GEOS_CatchCNShared 
+  DEPENDENCIES MAPL GEOS_LandShared GEOS_CatchCNShared esmf NetCDF::NetCDF_Fortran
   TYPE SHARED)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 if (is_openmp)
   target_compile_options(${this} PRIVATE ${OpenMP_Fortran_FLAGS})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CMakeLists.txt
@@ -10,9 +10,8 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared CLM45 GEOS_CatchCNShared
+  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared CLM45 GEOS_CatchCNShared esmf NetCDF::NetCDF_Fortran
   TYPE SHARED)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 if (is_openmp)
   target_compile_options(${this} PRIVATE ${OpenMP_Fortran_FLAGS})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/CMakeLists.txt
@@ -3,11 +3,10 @@ esma_set_this ()
 set (srcs
   GEOS_CatchGridComp.F90
   catchment.F90
-  catch_incr.F90         
+  catch_incr.F90
   )
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_LandShared)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+  DEPENDENCIES MAPL GEOS_LandShared esmf NetCDF::NetCDF_Fortran)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/CMakeLists.txt
@@ -5,9 +5,6 @@ set (srcs
    routing_model.F90
   )
 
-include_directories (${INC_ESMF} ${INC_NETCDF})
-
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
 
 install(PROGRAMS build_rivernetwork.py DESTINATION bin)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSvegdyn_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSvegdyn_GridComp/CMakeLists.txt
@@ -1,5 +1,4 @@
 esma_set_this ()
 
-esma_add_library (${this} SRCS GEOS_VegdynGridComp.F90 DEPENDENCIES MAPL)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+esma_add_library (${this} SRCS GEOS_VegdynGridComp.F90 DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/CMakeLists.txt
@@ -2,6 +2,5 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS GEOS_LandIceGridComp.F90
-  DEPENDENCIES MAPL GEOS_Shared GEOS_SurfaceShared
+  DEPENDENCIES MAPL GEOS_Shared GEOS_SurfaceShared esmf NetCDF::NetCDF_Fortran
   )
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/CMakeLists.txt
@@ -7,6 +7,5 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES GEOS_Shared MAPL CICE4)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+  DEPENDENCIES GEOS_Shared MAPL CICE4 esmf NetCDF::NetCDF_Fortran)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/CMakeLists.txt
@@ -1,28 +1,24 @@
 esma_set_this(OVERRIDE raster)
 set (srcs
-date_time_util.F90 
-leap_year.F90 
-easeV1_conv.F90   
+date_time_util.F90
+leap_year.F90
+easeV1_conv.F90
 mod_process_hres_data.F90
-easeV2_conv.F90  
+easeV2_conv.F90
 rasterize.F90
 read_riveroutlet.F90
-CubedSphere_GridMod.F90 
+CubedSphere_GridMod.F90
 rmTinyCatchParaMod.F90
 comp_CATCHCN_AlbScale_parameters.F90
 zip.c
 util.c
-)  
+)
 
 if(NOT FORTRAN_COMPILER_SUPPORTS_FINDLOC)
    list(APPEND srcs findloc.F90)
 endif ()
 
-include_directories(${INC_ESMF})
-include_directories(${INC_NETCDF})
-
-esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL GEOS_LandShared)
-target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran OpenMP::OpenMP_C)
+esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL GEOS_LandShared esmf NetCDF::NetCDF_Fortran OpenMP::OpenMP_Fortran OpenMP::OpenMP_C)
 
 if(NOT FORTRAN_COMPILER_SUPPORTS_FINDLOC)
    target_compile_definitions(${this} PRIVATE USE_EXTERNAL_FINDLOC)
@@ -31,14 +27,17 @@ endif ()
 # MAT NOTE This should use find_package(ZLIB) but Baselibs currently
 #     confuses find_package(). This is a hack until Baselibs is
 #     reorganized.
-set (INC_ZLIB ${BASEDIR}/include/zlib)
-target_include_directories(${this} PRIVATE ${INC_ZLIB})
+if (Baselibs_FOUND)
+  set (INC_ZLIB ${BASEDIR}/include/zlib)
+  target_include_directories(${this} PRIVATE ${INC_ZLIB})
+else ()
+  find_package(ZLIB)
+  target_link_libraries(${this} PRIVATE ZLIB::zlib)
+endif ()
 
 ecbuild_add_executable (TARGET chk_clsm_params.x SOURCES chk_clsm_params.F90  LIBS MAPL ${this})
 ecbuild_add_executable (TARGET CombineRasters.x SOURCES CombineRasters.F90 LIBS MAPL ${this})
-ecbuild_add_executable (TARGET mkCatchParam.x SOURCES mkCatchParam.F90 LIBS MAPL ${this} ${OpenMP_Fortran_LIBRARIES})
-set_target_properties(mkCatchParam.x PROPERTIES COMPILE_FLAGS "${OpenMP_Fortran_FLAGS}")
-set_target_properties(mkCatchParam.x PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
+ecbuild_add_executable (TARGET mkCatchParam.x SOURCES mkCatchParam.F90 LIBS MAPL ${this} OpenMP::OpenMP_Fortran)
 ecbuild_add_executable (TARGET mkCubeFVRaster.x SOURCES mkCubeFVRaster.F90 LIBS MAPL ${this})
 ecbuild_add_executable (TARGET mkLandRaster.x SOURCES mkLandRaster.F90 LIBS MAPL ${this})
 ecbuild_add_executable (TARGET mkLatLonRaster.x SOURCES mkLatLonRaster.F90 LIBS MAPL ${this})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CMakeLists.txt
@@ -5,25 +5,22 @@ set(srcs
 )
 
 set (exe_srcs
-  Scale_Catch.F90			    
-  Scale_CatchCN.F90		    
-  cv_SaltRestart.F90		    
+  Scale_Catch.F90
+  Scale_CatchCN.F90
+  cv_SaltRestart.F90
   SaltIntSplitter.F90
-  SaltImpConverter.F90		    
-  mk_CICERestart.F90		    
-  mk_CatchCNRestarts.F90		    
-  mk_CatchRestarts.F90		    
-  mk_LakeLandiceSaltRestarts.F90	    
+  SaltImpConverter.F90
+  mk_CICERestart.F90
+  mk_CatchCNRestarts.F90
+  mk_CatchRestarts.F90
+  mk_LakeLandiceSaltRestarts.F90
   mk_RouteRestarts.F90
   mk_GEOSldasRestarts.F90
-)  
-
-include_directories(${INC_ESMF})
-include_directories(${INC_NETCDF})
+)
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL)
+  DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
 
 foreach (src ${exe_srcs})
   string (REGEX REPLACE ".F90" "" exe ${src})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/CMakeLists.txt
@@ -12,5 +12,4 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES GEOS_Shared MAPL)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+  DEPENDENCIES GEOS_Shared MAPL esmf NetCDF::NetCDF_Fortran)

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOSdatmodyn_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOSdatmodyn_GridComp/CMakeLists.txt
@@ -5,6 +5,5 @@ set (srcs
   stratus_ic.F90 cfmip_ic.F90 NeuralNet.F90 GEOS_DatmoDynGridComp.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GEOS_Shared MAPL)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GEOS_Shared MAPL esmf NetCDF::NetCDF_Fortran)
 

--- a/GEOSmkiau_GridComp/CMakeLists.txt
+++ b/GEOSmkiau_GridComp/CMakeLists.txt
@@ -8,8 +8,6 @@ set (srcs
   DynVec_GridComp.F90
   )
 
-set(dependencies MAPL_cfio_r4 NCEP_sp_r4i4 GEOS_Shared GMAO_mpeu MAPL FVdycoreCubed_GridComp)
+set(dependencies MAPL_cfio_r4 NCEP_sp_r4i4 GEOS_Shared GMAO_mpeu MAPL FVdycoreCubed_GridComp esmf NetCDF::NetCDF_Fortran)
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies})
-target_include_directories (${this} PUBLIC ${include_INC_ESMF})
-target_include_directories (${this} PUBLIC ${INC_NETCDF})
 

--- a/GEOSogcm_GridComp/GEOS_OceanGridComp/GEOSdatasea_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOS_OceanGridComp/GEOSdatasea_GridComp/CMakeLists.txt
@@ -1,6 +1,3 @@
 esma_set_this ()
 
-esma_add_library (${this} SRCS GEOS_DataSeaGridComp.F90 DEPENDENCIES MAPL)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
-
-
+esma_add_library (${this} SRCS GEOS_DataSeaGridComp.F90 DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)

--- a/GEOSogcm_GridComp/GEOS_OradGridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOS_OradGridComp/CMakeLists.txt
@@ -1,5 +1,4 @@
 esma_set_this ()
 
-esma_add_library (${this} SRCS GEOS_OradGridComp.F90 DEPENDENCIES MAPL)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+esma_add_library (${this} SRCS GEOS_OradGridComp.F90 DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
 

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/CMakeLists.txt
@@ -1,5 +1,4 @@
 esma_set_this ()
 
-esma_add_library (${this} SRCS GEOS_DataSeaIceGridComp.F90 DEPENDENCIES MAPL CICE4)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+esma_add_library (${this} SRCS GEOS_DataSeaIceGridComp.F90 DEPENDENCIES MAPL CICE4 esmf NetCDF::NetCDF_Fortran)
 


### PR DESCRIPTION
This zero-diff PR has build system changes to support the use of Spack. Most of the changes just make the GEOS CMake look more like canonical CMake. GEOS previously couldn't support this, but it now can.

See https://github.com/GEOS-ESM/GEOSgcm/issues/387 for overall issue.