### PR TITLE
Updates for Spack Support, Round 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_GcmGridComp.F90)
   esma_add_library(${this}
     SRCS GEOS_GcmGridComp.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL
-    INCLUDES ${INC_ESMF})
+    DEPENDENCIES MAPL esmf)
 
   ecbuild_install_project( NAME GEOSgcm_GridComp)
 
@@ -25,6 +24,6 @@ else ()
 
 endif()
 
-  
+
 
 

--- a/GEOSagcm_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/CMakeLists.txt
@@ -10,8 +10,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_AgcmGridComp.F90)
   esma_add_library (${this}
     SRCS GEOS_AgcmGridComp.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GEOS_Shared Chem_Shared
-    INCLUDES ${INC_ESMF})
+    DEPENDENCIES MAPL GEOS_Shared Chem_Shared esmf)
 
 else ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
@@ -15,8 +15,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_PhysicsGridComp.F90)
   esma_add_library (${this}
     SRCS GEOS_PhysicsGridComp.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GMAO_mpeu GMAO_stoch
-    INCLUDES ${INC_ESMF})
+    DEPENDENCIES MAPL GMAO_mpeu GMAO_stoch esmf)
 
 else ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -17,8 +17,7 @@ endif ()
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES GEOS_Shared GMAO_mpeu MAPL Chem_Shared Chem_Base
-  INCLUDES ${INC_ESMF})
+  DEPENDENCIES GEOS_Shared GMAO_mpeu MAPL Chem_Shared Chem_Base esmf)
 
 get_target_property (extra_incs fms_r4 INCLUDE_DIRECTORIES)
 target_include_directories(${this} PRIVATE

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/CMakeLists.txt
@@ -10,6 +10,5 @@ set (alldirs
 esma_add_library (${this}
   SRCS GEOS_RadiationGridComp.F90
   SUBCOMPONENTS ${alldirs}
-  DEPENDENCIES MAPL GEOS_Shared
-  INCLUDES ${INC_ESMF})
+  DEPENDENCIES MAPL GEOS_Shared esmf)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
@@ -6,15 +6,14 @@ set (alldirs
    GEOSland_GridComp
    GEOSsaltwater_GridComp
    )
-  
+
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_SurfaceGridComp.F90)
 
   esma_add_library (${this}
     SRCS GEOS_SurfaceGridComp.F90
     SUBCOMPONENTS ${alldirs}
     SUBDIRS Shared
-    DEPENDENCIES GEOS_SurfaceShared MAPL GMAO_mpeu
-    INCLUDES ${INC_ESMF})
+    DEPENDENCIES GEOS_SurfaceShared MAPL GMAO_mpeu esmf)
 
 else ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlake_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlake_GridComp/CMakeLists.txt
@@ -2,6 +2,5 @@ esma_set_this()
 
 esma_add_library (${this}
   SRCS GEOS_LakeGridComp.F90
-  DEPENDENCIES GEOS_Shared MAPL
-  INCLUDES ${INC_ESMF})
+  DEPENDENCIES GEOS_Shared MAPL esmf)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/CMakeLists.txt
@@ -11,7 +11,6 @@ set (alldirs
 esma_add_library (${this}
   SRCS GEOS_LandGridComp.F90
   SUBCOMPONENTS ${alldirs}
-  SUBDIRS Shared 
-  DEPENDENCIES GEOS_SurfaceShared GEOS_LandShared MAPL
-  INCLUDES ${INC_ESMF})
+  SUBDIRS Shared
+  DEPENDENCIES GEOS_SurfaceShared GEOS_LandShared MAPL esmf)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/CMakeLists.txt
@@ -4,10 +4,9 @@ add_subdirectory (GEOScatchCNCLM40_GridComp)
 add_subdirectory (GEOScatchCNCLM45_GridComp)
 
 esma_add_library (${this}
-  SRCS GEOS_CatchCNGridComp.F90 
-  SUBDIRS Shared 
-  DEPENDENCIES GEOS_SurfaceShared GEOS_LandShared GEOS_CatchCNShared MAPL
-  INCLUDES ${INC_ESMF})
+  SRCS GEOS_CatchCNGridComp.F90
+  SUBDIRS Shared
+  DEPENDENCIES GEOS_SurfaceShared GEOS_LandShared GEOS_CatchCNShared MAPL esmf)
 
 # Special case for GEOScatch and GEOScatchCN components - build with / without openmp
 if (USE_OPENMP)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CLM40/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CLM40/CMakeLists.txt
@@ -43,6 +43,6 @@ esma_add_library (${this}
   TYPE SHARED)
 
 if (is_openmp)
-  target_compile_options(${this} PRIVATE ${OpenMP_Fortran_FLAGS})
+  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CMakeLists.txt
@@ -14,6 +14,6 @@ esma_add_library (${this}
   TYPE SHARED)
 
 if (is_openmp)
-  target_compile_options(${this} PRIVATE ${OpenMP_Fortran_FLAGS})
+  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CMakeLists.txt
@@ -50,6 +50,6 @@ esma_add_library (${this}
   TYPE SHARED)
 
 if (is_openmp)
-  target_compile_options(${this} PRIVATE ${OpenMP_Fortran_FLAGS})
+  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CMakeLists.txt
@@ -14,6 +14,6 @@ esma_add_library (${this}
   TYPE SHARED)
 
 if (is_openmp)
-  target_compile_options(${this} PRIVATE ${OpenMP_Fortran_FLAGS})
+  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/CMakeLists.txt
@@ -8,6 +8,5 @@ set_source_files_properties (catch_constants.f90 PROPERTIES COMPILE_FLAGS ${PP})
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES GEOS_SurfaceShared GEOS_Shared MAPL
+  DEPENDENCIES GEOS_SurfaceShared GEOS_Shared MAPL esmf
   TYPE SHARED)
-target_include_directories (${this} PUBLIC ${INC_ESMF})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CMakeLists.txt
@@ -24,17 +24,10 @@ esma_add_library (${this}
 
 foreach (src ${exe_srcs})
   string (REGEX REPLACE ".F90" "" exe ${src})
-  if (ESMA_USE_GFE_NAMESPACE)
-    ecbuild_add_executable (
-      TARGET ${exe}
-      SOURCES ${src}
-      LIBS MAPL GFTL_SHARED::gftl-shared GEOS_SurfaceShared GEOSroute_GridComp GEOS_LandShared ${this})
-  else ()
-    ecbuild_add_executable (
-      TARGET ${exe}
-      SOURCES ${src}
-      LIBS MAPL gftl-shared GEOS_SurfaceShared GEOSroute_GridComp GEOS_LandShared ${this})
-  endif ()
+  ecbuild_add_executable (
+    TARGET ${exe}
+    SOURCES ${src}
+    LIBS MAPL GFTL_SHARED::gftl-shared GEOS_SurfaceShared GEOSroute_GridComp GEOS_LandShared ${this})
 endforeach ()
 
 install(PROGRAMS mk_Restarts DESTINATION bin)

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/CMakeLists.txt
@@ -12,15 +12,14 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_SuperdynGridComp.F90)
   esma_add_library (${this}
     SRCS GEOS_SuperdynGridComp.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GEOS_Shared
-    INCLUDES ${INC_ESMF})
+    DEPENDENCIES MAPL GEOS_Shared esmf)
 
 else ()
 
   esma_add_subdirectories (${alldirs})
 
 endif ()
-  
+
 
 
 

--- a/GEOSdataatm_GridComp/CMakeLists.txt
+++ b/GEOSdataatm_GridComp/CMakeLists.txt
@@ -8,8 +8,7 @@ set (srcs
 
 esma_add_library (${this}
    SRCS ${srcs}
-   DEPENDENCIES MAPL CICE4 GEOS_Shared
-   INCLUDES ${INC_ESMF})
+   DEPENDENCIES MAPL CICE4 GEOS_Shared esmf)
 
 target_compile_definitions (${this} PRIVATE USE_CICE USE_R8)
 

--- a/GEOSogcm_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/CMakeLists.txt
@@ -8,12 +8,11 @@ set (alldirs
   GEOS_OceanGridComp
   )
 
-set (dependencies GEOS_Seaice_GridComp MAPL CICE4)
+set (dependencies GEOS_Seaice_GridComp MAPL CICE4 esmf)
 
 esma_add_library (${this}
   SRCS GEOS_OgcmGridComp.F90
   SUBCOMPONENTS ${alldirs}
-  SUBDIRS GEOSseaice_GridComp 
-  DEPENDENCIES ${dependencies}
-  INCLUDES ${INC_ESMF})
+  SUBDIRS GEOSseaice_GridComp
+  DEPENDENCIES ${dependencies})
 

--- a/GEOSogcm_GridComp/GEOS_OceanBioGeoChemGridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOS_OceanBioGeoChemGridComp/CMakeLists.txt
@@ -16,8 +16,7 @@ set (SRCS
 
 esma_add_library(${this}
   SRCS ${SRCS}
-  DEPENDENCIES MAPL
-  INCLUDES ${INC_ESMF})
+  DEPENDENCIES MAPL esmf)
 
 
 

--- a/GEOSogcm_GridComp/GEOS_OradBioGridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOS_OradBioGridComp/CMakeLists.txt
@@ -19,6 +19,5 @@ set (SRCS
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES MAPL
-  INCLUDES ${INC_ESMF})
+  DEPENDENCIES MAPL esmf)
 

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CMakeLists.txt
@@ -3,5 +3,4 @@ esma_set_this (OVERRIDE GEOS_Seaice_GridComp)
 esma_add_library (${this}
   SRCS GEOS_SeaIceGridComp.F90
   SUBCOMPONENTS GEOSdataseaice_GridComp GEOSCICEDyna_GridComp
-  DEPENDENCIES MAPL CICE4
-  INCLUDES ${INC_ESMF})
+  DEPENDENCIES MAPL CICE4 esmf)

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSCICEDyna_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSCICEDyna_GridComp/CMakeLists.txt
@@ -1,9 +1,8 @@
 esma_set_this ()
 
-esma_add_library (${this} 
-   SRCS GEOS_CICEDynaGridComp.F90 
-   DEPENDENCIES MAPL CICE4
-   INCLUDES ${INC_ESMF})
+esma_add_library (${this}
+   SRCS GEOS_CICEDynaGridComp.F90
+   DEPENDENCIES MAPL CICE4 esmf)
 
 target_compile_definitions(${this} PRIVATE DIAGOUT MODIFY_TOPOGRAPHY USE_R8)
 


### PR DESCRIPTION
Due to insufficient grepping on my part, some remnants of the
"non-canonical" CMake still remain. Apparently these were not necessary
changes for Spack, but they are changes that unify the CMake style of
GEOS to be more like "correct" CMake.

In this go-around, it is mainly finding `INC_ESMF` which I apparently
forgot to grep for last time (I was focused on NetCDF), and some
non-canonical OpenMP calls.

See https://github.com/GEOS-ESM/GEOSgcm/issues/387 for the meta-issue.