### PR TITLE
add a few connectivities, in AGCM and PHYS

### DIFF
--- a/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
@@ -920,6 +920,15 @@ contains
          RC=STATUS  )
      VERIFY_(STATUS)
 
+    call MAPL_AddConnectivity ( GC,                                                        &
+         SRC_NAME  = (/'T            ','PLE          ','ZLE          ','TROPP_BLENDED'/),  &
+         DST_NAME  = (/'T_avg24      ','PLE_avg24    ','ZLE_avg24    ','TROPP_avg24  '/),  &
+         DST_ID = PHYS,                                                                    &
+         SRC_ID = SDYN,                                                                    &
+         RC=STATUS  )
+     VERIFY_(STATUS)
+
+
     call MAPL_AddConnectivity ( GC,              &
          SRC_NAME    = 'PLE',                    &
          DST_NAME    = 'PLEINST',                &
@@ -2412,6 +2421,9 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
     call MAPL_TimerOn (STATE,"SUPERDYNAMICS"  )
 
     call ESMF_GridCompRun(GCS(SDYN), importState=GIM(SDYN), exportState=GEX(SDYN), clock=CLOCK, PHASE=2, userRC=STATUS)
+    VERIFY_(STATUS)
+
+    call MAPL_GenericRunCouplers( STATE, SDYN, CLOCK, RC=STATUS )
     VERIFY_(STATUS)
 
     call MAPL_TimerOff(STATE,"SUPERDYNAMICS"  )

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
@@ -1216,6 +1216,14 @@ contains
      VERIFY_(STATUS)
 
      call MAPL_AddConnectivity ( GC,                              &
+        SRC_NAME  = (/ 'Q         ','FCLD      ' /),              &
+        DST_NAME  = (/ 'Q_avg24   ','FCLD_avg24' /),              &
+        DST_ID      = CHEM,                                       &
+        SRC_ID      = MOIST,                                      &
+                                                       RC=STATUS  )
+     VERIFY_(STATUS)
+
+     call MAPL_AddConnectivity ( GC,                              &
          SHORT_NAME  = (/'ZPBL','PPBL'/),                         &
          DST_ID      = CHEM,                                      &
          SRC_ID      = TURBL,                                     &
@@ -1253,6 +1261,14 @@ contains
      call MAPL_AddConnectivity ( GC,                              &
         SHORT_NAME  = (/ 'TAUCLI', 'TAUCLW', 'CLDTT ',            &
                          'DFPAR ', 'DRPAR '                   /), &
+        DST_ID      =  CHEM,                                      &
+        SRC_ID      =  RAD,                                       &
+                                                       RC=STATUS  )
+     VERIFY_(STATUS)
+
+     call MAPL_AddConnectivity ( GC,                              &
+        SRC_NAME  = (/ 'TAUCLI      ', 'TAUCLW      '/),          &
+        DST_NAME  = (/ 'TAUCLI_avg24', 'TAUCLW_avg24'/),          &
         DST_ID      =  CHEM,                                      &
         SRC_ID      =  RAD,                                       &
                                                        RC=STATUS  )


### PR DESCRIPTION
This PR is zero-diff.

This PR provides connectivity to several fields that will be imported by a child of Chemistry as 24-hour averages. Averaging is done by the MAPL Couplers.

Note that the DST_NAME in each case has a suffix '_avg24'.  These fields will be imported by calling MAPL_AddImportSpec with arguments REFRESH_INTERVAL=60*60*24,AVERAGING_INTERVAL=60*60*24 .