### PR TITLE
Remove extraneous declaration

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
@@ -107,7 +107,7 @@ module GEOS_MoistGridCompMod
 !-srf-gf-scheme
 
 !ALT-protection for GF
-  USE ConvectionMod, only: Disable_Convection
+! USE ConvectionMod, only: Disable_Convection
 !ALT-protection for GF
 
 !--kml--------------


### PR DESCRIPTION
This PR is zero diff.
Comment out the declaration of Disable_Convection in MOIST.  It is no longer used.
But it is referenced later in the file, that's why the declaration was not removed altogether.