### PR TITLE
 GEOS_GwdGridComp (Gravity Wave Drag)

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -33,45 +33,12 @@ module GEOS_GwdGridCompMod
   use ESMF
   use MAPL
 
-#ifdef _CUDA
-  use gw_drag, only: &
-        ! Subroutines
-        GW_INTR, &
-        ! Working Arrays
-        ZM_DEV, LNPINT_DEV, PMLN_DEV, PMID_DEV, &
-        RPDEL_DEV, &
-        ! Inputs - PREGEO
-        PINT_DEV, RLAT_DEV, &
-        ! Outputs - PREGEO
-        PDEL_DEV, &
-        ! Inputs - GEOPOT
-        T_DEV, Q_DEV, &
-        ! Outputs - GEOPOT
-        ZI_DEV, &
-        ! Inputs - INTR
-        U_DEV, V_DEV, SGH_DEV, PREF_DEV, &
-        ! Outputs - INTR
-        DUDT_GWD_DEV, DVDT_GWD_DEV, DTDT_GWD_DEV, &
-        DUDT_ORG_DEV, DVDT_ORG_DEV, DTDT_ORG_DEV, &
-        TAUGWDX_DEV, TAUGWDY_DEV, TAUOX_DEV, TAUOY_DEV, &
-        FEO_DEV, FEPO_DEV,  TAUBKGX_DEV, TAUBKGY_DEV, &
-        TAUBX_DEV, TAUBY_DEV,  FEB_DEV, FEPB_DEV, &
-        UTBSRC_DEV, VTBSRC_DEV, TTBSRC_DEV, &
-        ! Outputs - POSTINTR
-        DUDT_TOT_DEV, DVDT_TOT_DEV, DTDT_TOT_DEV, &
-        DUDT_RAH_DEV, DVDT_RAH_DEV, DTDT_RAH_DEV, &
-        PEGWD_DEV, PEORO_DEV, PERAY_DEV, PEBKG_DEV, &
-        KEGWD_DEV, KEORO_DEV, KERAY_DEV, KEBKG_DEV, &
-        KERES_DEV, BKGERR_DEV
-  use cudafor
-#else
   use gw_oro, only : gw_oro_init
   use gw_convect, only : gw_beres_init, BeresSourceDesc
   use gw_common, only: GWBand, gw_common_init
   use gw_drag_ncar, only: gw_intr_ncar
 
   use gw_drag, only: gw_intr
-#endif
   
   implicit none
   private
@@ -1079,11 +1046,6 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
       real(ESMF_KIND_R8)                       :: DT_R8
       real                                     :: DT     ! time interval in sec
 
-#ifdef _CUDA
-      type(dim3) :: Grid, Block
-      integer :: blocksize
-#endif
-
 ! NCEP gwd related vars
       real, pointer :: TRATE(:,:,:)=>NULL()
       real          :: CDMBGWD(2)
@@ -1196,405 +1158,6 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
       call MAPL_GetPointer(EXPORT,    KERES, 'KERES'   , RC=STATUS); VERIFY_(STATUS)
       call MAPL_GetPointer(EXPORT,   BKGERR, 'BKGERR'  , RC=STATUS); VERIFY_(STATUS)
 
-#ifdef _CUDA
-
-      _ASSERT(  LM <= GPU_MAXLEVS,'needs informative message') ! If these are tripped GNUmakefile
-      _ASSERT(PGWV <= MAXPGWV,'needs informative message')     ! must be modified.
-
-      call MAPL_GetResource(MAPL,BLOCKSIZE,'BLOCKSIZE:',DEFAULT=128,RC=STATUS)
-      VERIFY_(STATUS)
-
-      Block = dim3(blocksize,1,1)
-      Grid  = dim3(ceiling(real(IM*JM)/real(blocksize)),1,1)
-
-      call MAPL_TimerOn(MAPL,"-DRIVER_ALLOC",RC=STATUS)
-      VERIFY_(STATUS)
-
-      ! ----------------------
-      ! Allocate device arrays
-      ! ----------------------
-  
-      ! Working Arrays
-      ! --------------
-  
-      ALLOCATE(ZM_DEV(IM*JM,LM),STAT=STATUS)       ! height above surface at layers
-      ALLOCATE(LNPINT_DEV(IM*JM,LM+1),STAT=STATUS) ! log(pint)
-      ALLOCATE(PMLN_DEV(IM*JM,LM),STAT=STATUS)     ! log midpoint pressures
-      ALLOCATE(PMID_DEV(IM*JM,LM),STAT=STATUS)     ! pressure at the layers
-      ALLOCATE(RPDEL_DEV(IM*JM,LM),STAT=STATUS)    ! 1.0 / pdel
-  
-      ! Inputs - PREGEO
-      ! ---------------
-  
-      ALLOCATE(PINT_DEV(IM*JM,LM+1),STAT=STATUS)   ! pressure at the layer edges
-      ALLOCATE(RLAT_DEV(IM*JM),STAT=STATUS)        ! latitude in radian
-  
-      ! Outputs - PREGEO
-      ! ----------------
-  
-      ALLOCATE(PDEL_DEV(IM*JM,LM),STAT=STATUS)     ! pressure thickness at the layers
-  
-      ! Inputs - GEOPOT
-      ! ---------------
-  
-      ALLOCATE(T_DEV(IM*JM,LM),STAT=STATUS)        ! temperature at layers
-      ALLOCATE(Q_DEV(IM*JM,LM),STAT=STATUS)        ! specific humidity
-  
-      ! Outputs - GEOPOT
-      ! ----------------
-  
-      ALLOCATE(ZI_DEV(IM*JM,LM+1),STAT=STATUS)     ! Height above surface at interfaces
-  
-      ! Inputs - INTR
-      ! -------------
-  
-      ALLOCATE(U_DEV(IM*JM,LM),STAT=STATUS)        ! zonal wind at layers
-      ALLOCATE(V_DEV(IM*JM,LM),STAT=STATUS)        ! meridional wind at layers
-      ALLOCATE(SGH_DEV(IM*JM),STAT=STATUS)         ! standard deviation of orography
-      ALLOCATE(PREF_DEV(LM+1),STAT=STATUS)         ! reference pressure at the layeredges
-  
-      ! Outputs - INTR
-      ! --------------
-    
-      ALLOCATE(DUDT_GWD_DEV(IM*JM,LM),STAT=STATUS) ! zonal wind tendency at layer 
-      ALLOCATE(DVDT_GWD_DEV(IM*JM,LM),STAT=STATUS) ! meridional wind tendency at layer 
-      ALLOCATE(DTDT_GWD_DEV(IM*JM,LM),STAT=STATUS) ! temperature tendency at layer
-      ALLOCATE(DUDT_ORG_DEV(IM*JM,LM),STAT=STATUS) ! zonal wind tendency at layer due to orography GWD
-      ALLOCATE(DVDT_ORG_DEV(IM*JM,LM),STAT=STATUS) ! meridional wind tendency at layer  due to orography GWD
-      ALLOCATE(DTDT_ORG_DEV(IM*JM,LM),STAT=STATUS) ! temperature tendency at layer  due to orography GWD
-      ALLOCATE(TAUGWDX_DEV(IM*JM),STAT=STATUS)     ! zonal      gravity wave surface    stress
-      ALLOCATE(TAUGWDY_DEV(IM*JM),STAT=STATUS)     ! meridional gravity wave surface    stress
-      ALLOCATE(TAUOX_DEV(IM*JM,LM+1),STAT=STATUS)  ! zonal      orographic gravity wave stress
-      ALLOCATE(TAUOY_DEV(IM*JM,LM+1),STAT=STATUS)  ! meridional orographic gravity wave stress
-      ALLOCATE(FEO_DEV(IM*JM,LM+1),STAT=STATUS)    ! energy flux of orographic gravity waves
-      ALLOCATE(FEPO_DEV(IM*JM,LM+1),STAT=STATUS)   ! pseudoenergy flux of orographic gravity waves
-      ALLOCATE(TAUBKGX_DEV(IM*JM),STAT=STATUS)     ! zonal      gravity wave background stress
-      ALLOCATE(TAUBKGY_DEV(IM*JM),STAT=STATUS)     ! meridional gravity wave background stress
-      ALLOCATE(TAUBX_DEV(IM*JM,LM+1),STAT=STATUS)  ! zonal      background gravity wave stress
-      ALLOCATE(TAUBY_DEV(IM*JM,LM+1),STAT=STATUS)  ! meridional background gravity wave stress
-      ALLOCATE(FEB_DEV(IM*JM,LM+1),STAT=STATUS)    ! energy flux of background gravity waves
-      ALLOCATE(FEPB_DEV(IM*JM,LM+1),STAT=STATUS)   ! pseudoenergy flux of background gravity waves
-      ALLOCATE(UTBSRC_DEV(IM*JM,LM),STAT=STATUS)   ! dU/dt below background launch level
-      ALLOCATE(VTBSRC_DEV(IM*JM,LM),STAT=STATUS)   ! dV/dt below background launch level
-      ALLOCATE(TTBSRC_DEV(IM*JM,LM),STAT=STATUS)   ! dT/dt below background launch level
-  
-      ! Outputs - POSTINTR
-      ! ------------------
-  
-      ALLOCATE(DUDT_TOT_DEV(IM*JM,LM),STAT=STATUS) ! Tendency of eastward wind due to GWD
-      ALLOCATE(DVDT_TOT_DEV(IM*JM,LM),STAT=STATUS) ! Tendency of northward wind due to GWD
-      ALLOCATE(DTDT_TOT_DEV(IM*JM,LM),STAT=STATUS) ! Tendency of air temperature due to GWD
-      ALLOCATE(DUDT_RAH_DEV(IM*JM,LM),STAT=STATUS) ! Tendency of eastward wind due to Rayleigh friction
-      ALLOCATE(DVDT_RAH_DEV(IM*JM,LM),STAT=STATUS) ! Tendency of northward wind due to Rayleigh friction
-      ALLOCATE(DTDT_RAH_DEV(IM*JM,LM),STAT=STATUS) ! Tendency of air temperature due to Rayleigh friction
-      ALLOCATE(PEGWD_DEV(IM*JM),STAT=STATUS)       ! Potential energy tendency across GWD
-      ALLOCATE(PEORO_DEV(IM*JM),STAT=STATUS)       ! Potential energy tendency due to orographic gravity
-      ALLOCATE(PERAY_DEV(IM*JM),STAT=STATUS)       ! Potential energy tendency due to Rayleigh friction
-      ALLOCATE(PEBKG_DEV(IM*JM),STAT=STATUS)       ! Potential energy tendency due to gw background
-      ALLOCATE(KEGWD_DEV(IM*JM),STAT=STATUS)       ! Kinetic energy tendency across GWD
-      ALLOCATE(KEORO_DEV(IM*JM),STAT=STATUS)       ! Kinetic energy tendency due to orographic gravity
-      ALLOCATE(KERAY_DEV(IM*JM),STAT=STATUS)       ! Kinetic energy tendency due to Rayleigh friction
-      ALLOCATE(KEBKG_DEV(IM*JM),STAT=STATUS)       ! Kinetic energy tendency due to gw background
-      ALLOCATE(KERES_DEV(IM*JM),STAT=STATUS)       ! Kinetic energy residual for total energy conservation
-      ALLOCATE(BKGERR_DEV(IM*JM),STAT=STATUS)      ! Kinetic energy residual for BKG energy conservation
-
-      call MAPL_TimerOff(MAPL,"-DRIVER_ALLOC",RC=STATUS)
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOn(MAPL,"-DRIVER_DATA",RC=STATUS)
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOn(MAPL,"--DRIVER_DATA_DEVICE",RC=STATUS)
-      VERIFY_(STATUS)
-
-      ! ---------------------
-      ! Copy inputs to device
-      ! ---------------------
-  
-      ! Inputs
-      ! ------
-  
-      STATUS = cudaMemcpy(PINT_DEV,PLE,IM*JM*(LM+1))
-      STATUS = cudaMemcpy(RLAT_DEV,LATS,IM*JM)
-      STATUS = cudaMemcpy(T_DEV,T,IM*JM*LM)
-      STATUS = cudaMemcpy(Q_DEV,Q,IM*JM*LM)
-      STATUS = cudaMemcpy(U_DEV,U,IM*JM*LM)
-      STATUS = cudaMemcpy(V_DEV,V,IM*JM*LM)
-      STATUS = cudaMemcpy(SGH_DEV,SGH,IM*JM)
-      STATUS = cudaMemcpy(PREF_DEV,PREF,LM+1)
-
-      call MAPL_TimerOff(MAPL,"--DRIVER_DATA_DEVICE",RC=STATUS)
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOff(MAPL,"-DRIVER_DATA",RC=STATUS)
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOn(MAPL,"-DRIVER_RUN",RC=STATUS)
-      VERIFY_(STATUS)
-
-      CALL PREGEO<<<Grid,Block>>>(IM*JM, LM, &
-            PINT_DEV, RLAT_DEV, PMID_DEV, PDEL_DEV, RPDEL_DEV, LNPINT_DEV, PMLN_DEV)
-
-      STATUS = cudaGetLastError()
-      if (STATUS /= 0) then 
-         write (*,*) "Error code from PREGEO kernel call: ", STATUS
-         write (*,*) "Kernel call failed: ", cudaGetErrorString(STATUS)
-         _ASSERT(.FALSE.,'needs informative message')
-      end if
-
-      ! Compute ZM
-      !-------------
-
-      call GEOPOTENTIAL<<<Grid,Block>>>(IM*JM,  LM,                        &
-            LNPINT_DEV, PMLN_DEV, PINT_DEV, PMID_DEV, PDEL_DEV, RPDEL_DEV, &
-            T_DEV,      Q_DEV,    ZI_DEV,   ZM_DEV                         )
-
-      STATUS = cudaGetLastError()
-      if (STATUS /= 0) then 
-         write (*,*) "Error code from GEOPOTENTIAL kernel call: ", STATUS
-         write (*,*) "Kernel call failed: ", cudaGetErrorString(STATUS)
-         _ASSERT(.FALSE.,'needs informative message')
-      end if
-
-      call MAPL_TimerOn(MAPL,"-INTR",RC=STATUS)
-      VERIFY_(STATUS)
-  
-      !Do gravity wave drag calculations on a list of soundings
-      !---------------------------------------------------------
-  
-      call GW_INTR<<<Grid,Block>>>(IM*JM, LM, DT, PGWV, BGSTRESSMAX, effgworo, effgwbkg)
-  
-      STATUS = cudaGetLastError()
-      if (STATUS /= 0) then 
-         write (*,*) "Error code from GW_INTR kernel call: ", STATUS
-         write (*,*) "Kernel call failed: ", cudaGetErrorString(STATUS)
-         _ASSERT(.FALSE.,'needs informative message')
-      end if
-  
-      call MAPL_TimerOff(MAPL,"-INTR",RC=STATUS)
-      VERIFY_(STATUS)
-
-      CALL POSTINTR<<<Grid,Block>>>(IM*JM, LM, DT, H0, HH, Z1, TAU1, &
-            ! Inputs
-            PREF_DEV, &
-            PDEL_DEV, &
-            U_DEV, &
-            V_DEV, &
-            DUDT_GWD_DEV, &
-            DVDT_GWD_DEV, &
-            DTDT_GWD_DEV, &
-            DUDT_ORG_DEV, &
-            DVDT_ORG_DEV, &
-            DTDT_ORG_DEV, &
-
-            ! Outputs
-            DUDT_TOT_DEV, &
-            DVDT_TOT_DEV, &
-            DTDT_TOT_DEV, &
-            DUDT_RAH_DEV, &
-            DVDT_RAH_DEV, &
-            DTDT_RAH_DEV, &
-            PEGWD_DEV,    &
-            PEORO_DEV,    &
-            PERAY_DEV,    &
-            PEBKG_DEV,    &
-            KEGWD_DEV,    &
-            KEORO_DEV,    &
-            KERAY_DEV,    &
-            KEBKG_DEV,    &
-            KERES_DEV,    &
-            BKGERR_DEV    )
-
-      STATUS = cudaGetLastError()
-      if (STATUS /= 0) then 
-         write (*,*) "Error code from POSTINTR kernel call: ", STATUS
-         write (*,*) "Kernel call failed: ", cudaGetErrorString(STATUS)
-         _ASSERT(.FALSE.,'needs informative message')
-      end if
-  
-      call MAPL_TimerOff(MAPL,"-DRIVER_RUN",RC=STATUS)
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOn(MAPL,"-DRIVER_DATA",RC=STATUS)
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOn(MAPL,"--DRIVER_DATA_DEVICE",RC=STATUS)
-      VERIFY_(STATUS)
-
-      ! ------------------------
-      ! Copy outputs from device
-      ! ------------------------
-  
-      ! Outputs - PREGEO
-      ! ----------------
-
-      ! MAT PDEL might be needed below to weight DTDT
-      if(associated(DTDT)) STATUS = cudaMemcpy(PDEL,PDEL_DEV,IM*JM*LM)
-
-      ! Outputs - GEOPOT
-      ! ----------------
-
-      !GPU This array is not used anywhere past this point. Uncomment
-      !GPU to copy it to the host if needed in future.
-      !GPU  STATUS = cudaMemcpy(ZI,ZI_DEV,IM*JM*(LM+1)) !MAT Not used after this
-
-      ! Outputs - INTR
-      ! --------------
-    
-      STATUS = cudaMemcpy(DUDT_GWD,DUDT_GWD_DEV,IM*JM*LM)
-      STATUS = cudaMemcpy(DVDT_GWD,DVDT_GWD_DEV,IM*JM*LM)
-      STATUS = cudaMemcpy(DTDT_GWD,DTDT_GWD_DEV,IM*JM*LM)
-
-      STATUS = cudaMemcpy(DUDT_ORG,DUDT_ORG_DEV,IM*JM*LM)
-      STATUS = cudaMemcpy(DVDT_ORG,DVDT_ORG_DEV,IM*JM*LM)
-      STATUS = cudaMemcpy(DTDT_ORG,DTDT_ORG_DEV,IM*JM*LM)
-
-      STATUS = cudaMemcpy(TAUXO_TMP,TAUGWDX_DEV,IM*JM)
-      STATUS = cudaMemcpy(TAUYO_TMP,TAUGWDY_DEV,IM*JM)
-      STATUS = cudaMemcpy(TAUXB_TMP,TAUBKGX_DEV,IM*JM)
-      STATUS = cudaMemcpy(TAUYB_TMP,TAUBKGY_DEV,IM*JM)
-
-      !GPU These arrays are not used anywhere past this point. Uncomment
-      !GPU to copy them to the host if needed in future.
-      !GPU  STATUS = cudaMemcpy(TAUXO_3D,TAUOX_DEV,IM*JM*(LM+1))
-      !GPU  STATUS = cudaMemcpy(TAUYO_3D,TAUOY_DEV,IM*JM*(LM+1))
-      !GPU  STATUS = cudaMemcpy(FEO_3D,FEO_DEV,IM*JM*(LM+1))
-      !GPU  STATUS = cudaMemcpy(FEPO_3D,FEPO_DEV,IM*JM*(LM+1))
-      !GPU  STATUS = cudaMemcpy(TAUXB_3D,TAUBX_DEV,IM*JM*(LM+1))
-      !GPU  STATUS = cudaMemcpy(TAUYB_3D,TAUBY_DEV,IM*JM*(LM+1))
-      !GPU  STATUS = cudaMemcpy(FEB_3D,FEB_DEV,IM*JM*(LM+1))
-      !GPU  STATUS = cudaMemcpy(FEPB_3D,FEPB_DEV,IM*JM*(LM+1))
-      !GPU  STATUS = cudaMemcpy(DUBKGSRC,UTBSRC_DEV,IM*JM*LM)
-      !GPU  STATUS = cudaMemcpy(DVBKGSRC,VTBSRC_DEV,IM*JM*LM)
-      !GPU  STATUS = cudaMemcpy(DTBKGSRC,TTBSRC_DEV,IM*JM*LM)
-
-      ! Outputs - POSTINTR
-      ! ------------------
-    
-      if(associated(DUDT    )) STATUS = cudaMemcpy(DUDT,    DUDT_TOT_DEV,IM*JM*LM)
-      if(associated(DVDT    )) STATUS = cudaMemcpy(DVDT,    DVDT_TOT_DEV,IM*JM*LM)
-      if(associated(DTDT    )) STATUS = cudaMemcpy(DTDT,    DTDT_TOT_DEV,IM*JM*LM)
-
-      if(associated(DUDT_RAY)) STATUS = cudaMemcpy(DUDT_RAY,DUDT_RAH_DEV,IM*JM*LM)
-      if(associated(DVDT_RAY)) STATUS = cudaMemcpy(DVDT_RAY,DVDT_RAH_DEV,IM*JM*LM)
-      if(associated(DTDT_RAY)) STATUS = cudaMemcpy(DTDT_RAY,DTDT_RAH_DEV,IM*JM*LM)
-
-      ! KE dIagnostics
-      !----------------
-
-      if(associated(PEGWD )) STATUS = cudaMemcpy(PEGWD, PEGWD_DEV,IM*JM)
-      if(associated(PEORO )) STATUS = cudaMemcpy(PEORO, PEORO_DEV,IM*JM)
-      if(associated(PERAY )) STATUS = cudaMemcpy(PERAY, PERAY_DEV,IM*JM)
-      if(associated(PEBKG )) STATUS = cudaMemcpy(PEBKG, PEBKG_DEV,IM*JM)
-      if(associated(KEGWD )) STATUS = cudaMemcpy(KEGWD, KEGWD_DEV,IM*JM)
-      if(associated(KEORO )) STATUS = cudaMemcpy(KEORO, KEORO_DEV,IM*JM)
-      if(associated(KERAY )) STATUS = cudaMemcpy(KERAY, KERAY_DEV,IM*JM)
-      if(associated(KEBKG )) STATUS = cudaMemcpy(KEBKG, KEBKG_DEV,IM*JM)
-      if(associated(KERES )) STATUS = cudaMemcpy(KERES, KERES_DEV,IM*JM)
-      if(associated(BKGERR)) STATUS = cudaMemcpy(BKGERR,BKGERR_DEV,IM*JM)
-  
-      call MAPL_TimerOff(MAPL,"--DRIVER_DATA_DEVICE",RC=STATUS)
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOff(MAPL,"-DRIVER_DATA",RC=STATUS)
-      VERIFY_(STATUS)
-
-      call MAPL_TimerOn(MAPL,"-DRIVER_DEALLOC",RC=STATUS)
-      VERIFY_(STATUS)
-
-      ! ------------------------
-      ! Deallocate device arrays
-      ! ------------------------
-  
-      ! Working Arrays
-      ! --------------
-  
-      DEALLOCATE(ZM_DEV)
-      DEALLOCATE(LNPINT_DEV)
-      DEALLOCATE(PMLN_DEV)
-      DEALLOCATE(PMID_DEV)
-      DEALLOCATE(RPDEL_DEV)
-  
-      ! Inputs - PREGEO
-      ! ---------------
-  
-      DEALLOCATE(PINT_DEV)
-      DEALLOCATE(RLAT_DEV)
-  
-      ! Outputs - PREGEO
-      ! ----------------
-  
-      DEALLOCATE(PDEL_DEV)
-  
-      ! Inputs - GEOPOT
-      ! ---------------
-  
-      DEALLOCATE(T_DEV)
-      DEALLOCATE(Q_DEV)
-  
-      ! Outputs - GEOPOT
-      ! ----------------
-  
-      DEALLOCATE(ZI_DEV)
-  
-      ! Inputs - INTR
-      ! -------------
-  
-      DEALLOCATE(U_DEV)
-      DEALLOCATE(V_DEV)
-      DEALLOCATE(SGH_DEV)
-      DEALLOCATE(PREF_DEV)
-  
-      ! Outputs - INTR
-      ! --------------
-    
-      DEALLOCATE(DUDT_GWD_DEV)
-      DEALLOCATE(DVDT_GWD_DEV)
-      DEALLOCATE(DTDT_GWD_DEV)
-      DEALLOCATE(DUDT_ORG_DEV)
-      DEALLOCATE(DVDT_ORG_DEV)
-      DEALLOCATE(DTDT_ORG_DEV)
-      DEALLOCATE(TAUGWDX_DEV)
-      DEALLOCATE(TAUGWDY_DEV)
-      DEALLOCATE(TAUOX_DEV)
-      DEALLOCATE(TAUOY_DEV)
-      DEALLOCATE(FEO_DEV)
-      DEALLOCATE(FEPO_DEV)
-      DEALLOCATE(TAUBKGX_DEV)
-      DEALLOCATE(TAUBKGY_DEV)
-      DEALLOCATE(TAUBX_DEV)
-      DEALLOCATE(TAUBY_DEV)
-      DEALLOCATE(FEB_DEV)
-      DEALLOCATE(FEPB_DEV)
-      DEALLOCATE(UTBSRC_DEV)
-      DEALLOCATE(VTBSRC_DEV)
-      DEALLOCATE(TTBSRC_DEV)
-  
-      ! Outputs - POSTINTR
-      ! ------------------
-  
-      DEALLOCATE(DUDT_TOT_DEV)
-      DEALLOCATE(DVDT_TOT_DEV)
-      DEALLOCATE(DTDT_TOT_DEV)
-      DEALLOCATE(DUDT_RAH_DEV)
-      DEALLOCATE(DVDT_RAH_DEV)
-      DEALLOCATE(DTDT_RAH_DEV)
-      DEALLOCATE(PEGWD_DEV)
-      DEALLOCATE(PEORO_DEV)
-      DEALLOCATE(PERAY_DEV)
-      DEALLOCATE(PEBKG_DEV)
-      DEALLOCATE(KEGWD_DEV)
-      DEALLOCATE(KEORO_DEV)
-      DEALLOCATE(KERAY_DEV)
-      DEALLOCATE(KEBKG_DEV)
-      DEALLOCATE(KERES_DEV)
-      DEALLOCATE(BKGERR_DEV)
-
-      call MAPL_TimerOff(MAPL,"-DRIVER_DEALLOC",RC=STATUS)
-      VERIFY_(STATUS)
-
-#else
-! This is the non-CUDA sectio
 
       CALL PREGEO(IM*JM,   LM,   &
                     PLE, LATS,   PMID,  PDEL, RPDEL,     PILN,     PMLN)
@@ -1840,8 +1403,6 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     if(associated(KERES   )) KERES  = KERES_X
     if(associated(BKGERR  )) BKGERR = BKGERR_X
 
-#endif
-
 !! Tendency diagnostics
 !!---------------------
 
@@ -1904,9 +1465,6 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 
-#ifdef _CUDA
-  attributes(global) &
-#endif
   subroutine geopotential(pcols  , pver   ,                   &
          piln   , pmln   , pint  , pmid   , pdel   , rpdel  , &
          t      , q      , zi     , zm     )
@@ -1926,13 +1484,8 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 !
 ! Input arguments
 !
-#ifdef _CUDA
-    integer, value :: pcols                ! Number of longitudes
-    integer, value :: pver                 ! Number of vertical layers
-#else
     integer, intent(in) :: pcols                ! Number of longitudes
     integer, intent(in) :: pver                 ! Number of vertical layers
-#endif
 
     real,    intent(in) :: piln (pcols,pver+1)  ! Log interface pressures
     real,    intent(in) :: pmln (pcols,pver)    ! Log midpoint pressures
@@ -1968,13 +1521,8 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 
 ! The surface height is zero by definition.
 
-#ifdef _CUDA
-    i = (blockidx%x - 1) * blockdim%x + threadidx%x
-
-    I_LOOP: if ( i <= pcols ) then
-#else
     I_LOOP: do i = 1, pcols
-#endif
+
        zi(i,pver+1) = 0.0
 
 ! Compute zi, zm from bottom up. 
@@ -2000,20 +1548,13 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
           zm(i,k) = zi(i,k+1) + ROG * tv * hkk
           zi(i,k) = zi(i,k+1) + ROG * tv * hkl
        end do
-#ifndef _CUDA
     end do I_LOOP
-#else
-    end if I_LOOP
-#endif 
 
     return
   end subroutine geopotential
 
 !----------------------------------------------------------------------- 
 
-#ifdef _CUDA
-  attributes(global) &
-#endif
   subroutine pregeo(pcols,pver,&
     ple,lats,pmid,pdel,rpdel,piln,pmln)
 
@@ -2024,13 +1565,8 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 ! Input arguments
 !
 
-#ifdef _CUDA
-    integer, value :: pcols         ! Number of longitudes
-    integer, value :: pver          ! Number of vertical layers
-#else
     integer, intent(in) :: pcols    ! Number of longitudes
     integer, intent(in) :: pver     ! Number of vertical layers
-#endif
 
     real,    intent(in) :: ple (pcols,pver+1)    ! Interface pressures
     real,    intent(in) :: lats(pcols)           ! latitude in radian
@@ -2059,13 +1595,8 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 ! Form pressure factors
 !----------------------
 
-#ifdef _CUDA
-    I = (BLOCKIDX%X - 1) * BLOCKDIM%X + THREADIDX%X
-
-    I_LOOP: IF ( I <= PCOLS ) THEN
-#else
     I_LOOP: DO I = 1, PCOLS
-#endif
+
        DO K = 1, PVER
            PMID(I,K) = 0.5*(  PLE(I,K  ) + PLE(I,K+1) )
            PDEL(I,K) =        PLE(I,K+1) - PLE(I,K  )
@@ -2074,17 +1605,10 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
            PMLN(I,K) = log(  PMID(I,K) ) !
        END DO
        PILN(I,PVER+1)  = log( PLE(I,PVER+1)  )
-#ifndef _CUDA
     END DO I_LOOP
-#else
-    END IF I_LOOP
-#endif 
 
   end subroutine pregeo
 
-#ifdef _CUDA
-  attributes(global) &
-#endif
   subroutine postintr(pcols,pver,dt, h0, hh, z1, tau1, &
         pref, &
         pdel, &
@@ -2122,17 +1646,10 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 ! Input arguments
 !
 
-#ifdef _CUDA
-    integer, value :: PCOLS ! Number of longitudes
-    integer, value :: PVER  ! Number of vertical layers
-    real,    value :: DT    ! Time step
-    real,    value :: H0, HH, Z1, TAU1 ! Rayleigh friction parameters
-#else    
     integer, intent(in) :: PCOLS ! Number of longitudes
     integer, intent(in) :: PVER  ! Number of vertical layers
     real,    intent(in) :: DT    ! Time step
     real,    intent(in) :: H0, HH, Z1, TAU1 ! Rayleigh friction parameters
-#endif
 
     real,    intent(in) :: PREF(PVER+1)
     real,    intent(in) :: PDEL(PCOLS,PVER)
@@ -2172,13 +1689,8 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 !-----------------------------------------------------------------------
 !
 
-#ifdef _CUDA
-    I = (BLOCKIDX%X - 1) * BLOCKDIM%X + THREADIDX%X
-
-    I_LOOP: IF ( I <= PCOLS ) THEN
-#else
     I_LOOP: DO I = 1, PCOLS
-#endif
+
        PEGWD(I)  = 0.0
        PEORO(I)  = 0.0
        PERAY(I)  = 0.0
@@ -2234,11 +1746,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
        BKGERR(I) = -( PEBKG(I) + KEBKG(I) )
        KERES(I)  =    PEGWD(I) + KEGWD(I) + BKGERR(I)
 
-#ifndef _CUDA
     END DO I_LOOP
-#else
-    END IF I_LOOP
-#endif 
 
   end subroutine postintr
 


### PR DESCRIPTION
CUDA is no longer used for `GEOS_GwdGridComp` (Gravity Wave Drag). There are significant portions of the code for CUDA controlled by preprocessor macros using a flag `_CUDA`. I ran tests with this branch and `develop` with zero diff.