### PR TITLE
Updates for Spack Stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # Anchors to prevent forgetting to update a version
 baselibs_version: &baselibs_version v7.5.0
-bcs_version: &bcs_version v10.22.5
+bcs_version: &bcs_version v10.23.0
 
 orbs:
   ci: geos-esm/circleci-tools@1

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -19,7 +19,7 @@ esma_add_library (${this}
   SRCS ${srcs}
   DEPENDENCIES GEOS_Shared GMAO_mpeu MAPL Chem_Shared Chem_Base esmf)
 
-get_target_property (extra_incs fms_r4 INCLUDE_DIRECTORIES)
+get_target_property (extra_incs fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(${this} PRIVATE
    $<BUILD_INTERFACE:${extra_incs}>
    )


### PR DESCRIPTION
This PR is needed for building GEOSgcm with spack-stack (see https://github.com/NOAA-EMC/spack/pull/174).

In it, we change an `INCLUDE_DIRECTORIES` to `INTERFACE_INCLUDE_DIRECTORIES`. This is needed as FMS-from-Spack uses a CMake config that does not provide `INCLUDE_DIRECTORIES`. 

Testing with GEOS using internal FMS and Baselibs show this still does work and is zero-diff.