### PR TITLE
Update CI BCs version to fix GEOSgcm run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # Anchors to prevent forgetting to update a version
 baselibs_version: &baselibs_version v7.5.0
-bcs_version: &bcs_version v10.22.5
+bcs_version: &bcs_version v10.23.0
 
 orbs:
   ci: geos-esm/circleci-tools@1


### PR DESCRIPTION
Due to recent changes in the GEOSgcm_App, we need to advance the BCs version in the CI so that the scripting for making an experiment works.