### PR TITLE
Add CatchCN vars to rst

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentCNRst.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentCNRst.F90
@@ -48,26 +48,27 @@ module CatchmentCNRstMod
      real, allocatable ::    HDM     (:)
      real, allocatable ::    GDP     (:)
      real, allocatable ::    PEATF   (:) 
+
      ! below is not necessary. It is not read. It is set to 0 during writing
-     !real, allocatable :: bflowm(:)
-     !real, allocatable :: totwatm(:)
-     !real, allocatable :: tairm(:)
-     !real, allocatable :: tpm(:)
-     !real, allocatable :: cnsum(:)
-     !real, allocatable :: sndzm(:)
-     !real, allocatable :: asnowm(:)
-     !real, allocatable :: ar1m(:)
-     !real, allocatable :: rainfm(:)
-     !real, allocatable :: rhm(:)
-     !real, allocatable :: runsrfm(:)
-     !real, allocatable :: snowfm(:)
-     !real, allocatable :: windm(:)
-     !real, allocatable :: tprec10d(:)
-     !real, allocatable :: tprec60d(:)
-     !real, allocatable :: t2m10d(:)
-     !real, allocatable :: sfmcm(:)
-     !real, allocatable :: psnsunm(:,:,:)
-     !real, allocatable :: psnsham(:,:,:)
+     real, allocatable :: bflowm(:)
+     real, allocatable :: totwatm(:)
+     real, allocatable :: tairm(:)
+     real, allocatable :: tpm(:)
+     real, allocatable :: cnsum(:)
+     real, allocatable :: sndzm(:)
+     real, allocatable :: asnowm(:)
+     real, allocatable :: ar1m(:)
+     real, allocatable :: rainfm(:)
+     real, allocatable :: rhm(:)
+     real, allocatable :: runsrfm(:)
+     real, allocatable :: snowfm(:)
+     real, allocatable :: windm(:)
+     real, allocatable :: tprec10d(:)
+     real, allocatable :: tprec60d(:)
+     real, allocatable :: t2m10d(:)
+     real, allocatable :: sfmcm(:)
+     real, allocatable :: psnsunm(:,:,:)
+     real, allocatable :: psnsham(:,:,:)
      
   contains
      procedure :: write_nc4
@@ -125,13 +126,8 @@ contains
         call catch%allocate_cn(__RC__)
         call catch%read_shared_nc4(formatter, __RC__)
 
-        myVariable => meta%get_variable("ITY")
-        dname => myVariable%get_ith_dimension(2)
-        dim1 = meta%get_dimension(dname)
-        do j=1,dim1
-           call MAPL_VarRead(formatter,"ITY",catch%cnity(:,j),offset1=j, __RC__)
-           call MAPL_VarRead(formatter,"FVG",catch%fvg(:,j),offset1=j, __RC__)
-        enddo
+        call MAPL_VarRead(formatter,"ITY",catch%cnity, __RC__)
+        call MAPL_VarRead(formatter,"FVG",catch%fvg, __RC__)
 
         call MAPL_VarRead(formatter,"TG",catch%tg, __RC__)
         call MAPL_VarRead(formatter,"TILE_ID",catch%TILE_ID, __RC__)
@@ -142,19 +138,30 @@ contains
         call MAPL_VarRead(formatter,"BGALBNR",catch%BGALBNR, __RC__)
         call MAPL_VarRead(formatter,"BGALBNF",catch%BGALBNF, __RC__)
 
-        myVariable => meta%get_variable("CNCOL")
-        dname => myVariable%get_ith_dimension(2)
-        dim1 = meta%get_dimension(dname)
-        if( catch%isCLM45) then
+        if( catch%isCLM40 ) then
+           call MAPL_VarRead(formatter,"SFMCM",   catch%sfmcm , __RC__)
+        endif
+
+        if( catch%isCLM45 ) then
            call MAPL_VarRead(formatter,"ABM",     catch%ABM, __RC__)
            call MAPL_VarRead(formatter,"FIELDCAP",catch%FIELDCAP, __RC__)
            call MAPL_VarRead(formatter,"HDM",     catch%HDM     , __RC__)
            call MAPL_VarRead(formatter,"GDP",     catch%GDP     , __RC__)
            call MAPL_VarRead(formatter,"PEATF",   catch%PEATF   , __RC__)
+
+
+           call MAPL_VarRead(formatter,"RHM",       catch%rhm        , __RC__)
+           call MAPL_VarRead(formatter,"WINDM",     catch%windm      , __RC__)
+           call MAPL_VarRead(formatter,"RAINFM",    catch%rainfm     , __RC__)
+           call MAPL_VarRead(formatter,"SNOWFM",    catch%snowfm     , __RC__)
+           call MAPL_VarRead(formatter,"RUNSRFM",   catch%runsrfm    , __RC__)
+           call MAPL_VarRead(formatter,"AR1M",      catch%ar1m       , __RC__)
+           call MAPL_VarRead(formatter,"T2M10D",    catch%T2M10D     , __RC__)
+           call MAPL_VarRead(formatter,"TPREC10D"   catch%TPREC10D   , __RC__)
+           call MAPL_VarRead(formatter,"TPREC60D"   catch%TPREC60D   , __RC__)
         endif
-        do j=1,dim1
-           call MAPL_VarRead(formatter,"CNCOL",catch%CNCOL(:,j),offset1=j, __RC__)
-        enddo
+        call MAPL_VarRead(formatter,"CNCOL",catch%CNCOL, __RC__)
+
         ! The following three lines were added as a bug fix by smahanam on 5 Oct 2020
         ! (to be merged into the "develop" branch in late 2020):
         ! The length of the 2nd dim of CNPFT differs from that of CNCOL.  Prior to this fix,
@@ -162,12 +169,18 @@ contains
         ! resulting in bad values in the "regridded" (re-tiled) restart file. 
         ! This impacted re-tiled restarts for both CNCLM40 and CLCLM45.
         ! - reichle, 23 Nov 2020
-        myVariable => meta%get_variable("CNPFT")
-        dname => myVariable%get_ith_dimension(2)
-        dim1 = meta%get_dimension(dname)
-        do j=1,dim1
-           call MAPL_VarRead(formatter,"CNPFT",catch%CNPFT(:,j),offset1=j, __RC__)
-        enddo
+        call MAPL_VarRead(formatter,"CNPFT",catch%CNPFT, __RC__)
+
+        ! more reading
+        call MAPL_VarRead(formatter,  "BFLOWM",  catch%bflowm ,_RC) 
+        call MAPL_VarRead(formatter,  "TOTWATM", catch%totwatm,_RC) 
+        call MAPL_VarRead(formatter,  "TAIRM",   catch%tairm  ,_RC) 
+        call MAPL_VarRead(formatter,  "TPM",     catch%tpm    ,_RC) 
+        call MAPL_VarRead(formatter,  "CNSUM",   catch%cnsum  ,_RC) 
+        call MAPL_VarRead(formatter,  "SNDZM",   catch%sndzm  ,_RC) 
+        call MAPL_VarRead(formatter,  "ASNOWM",  catch%asnowm ,_RC) 
+        call MAPL_VarRead(formatter,  "PSNSUNM", catch%psnsunm,_RC) 
+        call MAPL_VarRead(formatter,  "PSNSHAM", catch%psnsham,_RC) 
      endif
 
      call formatter%close()
@@ -223,14 +236,9 @@ contains
 
      call this%write_shared_nc4(formatter, __RC__)
 
-     myVariable => meta%get_variable("ITY")
-     dname => myVariable%get_ith_dimension(2)
-     dim1 = meta%get_dimension(dname)
-     do j=1,dim1
-        call MAPL_VarWrite(formatter,"ITY",this%cnity(:,j),offset1=j)
-        call MAPL_VarWrite(formatter,"FVG",this%fvg(:,j),offset1=j)
-        call MAPL_VarWrite(formatter,"TG",this%tg(:,j),offset1=j)
-     enddo
+     call MAPL_VarWrite(formatter,"ITY",this%cnity)
+     call MAPL_VarWrite(formatter,"FVG",this%fvg)
+     call MAPL_VarWrite(formatter,"TG",this%tg)
 
      call MAPL_VarWrite(formatter,"TILE_ID",this%TILE_ID)
      call MAPL_VarWrite(formatter,"NDEP",this%NDEP)
@@ -239,22 +247,10 @@ contains
      call MAPL_VarWrite(formatter,"BGALBVF",this%BGALBVF)
      call MAPL_VarWrite(formatter,"BGALBNR",this%BGALBNR)
      call MAPL_VarWrite(formatter,"BGALBNF",this%BGALBNF)
-     myVariable => meta%get_variable("CNCOL")
-     dname => myVariable%get_ith_dimension(2)
-     dim1 = meta%get_dimension(dname)
-
-     do j=1,dim1
-        call MAPL_VarWrite(formatter,"CNCOL",this%CNCOL(:,j),offset1=j)
-     enddo
-     myVariable => meta%get_variable("CNPFT")
-     dname => myVariable%get_ith_dimension(2)
-     dim1 = meta%get_dimension(dname)
-     do j=1,dim1
-        call MAPL_VarWrite(formatter,"CNPFT",this%CNPFT(:,j),offset1=j)
-     enddo
+     call MAPL_VarWrite(formatter,"CNCOL",this%CNCOL)
+     call MAPL_VarWrite(formatter,"CNPFT",this%CNPFT)
 
      dim1 = meta%get_dimension('tile')
-
      allocate (var(dim1),source = 0.)
 
      call MAPL_VarWrite(formatter,"BFLOWM", var)
@@ -343,6 +339,32 @@ contains
      allocate(this%HDM(ntiles))
      allocate(this%GDP(ntiles))
      allocate(this%PEATF(ntiles))
+
+     allocate(this%bflowm  (ntiles)
+     allocate(this%totwatm (ntiles)
+     allocate(this%tairm   (ntiles)
+     allocate(this%tpm     (ntiles)
+     allocate(this%cnsum   (ntiles)
+     allocate(this%sndzm   (ntiles)
+     allocate(this%asnowm  (ntiles)
+     allocate(this%psnsunm(ntiles,nveg,nzone)
+     allocate(this%psnsham(ntiles,nveg,nzone)
+
+     if (this%isCLM40) then
+        allocate(this%sfmcm   (ntiles)
+     endif
+     if (this%isCLM45) then
+        allocate(this%ar1m    (ntiles)
+        allocate(this%rainfm  (ntiles)
+        allocate(this%rhm     (ntiles)
+        allocate(this%runsrfm (ntiles)
+        allocate(this%snowfm  (ntiles)
+        allocate(this%windm   (ntiles)
+        allocate(this%tprec10d(ntiles)
+        allocate(this%tprec60d(ntiles)
+        allocate(this%t2m10d  (ntiles)
+     endif
+
      _RETURN(_SUCCESS)
    end subroutine allocate_cn
 
@@ -354,7 +376,7 @@ contains
     real, allocatable :: CLMC_pf1(:), CLMC_pf2(:), CLMC_sf1(:), CLMC_sf2(:)
     real, allocatable :: CLMC_pt1(:), CLMC_pt2(:), CLMC_st1(:), CLMC_st2(:)    
     real, allocatable :: NDEP(:), BVISDR(:), BVISDF(:), BNIRDR(:), BNIRDF(:) 
-    real, allocatable :: T2(:), var1(:), hdm(:), fc(:), gdp(:), peatf(:)
+    real, allocatable :: T2(:), hdm(:), fc(:), gdp(:), peatf(:)
     integer, allocatable :: ity(:), abm (:)
     integer       :: STATUS, ntiles, unit27, unit28, unit29, unit30
     integer       :: idum, i,j,n, ib, nv
@@ -378,7 +400,7 @@ contains
     allocate (CLMC_sf2(ntiles), CLMC_pt1(ntiles), CLMC_pt2(ntiles))
     allocate (CLMC_st1(ntiles), CLMC_st2(ntiles))
     allocate (hdm(ntiles), fc(ntiles), gdp(ntiles))
-    allocate (peatf(ntiles), abm(ntiles), var1(ntiles))
+    allocate (peatf(ntiles), abm(ntiles))
 
     inquire(file = trim(OutBcsDir)//'/clsm/catchcn_params.nc4', exist=file_exists)
     inquire(file = trim(OutBcsDir)//'/clsm/CLM_veg_typs_fracs', exist=NewLand )
@@ -548,7 +570,7 @@ contains
          CLMC_pt1, CLMC_pt2,CLMC_st1,CLMC_st2, var_dum2, var_dum3
      integer                :: AGCM_YY,AGCM_MM,AGCM_DD,AGCM_HR=0,AGCM_DATE
      real,    allocatable, dimension(:,:) :: fveg_offl,  ityp_offl, tg_tmp
-     real, allocatable :: var_off_col (:,:,:), var_off_pft (:,:,:,:)
+     real, allocatable :: var_off_col (:,:,:), var_off_pft (:,:,:,:), var_out(:), var_psn(:,:,:)
      integer :: status, in_ntiles, out_ntiles, numprocs
      logical :: root_proc
      integer :: mpierr, n, i, k, tag, req, st, ed, myid, L, iv, nv,nz, var_col, var_pft
@@ -726,6 +748,8 @@ contains
         allocate (var_off_col (1: in_ntiles, 1 : nzone,1 : var_col))
         allocate (var_off_pft (1: in_ntiles, 1 : nzone,1 : nveg, 1 : var_pft))
         allocate (var_dum2    (1:in_ntiles))
+        allocate (var_out     (1:out_ntiles))
+        allocate (var_psn     (1:out_ntiles), nveg, nzone)
 
         this%tile_id = [(i*1.0, i=1, out_ntiles)]
 
@@ -734,6 +758,59 @@ contains
           tg_tmp(:,i) = this%tg(this%id_glb(:),i)
         enddo        
         this%tg = tg_tmp
+       
+        var_out = this%bflowm (this%id_glb(:))
+        this%bflowm = var_out
+        var_out = this%totwatm(this%id_glb(:))
+        this%totwatm= var_out
+        var_out = this%tairm  (this%id_glb(:))
+        this%tairm  = var_out
+        var_out = this%tpm    (this%id_glb(:))
+        this%tpm    = var_out
+        var_out = this%cnsum  (this%id_glb(:))
+        this%cnsum  = var_out
+        var_out = this%sndzm  (this%id_glb(:))
+        this%sndzm  = var_out
+        var_out = this%asnowm (this%id_glb(:))
+        this%asnowm = var_out
+        do nz = 1, nzone
+           do nv = 1, nveg
+               var_psn(:,nv,nz) = this%psnsunm(this%id_glb(:), nv,nz)
+           enddo
+        enddo
+        this%psnsunm= var_psn
+
+        do nz = 1, nzone
+           do nv = 1, nveg
+               var_psn(:,nv,nz) = this%psnsham(this%id_glb(:), nv,nz)
+           enddo
+        enddo
+        this%psnsham = var_psn
+
+        if (this%isCLM40) then
+           var_out = this%sfmcm (this%id_glb(:))
+           this%sfmcm = var_out
+        endif
+        if (this%isCLM45) then
+           var_out = this%ar1m    (this%id_glb(:))
+           this%ar1m    = var_out
+           var_out = this%rainfm  (this%id_glb(:))
+           this%rainfm  = var_out
+           var_out = this%rhm     (this%id_glb(:))
+           this%rhm     = var_out
+           var_out = this%runsrfm (this%id_glb(:))
+           this%runsrfm = var_out
+           var_out = this%snowfm  (this%id_glb(:))
+           this%snowfm  = var_out
+           var_out = this%windm   (this%id_glb(:))
+           this%windm   = var_out
+           var_out = this%tprec10d(this%id_glb(:))
+           this%tprec10d= var_out
+           var_out = this%tprec60d(this%id_glb(:))
+           this%tprec60d= var_out
+           var_out = this%t2m10d  (this%id_glb(:))
+           this%t2m10d  = var_out
+        endif
 
         i = 1
         do nv = 1,VAR_COL

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentCNRst.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentCNRst.F90
@@ -50,7 +50,6 @@ module CatchmentCNRstMod
      real, allocatable ::    GDP     (:)
      real, allocatable ::    PEATF   (:) 
 
-     ! below is not necessary. It is not read. It is set to 0 during writing
      real, allocatable :: bflowm(:)
      real, allocatable :: totwatm(:)
      real, allocatable :: tairm(:)


### PR DESCRIPTION
This PR address the issue #651.  

Adds CatchCN-specific restart variables in CatchmentCNRst.F90 that were written to the output restart file but not read from the input restart file when restarts were remapped across resolutions, with the effect that these variables were set to 0 everywhere.

Trivially 0-diff for GCM tests because only CatchCN is touched.  Not 0-diff for CatchCN simulations that involve remapping of restarts across different resolutions. 

Note that this PR does not fix remapping of restarts with `regrid.pl`. Since regrid.pl is deprecated, it is not going to be fixed. CatchCN users should use `remap_catchANDcn.py` with a manually assembled yaml config file. Eventually, remap_catchANDcn.py will include interactive config functionality.

Contingencies:
This PR depends on https://github.com/GEOS-ESM/MAPL/pull/1757