### PR TITLE
correction of units for mislabeled CatchCNCLM45 variables

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/GEOS_CatchCNCLM45GridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/GEOS_CatchCNCLM45GridComp.F90
@@ -1737,7 +1737,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddInternalSpec(GC                       ,&
        LONG_NAME          = 'CN sum for relative humidity',&
-       UNITS              = 'K'                         ,&
+       UNITS              = '%'                         ,&
        SHORT_NAME         = 'RHM'                       ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
@@ -1747,7 +1747,7 @@ subroutine SetServices ( GC, RC )
      
   call MAPL_AddInternalSpec(GC                       ,&
        LONG_NAME          = 'CN sum for wind speed'     ,&
-       UNITS              = 'K'                         ,&
+       UNITS              = 'm s-1'                     ,&
        SHORT_NAME         = 'WINDM'                     ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
@@ -1757,7 +1757,7 @@ subroutine SetServices ( GC, RC )
   
   call MAPL_AddInternalSpec(GC                       ,&
        LONG_NAME          = 'CN sum for rainfall'       ,&
-       UNITS              = 'K'                         ,&
+       UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RAINFM'                    ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
@@ -1767,7 +1767,7 @@ subroutine SetServices ( GC, RC )
   
   call MAPL_AddInternalSpec(GC                       ,&
        LONG_NAME          = 'CN sum for snow fall'      ,&
-       UNITS              = 'K'                         ,&
+       UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'SNOWFM'                    ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
@@ -1777,7 +1777,7 @@ subroutine SetServices ( GC, RC )
   
   call MAPL_AddInternalSpec(GC                       ,&
        LONG_NAME          = 'CN sum for surface runoff' ,&
-       UNITS              = 'K'                         ,&
+       UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RUNSRFM'                   ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
@@ -1787,7 +1787,7 @@ subroutine SetServices ( GC, RC )
   
   call MAPL_AddInternalSpec(GC                       ,&
        LONG_NAME          = 'CN sum for frac saturated area',&
-       UNITS              = 'K'                         ,&
+       UNITS              = '1'                         ,&
        SHORT_NAME         = 'AR1M'                      ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&


### PR DESCRIPTION
This PR addresses issue #659 . It corrects the units for several CatchCNCLM45 restart variables, which were incorrectly specified as Kelvin ('K') in the MAPL_InternalSpecs in GEOS_CatchCNCLM45GridComp.F90

The fix implemented here only affects the documentation of these variables, so it is trivially 0-diff for both GEOSldas and the GCM.

@weiyuan-jiang @gmao-rreichle 