### PR TITLE
no re-tile for bcs parameters in catchment restart file

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentRst.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentRst.F90
@@ -266,40 +266,14 @@ contains
      integer, optional, intent(out):: rc
      integer :: status
      
-     call MAPL_VarRead(formatter,"BF1",this%bf1, __RC__)
-     call MAPL_VarRead(formatter,"BF2",this%bf2, __RC__)
-     call MAPL_VarRead(formatter,"BF3",this%bf3, __RC__)
+     ! the four variables are used as scaler
      call MAPL_VarRead(formatter,"VGWMAX",this%vgwmax, __RC__)
      call MAPL_VarRead(formatter,"CDCR1",this%cdcr1, __RC__)
      call MAPL_VarRead(formatter,"CDCR2",this%cdcr2, __RC__)
-     call MAPL_VarRead(formatter,"PSIS",this%psis, __RC__)
-     call MAPL_VarRead(formatter,"BEE",this%bee, __RC__)
      call MAPL_VarRead(formatter,"POROS",this%poros, __RC__)
-     call MAPL_VarRead(formatter,"WPWET",this%wpwet, __RC__)
-     call MAPL_VarRead(formatter,"COND",this%cond, __RC__)
-     call MAPL_VarRead(formatter,"GNU",this%gnu, __RC__)
-     call MAPL_VarRead(formatter,"ARS1",this%ars1, __RC__)
-     call MAPL_VarRead(formatter,"ARS2",this%ars2, __RC__)
-     call MAPL_VarRead(formatter,"ARS3",this%ars3, __RC__)
-     call MAPL_VarRead(formatter,"ARA1",this%ara1, __RC__)
-     call MAPL_VarRead(formatter,"ARA2",this%ara2, __RC__)
-     call MAPL_VarRead(formatter,"ARA3",this%ara3, __RC__)
-     call MAPL_VarRead(formatter,"ARA4",this%ara4, __RC__)
-     call MAPL_VarRead(formatter,"ARW1",this%arw1, __RC__)
-     call MAPL_VarRead(formatter,"ARW2",this%arw2, __RC__)
-     call MAPL_VarRead(formatter,"ARW3",this%arw3, __RC__)
-     call MAPL_VarRead(formatter,"ARW4",this%arw4, __RC__)
-     call MAPL_VarRead(formatter,"TSA1",this%tsa1, __RC__)
-     call MAPL_VarRead(formatter,"TSA2",this%tsa2, __RC__)
-     call MAPL_VarRead(formatter,"TSB1",this%tsb1, __RC__)
-     call MAPL_VarRead(formatter,"TSB2",this%tsb2, __RC__)
-     call MAPL_VarRead(formatter,"ATAU",this%atau, __RC__)
-     call MAPL_VarRead(formatter,"BTAU",this%btau, __RC__)
+
      call MAPL_VarRead(formatter,"TC",this%tc, __RC__)
      call MAPL_VarRead(formatter,"QC",this%qc, __RC__)
-!
-!     call MAPL_VarRead(formatter,"OLD_ITY",this%ity, __RC__)
-!
      call MAPL_VarRead(formatter,"CAPAC",this%capac, __RC__)
      call MAPL_VarRead(formatter,"CATDEF",this%catdef, __RC__)
      call MAPL_VarRead(formatter,"RZEXC",this%rzexc, __RC__)
@@ -445,36 +419,11 @@ contains
      integer, optional, intent(out):: rc
      integer :: ntiles
      ntiles = this%ntiles
-     allocate( this%        bf1(ntiles) )
-     allocate( this%        bf2(ntiles) )
-     allocate( this%        bf3(ntiles) )
      allocate( this%     vgwmax(ntiles) )
      allocate( this%      cdcr1(ntiles) )
      allocate( this%      cdcr2(ntiles) )
-     allocate( this%       psis(ntiles) )
-     allocate( this%        bee(ntiles) )
      allocate( this%      poros(ntiles) )
-     allocate( this%      wpwet(ntiles) )
-     allocate( this%       cond(ntiles) )
-     allocate( this%        gnu(ntiles) )
-     allocate( this%       ars1(ntiles) )
-     allocate( this%       ars2(ntiles) )
-     allocate( this%       ars3(ntiles) )
-     allocate( this%       ara1(ntiles) )
-     allocate( this%       ara2(ntiles) )
-     allocate( this%       ara3(ntiles) )
-     allocate( this%       ara4(ntiles) )
-     allocate( this%       arw1(ntiles) )
-     allocate( this%       arw2(ntiles) )
-     allocate( this%       arw3(ntiles) )
-     allocate( this%       arw4(ntiles) )
-     allocate( this%       tsa1(ntiles) )
-     allocate( this%       tsa2(ntiles) )
-     allocate( this%       tsb1(ntiles) )
-     allocate( this%       tsb2(ntiles) )
-     allocate( this%       atau(ntiles) )
-     allocate( this%       btau(ntiles) )
-     allocate( this%        ity(ntiles) )
+
      allocate( this%         tc(ntiles,4) )
      allocate( this%         qc(ntiles,4) )
      allocate( this%      capac(ntiles) )
@@ -490,9 +439,6 @@ contains
      
      if (this%meta%has_variable('TSURF')) then
        allocate( this%    tsurf(ntiles) )
-     endif
-     if (this%meta%has_variable('SNOWALB')) then
-       allocate( this%  snowalb(ntiles) )
      endif
 
      allocate( this%     wesnn1(ntiles) )
@@ -553,38 +499,35 @@ contains
       inquire(file = trim(DataDir)//'/clsm/catch_params.nc4', exist=file_exists)
       inquire(file = trim(DataDir)//"/clsm/CLM_veg_typs_fracs",exist=NewLand )
 
-      if (size(this%ara1) /= this%ntiles ) then
-        ! it is just re-allocate
-        this%ity   = DP2BR
-        this%ARA1  = DP2BR      
-        this%ARA2  = DP2BR      
-        this%ARA3  = DP2BR      
-        this%ARA4  = DP2BR      
-        this%ARS1  = DP2BR      
-        this%ARS2  = DP2BR      
-        this%ARS3  = DP2BR      
-        this%ARW1  = DP2BR      
-        this%ARW2  = DP2BR      
-        this%ARW3  = DP2BR      
-        this%ARW4  = DP2BR      
-        this%ATAU  = DP2BR      
-        this%BTAU  = DP2BR      
-        this%PSIS  = DP2BR      
-        this%BEE   = DP2BR      
-        this%BF1   = DP2BR      
-        this%BF2   = DP2BR      
-        this%BF3   = DP2BR      
-        this%TSA1  = DP2BR      
-        this%TSA2  = DP2BR      
-        this%TSB1  = DP2BR      
-        this%TSB2  = DP2BR      
-        this%COND  = DP2BR      
-        this%WPWET = DP2BR      
-        this%POROS = DP2BR
-        this%VGWMAX = DP2BR
-        this%cdcr1 = DP2BR
-        this%cdcr2 = DP2BR
-      endif
+      this%ity   = DP2BR
+      this%ARA1  = DP2BR      
+      this%ARA2  = DP2BR      
+      this%ARA3  = DP2BR      
+      this%ARA4  = DP2BR      
+      this%ARS1  = DP2BR      
+      this%ARS2  = DP2BR      
+      this%ARS3  = DP2BR      
+      this%ARW1  = DP2BR      
+      this%ARW2  = DP2BR      
+      this%ARW3  = DP2BR      
+      this%ARW4  = DP2BR      
+      this%ATAU  = DP2BR      
+      this%BTAU  = DP2BR      
+      this%PSIS  = DP2BR      
+      this%BEE   = DP2BR      
+      this%BF1   = DP2BR      
+      this%BF2   = DP2BR      
+      this%BF3   = DP2BR      
+      this%TSA1  = DP2BR      
+      this%TSA2  = DP2BR      
+      this%TSB1  = DP2BR      
+      this%TSB2  = DP2BR      
+      this%COND  = DP2BR      
+      this%WPWET = DP2BR      
+      this%POROS = DP2BR
+      this%VGWMAX = DP2BR
+      this%cdcr1 = DP2BR
+      this%cdcr2 = DP2BR
 
       if(file_exists) then
         call CatchFmt%Open(trim(DataDir)//'/clsm/catch_params.nc4', pFIO_READ, __RC__)
@@ -935,91 +878,14 @@ contains
        var_out    = this%poros(id_glb(:))
        this%poros = var_out
 
-       var_out   = this%cond(id_glb(:))
-       this%cond = var_out
-
-       var_out   = this%psis(id_glb(:))
-       this%psis = var_out
-
-       var_out  = this%bee(id_glb(:))
-       this%bee = var_out
-
-       var_out    = this%wpwet(id_glb(:))
-       this%wpwet = var_out
-
-       var_out   = this%gnu(id_glb(:))
-       this%gnu  = var_out
-
        var_out      = this%vgwmax(id_glb(:))
        this%vgwmax  = var_out
-
-       var_out   = this%bf1(id_glb(:))
-       this%bf1  = var_out
-
-       var_out   = this%bf2(id_glb(:))
-       this%bf2  = var_out
-
-       var_out   = this%bf3(id_glb(:))
-       this%bf3  = var_out
 
        var_out     = this%cdcr1(id_glb(:))
        this%cdcr1  = var_out
 
        var_out     = this%cdcr2(id_glb(:))
        this%cdcr2  = var_out
-
-       var_out     = this%ars1(id_glb(:))
-       this%ars1   = var_out
-
-       var_out     = this%ars2(id_glb(:))
-       this%ars2   = var_out
-
-       var_out     = this%ars3(id_glb(:))
-       this%ars3   = var_out
-
-       var_out     = this%ara1(id_glb(:))
-       this%ara1   = var_out
-
-       var_out     = this%ara2(id_glb(:))
-       this%ara2   = var_out
-
-       var_out     = this%ara3(id_glb(:))
-       this%ara3   = var_out
-
-       var_out     = this%ara4(id_glb(:))
-       this%ara4   = var_out
-
-       var_out     = this%arw1(id_glb(:))
-       this%arw1   = var_out
-
-       var_out     = this%arw2(id_glb(:))
-       this%arw2   = var_out
-
-       var_out     = this%arw3(id_glb(:))
-       this%arw3   = var_out
-
-       var_out     = this%arw4(id_glb(:))
-       this%arw4   = var_out
-
-       var_out     = this%tsa1(id_glb(:))
-       this%tsa1   = var_out
-
-       var_out     = this%tsa2(id_glb(:))
-       this%tsa2   = var_out
-
-       var_out     = this%tsb1(id_glb(:))
-       this%tsb1   = var_out
-
-       var_out     = this%tsb2(id_glb(:))
-       this%tsb2   = var_out
-
-       var_out     = this%atau(id_glb(:))
-       this%atau   = var_out
-
-       var_out     = this%btau(id_glb(:))
-       this%btau   = var_out
-
-       this%ity = [(k*1., k=1, out_ntiles)]
 
        tmp2d = this%tc
        deallocate(this%tc)
@@ -1096,11 +962,6 @@ contains
        if (this%meta%has_variable('TSURF')) then
           var_out = this%tsurf(id_glb(:)) 
           this%tsurf = var_out
-       endif
-
-       if (this%meta%has_variable('SNOWALB')) then
-          var_out = this%snowalb(id_glb(:)) 
-          this%snowalb = var_out
        endif
 
        ! CH CM CQ FR WW
@@ -1298,12 +1159,13 @@ contains
 
    subroutine set_scale_var(this )
      class(CatchmentRst), intent(inout) :: this
-     this%old_catdef = this%catdef
      this%old_poros  = this%poros
      this%old_cdcr1  = this%cdcr1
      this%old_cdcr2  = this%cdcr2
-     this%old_rzexc  = this%rzexc
      this%old_vgwmax = this%vgwmax
+
+     this%old_catdef = this%catdef
+     this%old_rzexc  = this%rzexc
      this%old_sndzn3 = this%sndzn3
      this%old_ghtcnt1 = this%ghtcnt1
      this%old_ghtcnt2 = this%ghtcnt2

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentRst.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentRst.F90
@@ -266,12 +266,13 @@ contains
      integer, optional, intent(out):: rc
      integer :: status
      
-     ! the four variables are used as scaler
+     ! these four (time-invariant) variables are used for rescaling of prognostic variables
      call MAPL_VarRead(formatter,"VGWMAX",this%vgwmax, __RC__)
      call MAPL_VarRead(formatter,"CDCR1",this%cdcr1, __RC__)
      call MAPL_VarRead(formatter,"CDCR2",this%cdcr2, __RC__)
      call MAPL_VarRead(formatter,"POROS",this%poros, __RC__)
 
+     ! Catchment model prognostic variables (and some diagnostics needed in Catch restart for GCM) 
      call MAPL_VarRead(formatter,"TC",this%tc, __RC__)
      call MAPL_VarRead(formatter,"QC",this%qc, __RC__)
      call MAPL_VarRead(formatter,"CAPAC",this%capac, __RC__)
@@ -1146,7 +1147,7 @@ contains
 
      endif
 
- ! PEATCLSM - ensure low CATDEF on peat tiles where "old" restart is not also peat
+  ! PEATCLSM - ensure low CATDEF on peat tiles where "old" restart is not also peat
   ! -------------------------------------------------------------------------------
 
      where ( (this%old_poros < PEATCLSM_POROS_THRESHOLD) .and. (this%poros >= PEATCLSM_POROS_THRESHOLD) )


### PR DESCRIPTION
No need to read bcs from restart files, instead, read bc parameters directly from target bc directory. 
Addresses #669 