### PR TITLE
Update CircleCI to use 7.7.0 baselibs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.5.0
+baselibs_version: &baselibs_version v7.7.0
 bcs_version: &bcs_version v10.23.0
 
 orbs:


### PR DESCRIPTION
This updates the CI to use 7.7.0 Baselibs.

This should also let the CI work once https://github.com/GEOS-ESM/GEOSgcm_App/pull/381 is pulled in.