### PR TITLE
Improve user interface of mk_runofftbl.F90

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
@@ -18,7 +18,39 @@ program Runoff
   character*100          :: fileLL="data/CATCH/Outlet_latlon."
   character*5            :: C_NX, C_NY
 
-  call get_command_argument(1,file)
+  logical                :: adjust_oceanLandSea_mask = .false. ! default is .false.
+  integer                :: nxt, command_argument_count
+  character*(128)        :: arg, &
+                            Usage = "mk_runofftbl.x CF0012x6C_TM0072xTM0036-Pfafstetter"
+
+! Read inputs -----------------------------------------------------
+  I = command_argument_count()
+  if (I < 1 .or. I > 2) then
+    print *, " "
+    print *, "Wrong number of input arguments, got: ", I
+    print *, "Example usage with defaults: "
+    print *, " "
+    print *, trim(Usage)
+    print *, " "
+    call exit(1)
+  end if
+
+  nxt = 1
+  call get_command_argument(nxt, file)
+  print *, " "
+  print*, "Working on with input BCs string: ", file
+  print *, " "
+  if (I > 1) then
+    nxt = nxt + 1
+    call get_command_argument(nxt, arg)
+    if ( trim(arg) .ne. 'yes') then
+      print *, "Incorrect optional second argument, should be: yes"
+      call exit(2)
+    else
+      adjust_oceanLandSea_mask = .true.
+    endif
+  endif
+! ------------------------------------------------------------------
 
   fileT = "til/"//trim(file)//".til" ! input
   fileR = "rst/"//trim(file)//".rst" ! input
@@ -275,6 +307,13 @@ program Runoff
   enddo
 
   print *, "area of land   = ",    sum(real(area*out,kind=8))
+
+  if (adjust_oceanLandSea_mask) then
+    print *, " "
+    print *, "Accounting for any mismatch between land-sea masks:"
+    print *, "of GEOS land and external ocean model."
+    print *, " "
+  endif
 
   print *, "Completed successfully"
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
@@ -329,21 +329,18 @@ contains
              lons, lats, area, type, tnum, Nr, Nt, Nto, im, jm)
   implicit none
   integer, intent(inout) :: dstind(Nr)
-  real, intent(inout) :: weight(Nr) ! New destination index in routing table
-  real, intent(in)  :: slmask(jm,im) ! sea-land mask
-  integer, intent(in) :: type(Nt) ! input tile type (ocean=0 or lake=19)
-  integer, intent(in)  :: ii(Nt), jj(Nt) ! indexes of ocean grid
-  real, intent(in)  :: lons(Nt), lats(Nt), area(Nt)  ! lons and lats and area of tiles
-  integer, intent(in) :: tnum(Nto) ! number of ocean tile in tile file
-  integer, intent(in) :: Nr, Nt, Nto, im, jm
+  real,    intent(inout) :: weight(Nr)     ! New destination index in routing table
+  real,    intent(in)    :: slmask(jm,im)  ! sea-land mask
+  integer, intent(in)    :: type(Nt)       ! input tile type (ocean=0 or lake=19)
+  integer, intent(in)    :: ii(Nt), jj(Nt) ! indexes of ocean grid
+  real,    intent(in)    :: lons(Nt), lats(Nt), area(Nt)  ! lons and lats and area of tiles
+  integer, intent(in)    :: tnum(Nto)      ! number of ocean tile in tile file
+  integer, intent(in)    :: Nr, Nt, Nto, im, jm
+
   real :: circles(3,Nt) ! metrics of great circle
-  real :: dist(Nto) ! distances to re-routed tile
+  real :: dist(Nto)     ! distances to re-routed tile
   real :: deg2rad
   integer :: i, dind, tt, nmoved
-
-  !f2py intent(in) :: slmask, ii, jj, lons, lats, area, type, tnum
-  !f2py intent(in,out) :: dstind, weight
-  !f2py intent(hide) :: Nr, Nt, Nto, im, jm
 
   deg2rad=acos(-1.)/180.
   circles(1,:)=sin(lats*deg2rad)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
@@ -329,47 +329,6 @@ program Runoff
 ! -----------------------------------------------------------------
 contains
 
-  subroutine reroute(dstind, weight, slmask, ii, jj, &
-             lons, lats, area, type, tnum, Nr, Nt, Nto, im, jm)
-  implicit none
-  integer, intent(inout) :: dstind(Nr)
-  real,    intent(inout) :: weight(Nr)     ! New destination index in routing table
-  real,    intent(in)    :: slmask(jm,im)  ! sea-land mask
-  integer, intent(in)    :: type(Nt)       ! input tile type (ocean=0 or lake=19)
-  integer, intent(in)    :: ii(Nt), jj(Nt) ! indexes of ocean grid
-  real,    intent(in)    :: lons(Nt), lats(Nt), area(Nt)  ! lons and lats and area of tiles
-  integer, intent(in)    :: tnum(Nto)      ! number of ocean tile in tile file
-  integer, intent(in)    :: Nr, Nt, Nto, im, jm
-
-  real :: circles(3,Nt) ! metrics of great circle
-  real :: dist(Nto)     ! distances to re-routed tile
-  real :: deg2rad
-  integer :: i, dind, tt, nmoved
-
-  deg2rad=acos(-1.)/180.
-  circles(1,:)=sin(lats*deg2rad)
-  circles(2,:)=cos(lats*deg2rad)*cos(lons*deg2rad)
-  circles(3,:)=cos(lats*deg2rad)*sin(lons*deg2rad)
-
-  nmoved=0.0
-
-  do i=1,Nr
-     dind=dstind(i)
-     if(type(dind) == 0) then ! do only for ocean tiles
-        if( slmask(jj(dind),ii(dind)) == 0) then
-           nmoved=nmoved+1
-           forall(tt=1:Nto) dist(tt)=acos(sum(circles(:,dind)*circles(:,tnum(tt))))
-           dstind(i)=tnum(minloc(dist,1))
-           weight(i)=weight(i)*area(dind)/area(dstind(i))
-           print*, nmoved
-        end if
-     end if     
-  end do
-  
-  print*, 'Total tiles re-routed: ', nmoved
-  end subroutine reroute
-! ----------------------
-
   subroutine read_oceanModel_mask( mask_file)
   implicit none
   character*128,    intent(in)  :: mask_file
@@ -394,7 +353,6 @@ contains
   call check( nf90_close(ncid)) ! close nc file
 
   deallocate( wetMask)
-
   end subroutine read_oceanModel_mask 
 ! ----------------------
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
@@ -318,4 +318,52 @@ program Runoff
   print *, "Completed successfully"
 
   call exit(0)
+
+! -----------------------------------------------------------------
+contains
+
+  subroutine reroute(dstind, weight, slmask, ii, jj, &
+             lons, lats, area, type, tnum, Nr, Nt, Nto, im, jm)
+  implicit none
+  integer, intent(inout) :: dstind(Nr)
+  real, intent(inout) :: weight(Nr) ! New destination index in routing table
+  real, intent(in)  :: slmask(jm,im) ! sea-land mask
+  integer, intent(in) :: type(Nt) ! input tile type (ocean=0 or lake=19)
+  integer, intent(in)  :: ii(Nt), jj(Nt) ! indexes of ocean grid
+  real, intent(in)  :: lons(Nt), lats(Nt), area(Nt)  ! lons and lats and area of tiles
+  integer, intent(in) :: tnum(Nto) ! number of ocean tile in tile file
+  integer, intent(in) :: Nr, Nt, Nto, im, jm
+  real :: circles(3,Nt) ! metrics of great circle
+  real :: dist(Nto) ! distances to re-routed tile
+  real :: deg2rad
+  integer :: i, dind, tt, nmoved
+
+  !f2py intent(in) :: slmask, ii, jj, lons, lats, area, type, tnum
+  !f2py intent(in,out) :: dstind, weight
+  !f2py intent(hide) :: Nr, Nt, Nto, im, jm
+
+  deg2rad=acos(-1.)/180.
+  circles(1,:)=sin(lats*deg2rad)
+  circles(2,:)=cos(lats*deg2rad)*cos(lons*deg2rad)
+  circles(3,:)=cos(lats*deg2rad)*sin(lons*deg2rad)
+
+  nmoved=0.0
+
+  do i=1,Nr
+     dind=dstind(i)
+     if(type(dind) == 0) then ! do only for ocean tiles
+        if( slmask(jj(dind),ii(dind)) == 0) then
+           nmoved=nmoved+1
+           forall(tt=1:Nto) dist(tt)=acos(sum(circles(:,dind)*circles(:,tnum(tt))))
+           dstind(i)=tnum(minloc(dist,1))
+           weight(i)=weight(i)*area(dind)/area(dstind(i))
+           print*, nmoved
+        end if
+     end if     
+  end do
+  
+  print*, 'Total tiles re-routed: ', nmoved
+  end subroutine reroute
+! -----------------------------------------------------------------
+
 end program Runoff

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
@@ -20,10 +20,10 @@ program Runoff
 
   call get_command_argument(1,file)
 
-  fileT = "til/"//trim(file)//".til"
-  fileR = "rst/"//trim(file)//".rst"
-  fileO = "til/"//trim(file)//".trn"
-  fileB = "til/"//trim(file)//".TRN"
+  fileT = "til/"//trim(file)//".til" ! input
+  fileR = "rst/"//trim(file)//".rst" ! input
+  fileO = "til/"//trim(file)//".trn" ! output
+  fileB = "til/"//trim(file)//".TRN" ! output
 
 ! Read I and J indeces of river outlets.
 ! These should all be ocean pixels
@@ -245,8 +245,8 @@ program Runoff
 
   print *, '>>>', sum(SrcFraction*area(DstTile))
 
-! Write output file
-!------------------
+! Write output files
+!-------------------
 
   print *, "Writing output file..."
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
@@ -40,7 +40,7 @@ program Runoff
   nxt = 1
   call get_command_argument(nxt, file)
   print *, " "
-  print*, "Working on with input BCs string: ", file
+  print*, "Working with input BCs string: ", file
   print *, " "
   if (I > 1) then
     nxt = nxt + 1

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
@@ -15,7 +15,7 @@ program Runoff
   integer                :: type, np,lnd, is,ie,ww
   integer                :: numtrans,  numclosed
   integer                :: status
-  character*100          :: file, fileT, fileR, fileO, fileB
+  character*100          :: file, fileT, fileR, fileO, fileB, fileBB
   character*100          :: fileLL="data/CATCH/Outlet_latlon."
   character*5            :: C_NX, C_NY
 
@@ -114,6 +114,23 @@ program Runoff
 ! Count the number of Ocean and land tiles in the tile file
 !  All land tiles preceed the ocean tiles.
 !----------------------------------------------------------
+
+! If asked for, adjust tiles to be 
+! comptabile with ocean model land-sea mask and write ANOTHER output file
+!-------------------------------------------------------------------------
+
+  if (adjust_oceanLandSea_mask) then
+    fileBB = "til/"//trim(file)//"_oceanMask_adj.TRN" ! output
+
+    print *, " "
+    print *, "Accounting for any mismatch between land-sea masks:"
+    print *, "- Of GEOS land and external ocean model."
+    print *, "- Output file: ", fileB
+    print *, " "
+    call read_oceanModel_mask( mapl_tp_file)
+!   ... some adjustment of following variable: `type` 
+!   ... using ocean model land-sea mask should be done here
+  endif
 
 !  print *, "Reading til file "//trim(fileT) 
 
@@ -294,27 +311,14 @@ program Runoff
   close(10)
 
   call write_route_file( fileB, NumTrans, SrcTile, DstTile, SrcFraction)
+  if (adjust_oceanLandSea_mask) &
+     call write_route_file( fileBB, NumTrans, SrcTile, DstTile, SrcFraction)
 
   do j=1,NumTrans
      Out(DstTile(j)) = Out(DstTile(j)) + In(SrcTile(J))*SrcFraction(J)
   enddo
   print *, "area of land   = ",    sum(real(area*out,kind=8))
 
-! If asked for
-! adjust for ocean model land-sea mask and write ANOTHER output file
-!---------------------------------------------------------------------------------
-
-  if (adjust_oceanLandSea_mask) then
-    fileB = "til/"//trim(file)//"_oceanMask_adj.TRN" ! output
-
-    print *, " "
-    print *, "Accounting for any mismatch between land-sea masks:"
-    print *, "- Of GEOS land and external ocean model."
-    print *, "- Output file: ", fileB
-    print *, " "
-    call read_oceanModel_mask( mapl_tp_file)
-    call write_route_file( fileB, NumTrans, SrcTile, DstTile, SrcFraction)
-  endif
 
   print *, "Completed successfully"
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/mk_runofftbl.F90
@@ -283,39 +283,42 @@ program Runoff
   print *, "Writing output file..."
 
   open(10,file=fileO, form="formatted", status="unknown")
-
   write(10,*) NumTrans
-
   do k=1,NumTrans
      write(10,"(2I10,f16.8)") SrcTile(k),DstTile(k),SrcFraction(k)
   end do
-
   close(10)
 
-
-  open(10,file=fileB, form="unformatted", status="unknown")
-
-  write(10) NumTrans
-  write(10) SrcTile
-  write(10) DstTile
-  write(10) SrcFraction
-
-  close(10)
+  call write_route_file( fileB, NumTrans, SrcTile, DstTile, SrcFraction)
 
   do j=1,NumTrans
      Out(DstTile(j)) = Out(DstTile(j)) + In(SrcTile(J))*SrcFraction(J)
   enddo
-
   print *, "area of land   = ",    sum(real(area*out,kind=8))
 
+! If asked for
+! adjust for ocean model land-sea mask and write ANOTHER output file
+!---------------------------------------------------------------------------------
+
   if (adjust_oceanLandSea_mask) then
+    fileB = "til/"//trim(file)//"_oceanMask_adj.TRN" ! output
+
     print *, " "
     print *, "Accounting for any mismatch between land-sea masks:"
-    print *, "of GEOS land and external ocean model."
+    print *, "- Of GEOS land and external ocean model."
+    print *, "- Output file: ", fileB
     print *, " "
+!   call (...)
+    call write_route_file( fileB, NumTrans, SrcTile, DstTile, SrcFraction)
   endif
 
   print *, "Completed successfully"
+
+  deallocate( SrcFraction)
+  deallocate( SortArr)
+  deallocate( rst)
+  deallocate( area)
+  deallocate( lats, lons)
 
   call exit(0)
 
@@ -364,6 +367,22 @@ contains
   
   print*, 'Total tiles re-routed: ', nmoved
   end subroutine reroute
+! ----------------------
+
+  subroutine write_route_file( fileB, NumTrans, SrcTile, DstTile, SrcFraction)
+  implicit none
+  character*100,    intent(in) :: fileB
+  integer,          intent(in) :: NumTrans
+  integer, pointer, intent(in) :: srctile(:), dsttile(:)
+  real,             intent(in) :: SrcFraction(:)
+
+  open(10,file=fileB, form="unformatted", status="unknown")
+  write(10) NumTrans
+  write(10) SrcTile
+  write(10) DstTile
+  write(10) SrcFraction
+  close(10)
+  end subroutine write_route_file
 ! -----------------------------------------------------------------
 
 end program Runoff


### PR DESCRIPTION
This PR:
- Provides a command line interface to `mk_runofftbl.F90`, with _default_ inputs.
- Optional arguments originate from [this issue](https://github.com/GEOS-ESM/GEOSgcm_GridComp/issues/681). Because the issue and thought process is evolving,
   - Optionally read in `MAPL_tripolar.nc` to fetch `ocean mask` via call to subroutine: `read_oceanModel_mask` currently returns nothing! However, it is available for _future_ use in follow up PR.


✅ Answers remain unchanged.