### PR TITLE
Fixes for GNU Build Issues

### DIFF
--- a/GEOS_GcmGridComp.F90
+++ b/GEOS_GcmGridComp.F90
@@ -35,7 +35,7 @@ module GEOS_GcmGridCompMod
   integer            :: NUM_ICE_CATEGORIES
   integer            :: NUM_ICE_LAYERS
   integer, parameter :: NUM_SNOW_LAYERS=1
-  integer            :: DO_CICE_THERMO  
+  integer            :: DO_CICE_THERMO
   integer            :: DO_DATAATM
   integer            :: DO_OBIO
   integer            :: DO_DATASEA
@@ -43,10 +43,10 @@ module GEOS_GcmGridCompMod
 
 !=============================================================================
 
-! !DESCRIPTION: This gridded component (GC) combines the Agcm GC, 
+! !DESCRIPTION: This gridded component (GC) combines the Agcm GC,
 !   and Ogcm GC into a new composite Gcm GC.
 
- 
+
 !EOP
 
 integer ::       AGCM
@@ -108,8 +108,8 @@ contains
     integer, intent(out)               :: RC  ! return code
 
 ! !DESCRIPTION:  The SetServices for the PhysicsGcm GC needs to register its
-!   Initialize and Run.  It uses the MAPL\_Generic construct for defining 
-!   state specs and couplings among its children.  In addition, it creates the   
+!   Initialize and Run.  It uses the MAPL\_Generic construct for defining
+!   state specs and couplings among its children.  In addition, it creates the
 !   children GCs (AGCM and OGCM) and runs their
 !   respective SetServices.
 
@@ -125,9 +125,9 @@ contains
 
 ! Locals
 
-    type (T_GCM_STATE), pointer         :: gcm_internal_state => null() 
+    type (T_GCM_STATE), pointer         :: gcm_internal_state => null()
     type (GCM_wrap)                     :: wrap
-    type (T_EXTDATA_STATE), pointer     :: extdata_internal_state 
+    type (T_EXTDATA_STATE), pointer     :: extdata_internal_state
     type (EXTDATA_wrap)                 :: ExtDataWrap
     type (MAPL_MetaComp),  pointer      :: MAPL
     character(len=ESMF_MAXSTR)          :: ReplayMode
@@ -180,9 +180,9 @@ contains
     if (DO_CICE_THERMO /= 0) then
        call ESMF_ConfigGetAttribute(CF, NUM_ICE_CATEGORIES, Label="CICE_N_ICE_CATEGORIES:" , _RC)
        call ESMF_ConfigGetAttribute(CF, NUM_ICE_LAYERS,     Label="CICE_N_ICE_LAYERS:" ,     _RC)
-    else 
+    else
        NUM_ICE_CATEGORIES = 1
-       NUM_ICE_LAYERS     = 1  
+       NUM_ICE_LAYERS     = 1
     endif
 
     call MAPL_GetResource ( MAPL, DO_OBIO,     Label="USE_OCEANOBIOGEOCHEM:",DEFAULT=0, _RC)
@@ -344,7 +344,7 @@ contains
 
     if(adjustl(ReplayMode)=="Regular") then
        rplRegular = .true.
-    else    
+    else
        rplRegular = .false.
     endif
 
@@ -526,8 +526,8 @@ contains
        VERIFY_(STATUS)
 
        call MAPL_AddConnectivity ( GC,                          &
-            SRC_NAME  = (/'Q ','PPBL','TROPP_BLENDED'/),        &
-            DST_NAME  = (/'QV','PPBL','TROPP_BLENDED'/),        &
+            SRC_NAME  = [character(len=13) :: 'Q ','PPBL','TROPP_BLENDED'], &
+            DST_NAME  = [character(len=13) :: 'QV','PPBL','TROPP_BLENDED'], &
             DST_ID = AIAU,                                      &
             SRC_ID = AGCM,                                      &
             RC=STATUS  )
@@ -577,21 +577,21 @@ contains
     end if
 
     if(DO_DATAATM /= 0) then
-        call MAPL_TerminateImport    ( GC,   & 
+        call MAPL_TerminateImport    ( GC,   &
              SHORT_NAME = (/'KPAR   ','UW     ','VW     ','UI     ', &
              'VI     ','TAUXBOT','TAUYBOT'/),         &
              CHILD      = AGCM,           &
              _RC)
     endif
 
-    if (DO_CICE_THERMO /= 0) then  
+    if (DO_CICE_THERMO /= 0) then
        call MAPL_TerminateImport    ( GC,   &
           SHORT_NAME = (/ &
                          'FRACICE', 'VOLICE ', 'VOLSNO ',              &
                          'ERGICE ', 'ERGSNO ', 'TAUAGE ', 'MPOND  '/),   &
           CHILD      = OGCM,           &
           _RC)
-    endif 
+    endif
 
 ! Allocate this instance of the internal state and put it in wrapper.
 ! -------------------------------------------------------------------
@@ -613,7 +613,7 @@ contains
        ExtDataWrap%ptr => extdata_internal_state
        call ESMF_UserCompSetInternalState( GC, 'ExtData_state',ExtDataWrap,status)
        VERIFY_(STATUS)
-      
+
        call history_setservice(_RC)
     end if
 
@@ -661,7 +661,7 @@ contains
          call ESMF_ConfigFindLabel(gcm_cf,"REPLAY_HISTORY_RC:",isPresent=is_present,_RC)
 
          if (is_present) then
-            gcm_internal_state%run_history = .true. 
+            gcm_internal_state%run_history = .true.
             call MAPL_GetResource(MAPL,replay_history,"REPLAY_HISTORY_RC:",_RC)
             hist_cf = ESMF_ConfigCreate(_RC)
             call ESMF_ConfigLoadFile(hist_cf,trim(replay_history),_RC)
@@ -672,15 +672,15 @@ contains
             history_metaobj => null()
             call MAPL_InternalStateCreate(gcm_internal_state%history_parent,history_metaobj,_RC)
             call MAPL_Set(history_metaobj,cf=hist_cf,name="History_GCM_parent",component=stub_component,_RC)
-            hist = MAPL_AddChild(history_metaobj,name="History_GCM",ss=hist_setservices,_RC) 
+            hist = MAPL_AddChild(history_metaobj,name="History_GCM",ss=hist_setservices,_RC)
          end if
          _RETURN(_SUCCESS)
       end subroutine history_setservice
 
       subroutine OBIO_TerminateImports(DO_DATAATM, RC)
 
-        integer,                    intent(IN   ) ::  DO_DATAATM 
-        integer, optional,          intent(  OUT) ::  RC  
+        integer,                    intent(IN   ) ::  DO_DATAATM
+        integer, optional,          intent(  OUT) ::  RC
 
         character(len=ESMF_MAXSTR), parameter     :: IAm="OBIO_TerminateImports"
         integer                                   :: STATUS
@@ -688,10 +688,10 @@ contains
 
         call MAPL_TerminateImport    ( GC,     &
            SHORT_NAME = [character(len=7) ::   &
-              'CO2SC  ','DUDP   ','DUWT   ','DUSD   '],&  
+              'CO2SC  ','DUDP   ','DUWT   ','DUSD   '],&
            CHILD      = OGCM,                  &
            RC=STATUS  )
-        VERIFY_(STATUS)        
+        VERIFY_(STATUS)
 
         call MAPL_TerminateImport( GC,                               &
            SHORT_NAME = (/'CCOVM ', 'CDREM ', 'RLWPM ', 'CLDTCM',    &
@@ -708,12 +708,12 @@ contains
 
         do k=1, 33
          write(unit = suffix, fmt = '(i2.2)') k
-         call MAPL_TerminateImport( GC,           &    
+         call MAPL_TerminateImport( GC,           &
             SHORT_NAME = [ character(len=(8)) ::  &
-               'TAUA_'//suffix,                   &    
-               'ASYMP_'//suffix,                  &    
-               'SSALB_'//suffix ],                &    
-            CHILD      = OGCM,                    &    
+               'TAUA_'//suffix,                   &
+               'ASYMP_'//suffix,                  &
+               'SSALB_'//suffix ],                &
+            CHILD      = OGCM,                    &
             RC=STATUS  )
          VERIFY_(STATUS)
         enddo
@@ -747,20 +747,20 @@ contains
 
 ! !ARGUMENTS:
 
-    type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+    type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component
     type(ESMF_State),    intent(inout) :: IMPORT ! Import state
     type(ESMF_State),    intent(inout) :: EXPORT ! Export state
     type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
     integer, optional,   intent(  out) :: RC     ! Error code
 
-! !DESCRIPTION: 
- 
+! !DESCRIPTION:
+
 
 !EOP
 
 ! ErrLog Variables
 
-    character(len=ESMF_MAXSTR)           :: IAm 
+    character(len=ESMF_MAXSTR)           :: IAm
     integer                              :: STATUS
     character(len=ESMF_MAXSTR)           :: COMP_NAME
 
@@ -786,9 +786,9 @@ contains
     character(len=ESMF_MAXSTR)          :: tilingfile
     character(len=ESMF_MAXSTR)          :: tmpStr
     character(len=ESMF_MAXSTR)          :: ReplayMode
-    type (T_GCM_STATE), pointer         :: gcm_internal_state => null() 
+    type (T_GCM_STATE), pointer         :: gcm_internal_state => null()
     type (GCM_wrap)                     :: wrap
-    
+
     type(ESMF_Calendar)                 :: cal
     type(ESMF_Time)                     :: rep_StartTime
     type(ESMF_Time)                     :: rep_RefTime
@@ -826,7 +826,7 @@ contains
 
 !=============================================================================
 
-! Begin... 
+! Begin...
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -958,12 +958,12 @@ contains
        VERIFY_(STATUS)
 
        ! Initialize REPLAY_STARTDATE in YYYYMMDD & HHMMSS format
-       ! ------------------------------------------------------- 
+       ! -------------------------------------------------------
        rep_startdate(1) = 10000*rep_YY + 100*rep_MM + rep_DD
-       rep_startdate(2) = 10000*rep_H  + 100*rep_M  + rep_S 
+       rep_startdate(2) = 10000*rep_H  + 100*rep_M  + rep_S
 
        ! Update REPLAY_STARTDATE with User-Supplied values from CONFIG
-       ! ------------------------------------------------------------- 
+       ! -------------------------------------------------------------
        call MAPL_GetResource( MAPL, rep_startdate(1), label='REPLAY_STARTDATE:', default=rep_startdate(1), rc=STATUS )
        call MAPL_GetResource( MAPL, rep_startdate(2), label='REPLAY_STARTTIME:', default=rep_startdate(2), rc=STATUS )
 
@@ -1026,7 +1026,7 @@ contains
                                                         RingInterval = CORRECTOR_DURATION, sticky=.false., rc=status )
                 VERIFY_(STATUS)
 
-              ! REGULAR REPLAY may require Predictor_Step: ana09.eta 
+              ! REGULAR REPLAY may require Predictor_Step: ana09.eta
               ! ----------------------------------------------------
                 Regular_Replay09Alarm = ESMF_AlarmCreate( name="RegularReplay09", clock=clock,               &
                                                           RingTime     = rep_StartTime + CORRECTOR_DURATION, &
@@ -1055,10 +1055,10 @@ contains
            call ESMF_TimeIntervalGet( PREDICTOR_DURATION, S=rep_S, rc=status )
            if( rep_S .gt. i_PREDICTOR_DURATION ) then
                IF(MAPL_AM_I_ROOT()) then
-                  PRINT * 
+                  PRINT *
                   PRINT *,'ERROR!             User-Defined PREDICTOR_DURATION: ',i_PREDICTOR_DURATION
                   PRINT *,'is SMALLER THAN required Calculated PREDICTOR_DURATION: ',rep_S
-                  PRINT * 
+                  PRINT *
                endif
                VERIFY_(ESMF_FAILURE)
            else
@@ -1112,7 +1112,7 @@ contains
        RingTime = rep_StartTime
 
        replayStartAlarm = ESMF_AlarmCreate( name="startReplay", clock=clock, &
-                                            RingTime     = ringTime,         & 
+                                            RingTime     = ringTime,         &
                                             RingInterval = CORRECTOR_DURATION, sticky=.true., rc=status )
        VERIFY_(STATUS)
 
@@ -1148,7 +1148,7 @@ contains
            VERIFY_(STATUS)
 
            MKIAU_RingDate = 10000*rep_YY + 100*rep_MM + rep_DD
-           MKIAU_RingTime = 10000*rep_H  + 100*rep_M  + rep_S 
+           MKIAU_RingTime = 10000*rep_H  + 100*rep_M  + rep_S
 
            call MAPL_ConfigSetAttribute(  CF, MKIAU_RingDate, Label="MKIAU_RingDate:", RC=STATUS)
            VERIFY_(STATUS)
@@ -1185,7 +1185,7 @@ contains
        call MAPL_AddRecord(CMAPL, ALARMS, (/MAPL_Write2Ram/), rc=status)
        VERIFY_(STATUS)
 
-       call MAPL_GetObjectFromGC ( GCS(OGCM), CMAPL, RC=STATUS)                                                                   
+       call MAPL_GetObjectFromGC ( GCS(OGCM), CMAPL, RC=STATUS)
        VERIFY_(STATUS)
        call MAPL_AddRecord(CMAPL, ALARMS, (/MAPL_Write2Ram/), rc=status)
        VERIFY_(STATUS)
@@ -1288,7 +1288,7 @@ contains
         RC=STATUS)
    VERIFY_(STATUS)
 
-   if (DO_CICE_THERMO /= 0) then  
+   if (DO_CICE_THERMO /= 0) then
       call AllocateExports(GCM_INTERNAL_STATE%expSKIN, &
            (/'TAUXW    ', 'TAUYW    '/), &
            RC=STATUS)
@@ -1304,11 +1304,11 @@ contains
    endif
 
    call AllocateExports(GEX(OGCM), (/'UW      ', 'VW      ', &
-                                     'UI      ', 'VI      ', & 
-                                     'FRZMLT  ', 'KPAR    ', & 
+                                     'UI      ', 'VI      ', &
+                                     'FRZMLT  ', 'KPAR    ', &
                                      'TS_FOUND', 'SS_FOUND' /), RC=STATUS)
    VERIFY_(STATUS)
-   if (DO_CICE_THERMO == 0) then  
+   if (DO_CICE_THERMO == 0) then
       call AllocateExports(GEX(OGCM), (/'FRACICE '/), _RC)
       if (seaIceT_extData) then
         call AllocateExports(GEX(OGCM), (/'SEAICETHICKNESS '/), _RC)
@@ -1316,7 +1316,7 @@ contains
    else
       call AllocateExports(GEX(OGCM), (/'TAUXIBOT', 'TAUYIBOT'/), RC=STATUS)
    end if
-    
+
    call ESMF_ClockGetAlarm(clock, alarmname=trim(GCNAMES(OGCM)) // '_Alarm', &
                            alarm=GCM_INTERNAL_STATE%alarmOcn, rc=status)
    VERIFY_(STATUS)
@@ -1415,52 +1415,52 @@ contains
 
    subroutine AllocateExports_OBIO(DO_DATAATM, RC)
 
-     integer,                    intent(IN   ) ::  DO_DATAATM 
-     integer, optional,          intent(  OUT) ::  RC  
+     integer,                    intent(IN   ) ::  DO_DATAATM
+     integer, optional,          intent(  OUT) ::  RC
 
      integer                                   :: STATUS
      integer          :: k
 
-     call AllocateExports( GCM_INTERNAL_STATE%expSKIN,                   &    
-          (/'UU'/),                                     &    
+     call AllocateExports( GCM_INTERNAL_STATE%expSKIN,                   &
+          (/'UU'/),                                     &
           RC=STATUS )
      VERIFY_(STATUS)
 
-     call AllocateExports( GCM_INTERNAL_STATE%expSKIN,                   &    
-          (/'CO2SC'/),                                  &    
+     call AllocateExports( GCM_INTERNAL_STATE%expSKIN,                   &
+          (/'CO2SC'/),                                  &
           RC=STATUS )
      VERIFY_(STATUS)
 
      do k=1, 33
         write(unit = suffix, fmt = '(i2.2)') k
         call AllocateExports(GCM_INTERNAL_STATE%expSKIN, &
-           [ character(len=8) ::                         &    
-              'TAUA_'//suffix,                           &    
-              'ASYMP_'//suffix,                          &    
-              'SSALB_'//suffix] ,                        &    
+           [ character(len=8) ::                         &
+              'TAUA_'//suffix,                           &
+              'ASYMP_'//suffix,                          &
+              'SSALB_'//suffix] ,                        &
            RC=STATUS)
         VERIFY_(STATUS)
      enddo
 
-     call AllocateExports_UGD( GCM_INTERNAL_STATE%expSKIN,               &    
-             (/'DUDP', 'DUWT', 'DUSD'/),             &    
+     call AllocateExports_UGD( GCM_INTERNAL_STATE%expSKIN,               &
+             (/'DUDP', 'DUWT', 'DUSD'/),             &
              RC=STATUS )
      VERIFY_(STATUS)
 
-     call AllocateExports(GCM_INTERNAL_STATE%expSKIN,                      &    
+     call AllocateExports(GCM_INTERNAL_STATE%expSKIN,                      &
                        (/'CCOVM ', 'CDREM ', 'RLWPM ', 'CLDTCM', 'RH    ', &
-                         'OZ    ', 'WV    '/),                             &    
+                         'OZ    ', 'WV    '/),                             &
                        RC=STATUS)
      VERIFY_(STATUS)
-     
-     if(DO_DATAATM==0) then 
-        call AllocateExports_UGD( GCM_INTERNAL_STATE%expSKIN,               &    
-             (/'BCDP', 'BCWT', 'OCDP', 'OCWT' /),                           &    
+
+     if(DO_DATAATM==0) then
+        call AllocateExports_UGD( GCM_INTERNAL_STATE%expSKIN,               &
+             (/'BCDP', 'BCWT', 'OCDP', 'OCWT' /),                           &
              RC=STATUS )
         VERIFY_(STATUS)
-     
-        call AllocateExports_UGD( GCM_INTERNAL_STATE%expSKIN,               &    
-             (/'FSWBAND  ', 'FSWBANDNA'/),               &    
+
+        call AllocateExports_UGD( GCM_INTERNAL_STATE%expSKIN,               &
+             (/'FSWBAND  ', 'FSWBANDNA'/),               &
              RC=STATUS )
         VERIFY_(STATUS)
      endif
@@ -1480,20 +1480,20 @@ contains
 
 ! !ARGUMENTS:
 
-    type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+    type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component
     type(ESMF_State),    intent(inout) :: IMPORT ! Import state
     type(ESMF_State),    intent(inout) :: EXPORT ! Export state
     type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
     integer, optional,   intent(  out) :: RC     ! Error code
 
-! !DESCRIPTION: 
- 
+! !DESCRIPTION:
+
 
 !EOP
 
 ! ErrLog Variables
 
-    character(len=ESMF_MAXSTR)           :: IAm 
+    character(len=ESMF_MAXSTR)           :: IAm
     integer                              :: STATUS
     character(len=ESMF_MAXSTR)           :: COMP_NAME
 
@@ -1512,7 +1512,7 @@ contains
     type(ESMF_State)           :: impSKIN
     type(ESMF_State)           :: expSKIN
 
-    type (T_GCM_STATE), pointer         :: gcm_internal_state => null() 
+    type (T_GCM_STATE), pointer         :: gcm_internal_state => null()
     type (GCM_wrap)                     :: wrap
     type (T_ExtData_STATE), pointer     :: ExtData_internal_state  => null()
     type (ExtData_wrap)                 :: ExtDatawrap
@@ -1543,7 +1543,7 @@ contains
 
 !=============================================================================
 
-! Begin... 
+! Begin...
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -1554,7 +1554,7 @@ contains
 
     call ESMF_VMGetCurrent ( VM=vm, RC=STATUS )
     VERIFY_(STATUS)
-    
+
 ! Get my MAPL_Generic state
 !--------------------------
 
@@ -1722,7 +1722,7 @@ contains
                    call RUN_OCEAN(Phase=2, RC=STATUS)
                    VERIFY_(STATUS)
                 end if
-                
+
                 ! Advance the Clock
                 ! -----------------
 
@@ -1874,7 +1874,7 @@ contains
     else
       call MAPL_TimerOn(MAPL,"AGCM"        )
     endif
-   
+
     call ESMF_GridCompRun ( GCS(AGCM), importState=GIM(AGCM), exportState=GEX(AGCM), clock=clock, userRC=status )
     VERIFY_(STATUS)
 
@@ -1894,7 +1894,7 @@ contains
 
     call RUN_OCEAN(RC=STATUS)
     VERIFY_(STATUS)
-    
+
 
      call MAPL_TimerOff(MAPL,"TOTAL")
      call MAPL_TimerOff(MAPL,"RUN"  )
@@ -1922,7 +1922,7 @@ contains
                                        exportState=hist_exports(hist),&
                                        clock=clock,userRC=user_status,_RC)
        _RETURN(_SUCCESS)
- 
+
      end subroutine run_history
 
      subroutine RUN_OCEAN(phase, rc)
@@ -1960,7 +1960,7 @@ contains
          call MAPL_CopyFriendliness(GIM(OGCM),'HI',expSKIN,'HSKINI', _RC)
          call MAPL_CopyFriendliness(GIM(OGCM),'SI',expSKIN,'SSKINI', _RC)
        endif
-       if (DO_CICE_THERMO /= 0) then  
+       if (DO_CICE_THERMO /= 0) then
           call MAPL_CopyFriendliness(GIM(OGCM),'FRACICE',expSKIN,'FR',    _RC)
           call MAPL_CopyFriendliness(GIM(OGCM),'VOLICE',expSKIN,'VOLICE', _RC)
           call MAPL_CopyFriendliness(GIM(OGCM),'VOLSNO',expSKIN,'VOLSNO', _RC)
@@ -1968,8 +1968,8 @@ contains
           call MAPL_CopyFriendliness(GIM(OGCM),'ERGSNO',expSKIN,'ERGSNO', _RC)
           call MAPL_CopyFriendliness(GIM(OGCM),'TAUAGE',expSKIN,'TAUAGE', _RC)
           call MAPL_CopyFriendliness(GIM(OGCM),'MPOND',expSKIN,'VOLPOND', _RC)
-       endif 
-       
+       endif
+
 ! Do the routing between the atm and ocean's decompositions of the exchage grid
 !------------------------------------------------------------------------------
        if (.not. seaIceT_extData) then
@@ -1982,7 +1982,7 @@ contains
          endif
        endif
 
-       if (DO_CICE_THERMO /= 0) then  
+       if (DO_CICE_THERMO /= 0) then
           call DO_A2O_SUBTILES_R4R4(GIM(OGCM),'TI'     , SUBINDEXO, &
                expSKIN  ,'TSKINI' , SUBINDEXO, _RC)
           call DO_A2O_SUBTILES_R4R8(GIM(OGCM),'FRACICE', SUBINDEXO, &
@@ -2003,19 +2003,19 @@ contains
                expSKIN  ,'VOLPOND' , SUBINDEXO, _RC)
        endif
 
-       if (DO_CICE_THERMO /= 0) then  
+       if (DO_CICE_THERMO /= 0) then
           call DO_A2O(GIM(OGCM),'TAUXW'  ,expSKIN,'TAUXW'  , RC=STATUS); VERIFY_(STATUS)
           call DO_A2O(GIM(OGCM),'TAUYW'  ,expSKIN,'TAUYW'  , RC=STATUS); VERIFY_(STATUS)
        else
           call DO_A2O(GIM(OGCM),'TAUXW'  ,expSKIN,'TAUXO'  , RC=STATUS); VERIFY_(STATUS)
           call DO_A2O(GIM(OGCM),'TAUYW'  ,expSKIN,'TAUYO'  , RC=STATUS); VERIFY_(STATUS)
        endif
-       
+
        call DO_A2O(GIM(OGCM),'TAUXI'  ,expSKIN,'TAUXI'  , RC=STATUS)
        VERIFY_(STATUS)
        call DO_A2O(GIM(OGCM),'TAUYI'  ,expSKIN,'TAUYI'  , RC=STATUS)
        VERIFY_(STATUS)
-       
+
        call DO_A2O(GIM(OGCM),'PENPAR' ,expSKIN,'PENPAR' , RC=STATUS)
        VERIFY_(STATUS)
        call DO_A2O(GIM(OGCM),'PENPAF' ,expSKIN,'PENPAF' , RC=STATUS)
@@ -2057,7 +2057,7 @@ contains
           call OBIO_A2O(DO_DATAATM, RC)
        endif
        call MAPL_TimerOff(MAPL,"--A2O"  )
-       
+
 !--
 ! OGCM exports to SURFACE imports
 
@@ -2086,7 +2086,7 @@ contains
          call DO_O2A(expSKIN, 'SSKINI'   , GIM(OGCM), 'SI'    , _RC)
        endif
 
-       if (DO_CICE_THERMO /= 0) then  
+       if (DO_CICE_THERMO /= 0) then
           call DO_O2A_SUBTILES_R4R4(expSKIN  , 'TSKINI'     , SUBINDEXO,  &
                GIM(OGCM), 'TI'         , SUBINDEXO, RC=STATUS)
           VERIFY_(STATUS)
@@ -2113,7 +2113,7 @@ contains
           call DO_O2A_SUBTILES_R8R4(expSKIN  , 'VOLPOND'     , SUBINDEXO,  &
                GIM(OGCM), 'MPOND'       , SUBINDEXO, RC=STATUS)
           VERIFY_(STATUS)
-       endif  
+       endif
 
        call DO_O2A(impSKIN, 'UW'       , GEX(OGCM), 'UW'    , _RC)
        call DO_O2A(impSKIN, 'VW'       , GEX(OGCM), 'VW'    , _RC)
@@ -2148,8 +2148,8 @@ contains
 
    subroutine OBIO_A2O(DO_DATAATM, RC)
 
-     integer,                    intent(IN   ) ::  DO_DATAATM 
-     integer, optional,          intent(  OUT) ::  RC  
+     integer,                    intent(IN   ) ::  DO_DATAATM
+     integer, optional,          intent(  OUT) ::  RC
 
      integer                                   :: STATUS
      integer          :: k
@@ -2230,7 +2230,7 @@ contains
      call ESMF_VMBarrier(VM, rc=status)
      VERIFY_(STATUS)
      if (associated(ptrO) .and. associated(ptrA)) then
-        call MAPL_LocStreamTransform( ptrO, XFORM_A2O, ptrA, RC=STATUS ) 
+        call MAPL_LocStreamTransform( ptrO, XFORM_A2O, ptrA, RC=STATUS )
         VERIFY_(STATUS)
      end if
      call ESMF_VMBarrier(VM, rc=status)
@@ -2261,7 +2261,7 @@ contains
      VERIFY_(STATUS)
      if (associated(ptrO) .and. associated(ptrA)) then
         do N = 1, size(ptrA,2)
-           call MAPL_LocStreamTransform( ptrO(:,N), XFORM_A2O, ptrA(:,N), RC=STATUS ) 
+           call MAPL_LocStreamTransform( ptrO(:,N), XFORM_A2O, ptrA(:,N), RC=STATUS )
            VERIFY_(STATUS)
         end do
      end if
@@ -2292,7 +2292,7 @@ contains
      call ESMF_VMBarrier(VM, rc=status)
      VERIFY_(STATUS)
      if (associated(ptrO) .and. associated(ptrA)) then
-        call MAPL_LocStreamTransform( ptrA, XFORM_O2A, ptrO, RC=STATUS ) 
+        call MAPL_LocStreamTransform( ptrA, XFORM_O2A, ptrO, RC=STATUS )
         VERIFY_(STATUS)
      end if
      call ESMF_VMBarrier(VM, rc=status)
@@ -2315,7 +2315,7 @@ contains
 
      real,                       pointer :: ptrA(:,:) => null()
      real,                       pointer :: ptrO(:,:) => null()
-     integer                             :: N, DIMSO, DIMSA  
+     integer                             :: N, DIMSO, DIMSA
 
      DIMSO = size(SUBINDEXO)
      DIMSA = size(SUBINDEXA)
@@ -2330,7 +2330,7 @@ contains
      if (associated(ptrO) .and. associated(ptrA)) then
         do N=1,DIMSO
          call MAPL_LocStreamTransform( ptrO(:,SUBINDEXO(N)), XFORM_A2O, &
-                                       ptrA(:,SUBINDEXA(N)), RC=STATUS ) 
+                                       ptrA(:,SUBINDEXA(N)), RC=STATUS )
          VERIFY_(STATUS)
         enddo
      end if
@@ -2354,7 +2354,7 @@ contains
 
      real(kind=ESMF_KIND_R8),    pointer :: ptrA(:,:) => null()
      real,                       pointer :: ptrO(:,:) => null()
-     integer                             :: N, DIMSO, DIMSA  
+     integer                             :: N, DIMSO, DIMSA
 
      DIMSO = size(SUBINDEXO)
      DIMSA = size(SUBINDEXA)
@@ -2369,7 +2369,7 @@ contains
      if (associated(ptrO) .and. associated(ptrA)) then
         do N=1,DIMSO
          call MAPL_LocStreamTransform( ptrO(:,SUBINDEXO(N)), XFORM_A2O, &
-                                       ptrA(:,SUBINDEXA(N)), RC=STATUS ) 
+                                       ptrA(:,SUBINDEXA(N)), RC=STATUS )
          VERIFY_(STATUS)
         enddo
      end if
@@ -2395,8 +2395,8 @@ contains
 
      real(kind=ESMF_KIND_R8),    pointer :: ptrA(:,:,:) => null()
      real,                       pointer :: ptrO(:,:,:) => null()
-     integer                             :: N, K, DIMSO, DIMSA  
-    
+     integer                             :: N, K, DIMSO, DIMSA
+
 
      DIMSO = size(SUBINDEXO)
      DIMSA = size(SUBINDEXA)
@@ -2412,7 +2412,7 @@ contains
         do N=1,DIMSO
            do K=1,DIMS
              call MAPL_LocStreamTransform( ptrO(:,K,SUBINDEXO(N)), XFORM_A2O, &
-                                           ptrA(:,K,SUBINDEXA(N)), RC=STATUS ) 
+                                           ptrA(:,K,SUBINDEXA(N)), RC=STATUS )
              VERIFY_(STATUS)
            enddo
         enddo
@@ -2437,7 +2437,7 @@ contains
 
      real,                       pointer :: ptrA(:,:) => null()
      real,                       pointer :: ptrO(:,:) => null()
-     integer                             :: N, DIMSO, DIMSA  
+     integer                             :: N, DIMSO, DIMSA
 
      DIMSO = size(SUBINDEXO)
      DIMSA = size(SUBINDEXA)
@@ -2452,7 +2452,7 @@ contains
      if (associated(ptrO) .and. associated(ptrA)) then
         do N=1,DIMSO
            call MAPL_LocStreamTransform( ptrA(:, SUBINDEXA(N)), XFORM_O2A, &
-                                         ptrO(:, SUBINDEXO(N)), RC=STATUS ) 
+                                         ptrO(:, SUBINDEXO(N)), RC=STATUS )
            VERIFY_(STATUS)
         enddo
      end if
@@ -2476,7 +2476,7 @@ contains
 
      real(kind=ESMF_KIND_R8),    pointer :: ptrA(:,:) => null()
      real,                       pointer :: ptrO(:,:) => null()
-     integer                             :: N, DIMSO, DIMSA  
+     integer                             :: N, DIMSO, DIMSA
 
      DIMSO = size(SUBINDEXO)
      DIMSA = size(SUBINDEXA)
@@ -2491,7 +2491,7 @@ contains
      if (associated(ptrO) .and. associated(ptrA)) then
         do N=1,DIMSO
            call MAPL_LocStreamTransform( ptrA(:, SUBINDEXA(N)), XFORM_O2A, &
-                                         ptrO(:, SUBINDEXO(N)), RC=STATUS ) 
+                                         ptrO(:, SUBINDEXO(N)), RC=STATUS )
            VERIFY_(STATUS)
         enddo
      end if
@@ -2517,7 +2517,7 @@ contains
 
      real(kind=ESMF_KIND_R8),    pointer :: ptrA(:,:,:) => null()
      real,                       pointer :: ptrO(:,:,:) => null()
-     integer                             :: N, K, DIMSO, DIMSA  
+     integer                             :: N, K, DIMSO, DIMSA
 
      DIMSO = size(SUBINDEXO)
      DIMSA = size(SUBINDEXA)
@@ -2533,7 +2533,7 @@ contains
         do N=1,DIMSO
           do K=1,DIMS
             call MAPL_LocStreamTransform( ptrA(:,K,SUBINDEXA(N)), XFORM_O2A, &
-                                          ptrO(:,K,SUBINDEXO(N)), RC=STATUS ) 
+                                          ptrO(:,K,SUBINDEXO(N)), RC=STATUS )
             VERIFY_(STATUS)
           enddo
         enddo

--- a/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
@@ -52,7 +52,7 @@ module GEOS_AgcmGridCompMod
 
 !=============================================================================
 
-! !DESCRIPTION: This gridded component (GC) combines the Superdynamics GC, 
+! !DESCRIPTION: This gridded component (GC) combines the Superdynamics GC,
 !   and Physics GC into a new composite Agcm GC.
 
 !\begin{verbatim}
@@ -64,9 +64,9 @@ module GEOS_AgcmGridCompMod
 !     If Non-Hydrostatic Dynamics
 !       DWDT .... Mass-Weighted W-Wind      Tendency (Pa m /s)
 !\end{verbatim}
- 
+
 !EOP
-  
+
   integer :: SDYN
   integer :: PHYS
   integer :: ORB
@@ -119,8 +119,8 @@ contains
     integer, optional                  :: RC  ! return code
 
 ! !DESCRIPTION:  The SetServices for the Physics GC needs to register its
-!   Initialize and Run.  It uses the MAPL\_Generic construct for defining 
-!   state specs and couplings among its children.  In addition, it creates the   
+!   Initialize and Run.  It uses the MAPL\_Generic construct for defining
+!   state specs and couplings among its children.  In addition, it creates the
 !   children GCs (SURF, CHEM, RADIATION, MOIST, TURBULENCE) and runs their
 !   respective SetServices.
 
@@ -195,7 +195,7 @@ contains
                       adjustl(ReplayMode) /= "Regular" ) ) then
              _ASSERT( adjustl(ReplayMode) == "NoReplay"  ,'needs informative message')
     endif
- 
+
 !BOS
 
 ! !IMPORT STATE:
@@ -249,7 +249,7 @@ contains
          DIMS       = MAPL_DimsHorzVert,                           &
          VLOCATION  = MAPL_VLocationCenter,             RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec ( gc,                                  &
          SHORT_NAME = 'DTSDT',                                     &
          LONG_NAME  = 'skin_temperature_increment',                &
@@ -316,7 +316,7 @@ contains
          DIMS       = MAPL_DimsHorzVert,                           &
          VLOCATION  = MAPL_VLocationCenter,             RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddInternalSpec ( gc,                                &
          SHORT_NAME = 'DTSDT',                                     &
          LONG_NAME  = 'skin_temperature_tendency',                 &
@@ -1040,7 +1040,7 @@ contains
          SRC_ID = ORB,                                             &
          DST_ID = PHYS,                                            &
                                                         RC=STATUS  )
-     VERIFY_(STATUS) 
+     VERIFY_(STATUS)
 
 #ifdef SCMSURF
     call MAPL_AddConnectivity ( GC,    &
@@ -1064,7 +1064,7 @@ contains
 
      call MAPL_TerminateImport    ( GC,                                                     &
           SHORT_NAME = (/'DUDT  ','DVDT  ','DWDT  ','DTDT  ','DPEDT ','DQVANA','DQLANA',    &
-                         'DQIANA','DQRANA','DQSANA','DQGANA','DOXANA','PHIS','VARFLT'/),  &
+                         'DQIANA','DQRANA','DQSANA','DQGANA','DOXANA','PHIS  ','VARFLT'/),  &
           CHILD      = SDYN,                                                                &
           RC=STATUS  )
      VERIFY_(STATUS)
@@ -1106,7 +1106,7 @@ contains
 ! All done
 !---------
 
-    RETURN_(ESMF_SUCCESS)  
+    RETURN_(ESMF_SUCCESS)
   end subroutine SetServices
 
 
@@ -1114,7 +1114,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 !BOP
- 
+
 ! !IROUTINE: Initialize -- Initialize method for the composite Agcm Gridded Component
 
 ! !INTERFACE:
@@ -1123,20 +1123,20 @@ contains
 
 ! !ARGUMENTS:
 
-  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component
   type(ESMF_State),    intent(inout) :: IMPORT ! Import state
   type(ESMF_State),    intent(inout) :: EXPORT ! Export state
   type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
   integer, optional,   intent(  out) :: RC     ! Error code
 
-! !DESCRIPTION: 
- 
+! !DESCRIPTION:
+
 
 !EOP
 
 ! ErrLog Variables
 
-  character(len=ESMF_MAXSTR)           :: IAm 
+  character(len=ESMF_MAXSTR)           :: IAm
   integer                              :: STATUS
   character(len=ESMF_MAXSTR)           :: COMP_NAME
 
@@ -1152,7 +1152,7 @@ contains
    type (ESMF_Alarm)                   :: ALARM4D
    type (ESMF_Config)                  :: cf
    integer                             :: I, NQ
-   real                                :: POFFSET, DT             
+   real                                :: POFFSET, DT
    real, pointer, dimension(:,:)       :: PHIS,SGH,VARFLT,PTR
    real, pointer, dimension(:,:,:)     :: TEND!
    character(len=ESMF_MAXSTR)          :: replayMode
@@ -1170,7 +1170,7 @@ contains
 
 ! =============================================================================
 
-! Begin... 
+! Begin...
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -1202,7 +1202,7 @@ contains
     VERIFY_(STATUS)
 
 ! Initialize the advection increments bundle (TRADVI)
-! with tracer increment names 
+! with tracer increment names
 !-----------------------------------------------------
 
     call Initialize_IncBundle_init(GC, GEX(PHYS), EXPORT, DYNinc, __RC__)
@@ -1286,7 +1286,7 @@ contains
        VERIFY_(STATUS)
        call MAPL_AttributeSet(field, NAME="MAPL_InitStatus", &
                               VALUE=MAPL_InitialRestart, RC=STATUS)
-       VERIFY_(STATUS)      
+       VERIFY_(STATUS)
     END DO
 
 ! Initialize Predictor Alarm
@@ -1310,7 +1310,7 @@ contains
 
    ALARM = ESMF_AlarmCreate( name='PredictorAlarm',    &
                              CLOCK = CLOCK,            &
-                             RingTime     = ringTime,  & 
+                             RingTime     = ringTime,  &
                              RingInterval = TIMEINT,   &
                              RC           = STATUS     )
    VERIFY_(STATUS)
@@ -1429,20 +1429,20 @@ contains
 
 ! !ARGUMENTS:
 
-  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component
   type(ESMF_State),    intent(inout) :: IMPORT ! Import state
   type(ESMF_State),    intent(inout) :: EXPORT ! Export state
   type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
   integer, optional,   intent(  out) :: RC     ! Error code
 
-! !DESCRIPTION: 
- 
+! !DESCRIPTION:
+
 
 !EOP
 
 ! ErrLog Variables
 
-  character(len=ESMF_MAXSTR)           :: IAm 
+  character(len=ESMF_MAXSTR)           :: IAm
   integer                              :: STATUS
   character(len=ESMF_MAXSTR)           :: COMP_NAME
 
@@ -1484,12 +1484,12 @@ contains
 
 !! real,   allocatable, dimension(:,:)   :: ALPHA2D
    real,   allocatable, dimension(:,:)   :: QFILL
-   real,   allocatable, dimension(:,:)   :: QINT 
+   real,   allocatable, dimension(:,:)   :: QINT
    real,   allocatable, dimension(:,:)   :: ALF_BKS_INT
    real,   allocatable, dimension(:,:)   :: DRY_BKG_INT
    real,   allocatable, dimension(:,:)   :: DRY_ANA_INT
-   real,   allocatable, dimension(:,:)   :: QDP_BKG_INT 
-   real,   allocatable, dimension(:,:)   :: QDP_ANA_INT 
+   real,   allocatable, dimension(:,:)   :: QDP_BKG_INT
+   real,   allocatable, dimension(:,:)   :: QDP_ANA_INT
    real*8, allocatable, dimension(:,:)   :: SUMKE
    real*8, allocatable, dimension(:,:)   :: SUMCPT1, SUMCPT2
    real*8, allocatable, dimension(:,:)   :: SUMTHV1, SUMTHV2
@@ -1519,7 +1519,7 @@ contains
    real, pointer, dimension(:,:)       :: PERES        => null()
    real, pointer, dimension(:,:)       :: PEFILL       => null()
    real, pointer, dimension(:,:)       :: PEPHY_SDYN   => null()  ! D(CpT)DT from ADD_INCS (SuperDYNamics)
-   real, pointer, dimension(:,:)       :: PEPHY_PHYS   => null()  ! D(CpT)DT from PHYSics 
+   real, pointer, dimension(:,:)       :: PEPHY_PHYS   => null()  ! D(CpT)DT from PHYSics
 
    real, pointer, dimension(:,:)       :: DTHVDTFILINT => null()
    real, pointer, dimension(:,:)       :: DTHVDTPHYINT => null()
@@ -1635,7 +1635,7 @@ contains
 
 !=============================================================================
 
-! Begin... 
+! Begin...
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -1659,7 +1659,7 @@ contains
 
     call MAPL_Get ( STATE, GCS=GCS, GIM=GIM, GEX=GEX,  &
                     INTERNAL_ESMF_STATE=INTERNAL,      &
-                    IM=IM, JM=JM, LM=LM,               & 
+                    IM=IM, JM=JM, LM=LM,               &
                     RC=STATUS )
     VERIFY_(STATUS)
 
@@ -1743,7 +1743,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                LAST_CORRECTOR = ESMF_AlarmWillRingNext( ALARM, rc=status)
                VERIFY_(STATUS)
 
-           else if(  (rplMode=="Exact")   .or.  & 
+           else if(  (rplMode=="Exact")   .or.  &
                    ( (rplMode=="Regular") .and. (PREDICTOR_DURATION.gt.MKIAU_FREQUENCY/2) )  ) then
 
                ! Set Active PREDICTOR_STEP Alarm to OFF
@@ -1781,7 +1781,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                is_shutoff = ESMF_AlarmIsRinging( Alarm,rc=Status)
                VERIFY_(status)
 
-               if (is_shutoff) then ! once this alarm rings, is_shutoff will remain true for the rest of the run 
+               if (is_shutoff) then ! once this alarm rings, is_shutoff will remain true for the rest of the run
                !  if ( MAPL_am_I_root() ) print *, 'Zeroing AGCM_IMPORT'
                   call MAPL_GetPointer(IMPORT,ptr3d,'DUDT' ,RC=STATUS) ; ptr3d=0.0
                   call MAPL_GetPointer(IMPORT,ptr3d,'DVDT' ,RC=STATUS) ; ptr3d=0.0
@@ -1792,7 +1792,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                   call MAPL_GetPointer(IMPORT,ptr2d,'DTSDT',RC=STATUS) ; if(associated(ptr2d)) ptr2d=0.0
                else
                   call ESMF_ClockGetAlarm(Clock,'ReplayShutOff',Alarm,rc=Status)
-                  VERIFY_(status) 
+                  VERIFY_(status)
                   is_shutoff = ESMF_AlarmWillRingNext( Alarm,rc=status )
                   VERIFY_(status)
                endif
@@ -1800,28 +1800,28 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
              ! Check for Beginning of REPLAY cycle
              ! -----------------------------------
                call ESMF_ClockGetAlarm(Clock,'replayCycle',Alarm,rc=Status)
-               VERIFY_(status) 
+               VERIFY_(status)
                Begin_REPLAY_Cycle = ESMF_AlarmIsRinging( Alarm,rc=status )
-               VERIFY_(status) 
+               VERIFY_(status)
 
              ! Check Alarm for Beginning of EXACT_REPLAY09 cycle
              ! -------------------------------------------------
                call ESMF_ClockGetAlarm(Clock,'ExactReplay09',Alarm,rc=Status)
-               VERIFY_(status) 
+               VERIFY_(status)
                is_ExactReplay09_ringing = ESMF_AlarmIsRinging( Alarm,rc=status )
-               VERIFY_(status) 
+               VERIFY_(status)
 
              ! Check Alarm for REGULAR_REPLAY09 cycle
              ! --------------------------------------
                call ESMF_ClockGetAlarm(Clock,'RegularReplay09',Alarm,rc=Status)
-               VERIFY_(status) 
+               VERIFY_(status)
                is_RegularReplay09_ringing = ESMF_AlarmIsRinging( Alarm,rc=status )
-               VERIFY_(status) 
+               VERIFY_(status)
 
              ! Check for Last Corrector
              ! -------------------------------------
                call ESMF_ClockGetAlarm(Clock,'ExactReplay',Alarm,rc=Status)
-               VERIFY_(status) 
+               VERIFY_(status)
                LAST_CORRECTOR = ESMF_AlarmWillRingNext( ALARM, rc=status)
                VERIFY_(STATUS)
 
@@ -1829,7 +1829,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
 ! ---------------------------------------
                if( first ) then
                    call ESMF_ClockGet(Clock, CurrTime=currTime, rc=Status)
-                   VERIFY_(status) 
+                   VERIFY_(status)
 
                    call ESMF_TimeIntervalSet( TINT, S=INT(DT), rc=STATUS )
                    VERIFY_(STATUS)
@@ -1853,14 +1853,14 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                        if( is_ExactReplay09_ringing ) then
                            if( filetmpl09.ne.'NULL' ) then
                                call MAPL_GetCurrentFile(FILETMPL=filetmpl09, TIME=REPLAY_TIME, FILENAME=ReplayFile, RC=STATUS)
-                               VERIFY_(status) 
+                               VERIFY_(status)
                            else
                                call MAPL_GetCurrentFile(FILETMPL=filetmpl,   TIME=REPLAY_TIME, FILENAME=ReplayFile, RC=STATUS)
-                               VERIFY_(status) 
+                               VERIFY_(status)
                            endif
                        else
                                call MAPL_GetCurrentFile(FILETMPL=filetmpl,   TIME=REPLAY_TIME, FILENAME=ReplayFile, RC=STATUS)
-                               VERIFY_(status) 
+                               VERIFY_(status)
                        endif
                    endif
 
@@ -1868,14 +1868,14 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                        if( is_RegularReplay09_ringing ) then
                            if( filetmpl09.ne.'NULL' ) then
                                call MAPL_GetCurrentFile(FILETMPL=filetmpl09, TIME=REPLAY_TIME, FILENAME=ReplayFile, RC=STATUS)
-                               VERIFY_(status) 
+                               VERIFY_(status)
                            else
                                call MAPL_GetCurrentFile(FILETMPL=filetmpl,   TIME=REPLAY_TIME, FILENAME=ReplayFile, RC=STATUS)
-                               VERIFY_(status) 
+                               VERIFY_(status)
                            endif
                        else
                                call MAPL_GetCurrentFile(FILETMPL=filetmpl,   TIME=REPLAY_TIME, FILENAME=ReplayFile, RC=STATUS)
-                               VERIFY_(status) 
+                               VERIFY_(status)
                        endif
                    endif
 
@@ -1955,7 +1955,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
     DP  =      PLE(:,:,1:LM)-PLE(:,:,0:LM-1)
 
 ! --------------------------------------------------------
-! ALPHA and BETA BIAS Correction Coefficients 
+! ALPHA and BETA BIAS Correction Coefficients
 ! --------------------------------------------------------
 ! AGCM_IMPORT   =>  IAU(n)     ALPHA = 0 (Default)
 ! AGCM_INTERNAL => BIAS(n)     BETA  = 1 (Default)
@@ -1981,7 +1981,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
         if(DO_4DIAU .and. (TYPE == CORRECTOR) ) then
            call ESMF_AlarmRingerOff(ALARM4D, RC=STATUS)
            VERIFY_(STATUS)
-           call update_ainc_(RC=STATUS) 
+           call update_ainc_(RC=STATUS)
            VERIFY_(STATUS)
         endif
 
@@ -2011,7 +2011,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
         allocate(  tdpnew( IM,JM,  LM),STAT=STATUS ) ; VERIFY_(STATUS)
         allocate(  dp_ana( IM,JM,  LM),STAT=STATUS ) ; VERIFY_(STATUS)
         allocate( ple_ana( IM,JM,0:LM),STAT=STATUS ) ; VERIFY_(STATUS)
-                
+
         ! Create Proxies for Updated Pressure and Temperature due to Analysis
         !--------------------------------------------------------------------
         ple_ana = ple + dt*dpedt
@@ -2026,7 +2026,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
         deallocate(  dp_ana )
         deallocate( ple_ana )
     endif
-       
+
 ! Add Analysis Increment Directly to Friendlies
 !----------------------------------------------
 
@@ -2153,7 +2153,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                     IF( CONSTRAIN_DAS == 1 ) then
                        allocate( qdp_bkg( IM,JM,LM ),STAT=STATUS ) ; VERIFY_(STATUS)
                        qdp_bkg = (         q+qlls+qlcn+qils+qicn+qrain+qsnow+qgraupel   ) * dp
-#if debug              
+#if debug
                        allocate( dry_bkg( IM,JM,LM ),STAT=STATUS ) ; VERIFY_(STATUS)
                        dry_bkg = ( 1.0 - ( q+qlls+qlcn+qils+qicn+qrain+qsnow+qgraupel ) ) * dp
 #endif
@@ -2202,7 +2202,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                     ! ---------------------
                        allocate(  qdp_ana(IM,JM,LM),STAT=STATUS ); VERIFY_(STATUS)
                        qdp_ana = (         q+qlls+qlcn+qils+qicn+qrain+qsnow+qgraupel   ) * dp_ana
- 
+
                     ! Vertically Integrate ANA & BKG Water Mass where they Differ
                     ! -----------------------------------------------------------
                        allocate( sum_qdp_bkg( IM,JM ),STAT=STATUS ) ; VERIFY_(STATUS)
@@ -2219,7 +2219,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                     ! Compute Area-Mean Vertically Integrated BKG Water Mass
                     ! ------------------------------------------------------
                        allocate( qdp_bkg_int( IM,JM ),STAT=STATUS ) ; VERIFY_(STATUS)
-                       where( sum_qdp_bkg.ne.0.0_8 ) 
+                       where( sum_qdp_bkg.ne.0.0_8 )
                            qdp_bkg_int = sum_qdp_bkg
                        elsewhere
                            qdp_bkg_int = MAPL_UNDEF
@@ -2230,7 +2230,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                     ! Compute Area-Mean Vertically Integrated ANA Water Mass
                     ! ------------------------------------------------------
                        allocate( qdp_ana_int( IM,JM ),STAT=STATUS ) ; VERIFY_(STATUS)
-                       where( sum_qdp_ana.ne.0.0_8 ) 
+                       where( sum_qdp_ana.ne.0.0_8 )
                            qdp_ana_int = sum_qdp_ana
                        elsewhere
                            qdp_ana_int = MAPL_UNDEF
@@ -2488,7 +2488,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
     call MAPL_TimerOff(STATE,"PHYSICS"  )
 !   call SYSTEM_CLOCK(END_TIME)
 !   PHY_TIME = END_TIME-START_TIME
-!   if(PHY_TIME<0) then 
+!   if(PHY_TIME<0) then
 !      PHY_TIME = PHY_TIME + COUNT_MAX
 !   endif
 
@@ -2911,7 +2911,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
 
       call MAPL_GetPointer(GIM(COMP), TENDSD, trim(NAME)        , rc=STATUS)
       VERIFY_(STATUS)
-      
+
       select case (TYPE)
          case (FREERUN)
 
@@ -3067,7 +3067,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
 
       call MAPL_GetPointer(GIM(COMP), TENDSD, trim(NAME)        , rc=STATUS)
       VERIFY_(STATUS)
-      
+
       select case (TYPE)
          case (FREERUN)
 
@@ -3135,7 +3135,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
       VERIFY_(STATUS)
       call MAPL_GetPointer(GEX(PHYS), TENDPH, trim(NAME)        , rc=STATUS)
       VERIFY_(STATUS)
-      
+
       TENDSD = TENDPH
 
     end subroutine DO_UPDATE_PHY
@@ -3157,20 +3157,20 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
       VERIFY_(STATUS)
 
       QOLD = Q   ! Initialize Old Value for Total Tendency Diagnostic
-      
+
       select case (TYPE)
       case (PREDICTOR)
 
          call MAPL_GetPointer(INTERNAL , TENDBS, trim(NAME), rc=STATUS)
          VERIFY_(STATUS)
-         
+
          Q = Q + max( DTX*TENDBS*FC, -Q )  ! Prevent Negative Q
 
       case (FORECAST)
 
          call MAPL_GetPointer(INTERNAL , TENDBS, trim(NAME), rc=STATUS)
          VERIFY_(STATUS)
-         
+
          TENDBS = BET * TENDBS
 
          Q = Q + max( DTX*TENDBS*FC, -Q )  ! Prevent Negative Q
@@ -3251,14 +3251,14 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
       QTEMP1 = 0.0
       do L=1,LM
       QTEMP1(:,:) = QTEMP1(:,:) + Q(:,:,L)*DP(:,:,L)
-      enddo 
+      enddo
 
       where( Q < 0.0 ) Q = 0.0
 
       QTEMP2 = 0.0
       do L=1,LM
       QTEMP2(:,:) = QTEMP2(:,:) + Q(:,:,L)*DP(:,:,L)
-      enddo 
+      enddo
 
       where( qtemp2.ne.0.0_8 )
              qtemp2 = max( qtemp1/qtemp2, 0.0_8 )
@@ -3266,14 +3266,14 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
 
       do L=1,LM
       Q(:,:,L) = Q(:,:,L)*qtemp2(:,:)
-      enddo 
+      enddo
 
       QTEMP2 = 0.0
       do L=1,LM
       QTEMP2(:,:) = QTEMP2(:,:) + Q(:,:,L)*DP(:,:,L)
-      enddo 
+      enddo
 
-      WHERE( QTEMP1 >= 0.0 ) 
+      WHERE( QTEMP1 >= 0.0 )
               QFILL  = 0.0
       ELSEWHERE
               QFILL = -QTEMP1 / (DT*MAPL_GRAV)
@@ -3301,8 +3301,8 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
     integer :: kstep, kshift
     integer :: MKIAU_RingDate
     integer :: MKIAU_RingTime
-    integer :: rep_YY, rep_MM, rep_DD 
-    integer :: rep_H,  rep_M,  rep_S 
+    integer :: rep_YY, rep_MM, rep_DD
+    integer :: rep_H,  rep_M,  rep_S
     integer :: MKIAU_FREQUENCY
     logical :: IAU_DIGITAL_FILTER
 
@@ -3318,7 +3318,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
 
     call MAPL_GetResource(STATE, REPLAY_MODE, Label='REPLAY_MODE:', default="NoReplay", RC=STATUS )
     VERIFY_(STATUS)
- 
+
     call MAPL_GetResource(STATE, STRING, LABEL="IAU_DIGITAL_FILTER:", default="YES", RC=STATUS)
     VERIFY_(STATUS)
     STRING = ESMF_UtilStringUpperCase(STRING)
@@ -3348,7 +3348,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
             allocate(myCoeffs%dfi(nsteps))
             myCoeffs%istep=0
 
-            call dfi_coeffs (DT,MKIAU_FREQUENCY,TAUANL,nsteps,myCoeffs%dfi) 
+            call dfi_coeffs (DT,MKIAU_FREQUENCY,TAUANL,nsteps,myCoeffs%dfi)
 
         ! Shift DFI Coefficients if Necessary
         ! -----------------------------------
@@ -3392,7 +3392,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
            shifted_dfi(nsteps) = shifted_dfi(1)
            myCoeffs%dfi        = shifted_dfi
            deallocate( shifted_dfi )
-       
+
            if (MAPL_am_I_root()) then
               print*, 'DFI initialized for',nsteps,' steps'
               do i=1,nsteps-1
@@ -3410,7 +3410,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
     endif
 
     end subroutine get_iau_coeff
-    
+
     subroutine update_ainc_(RC)
 
     use ESMF_CFIOFileMod
@@ -3431,7 +3431,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
 ! In case of handling analysis increment:
 !    - if needed, interpolate analysis increment to model grid
 !    - convert analysis increment to IAU increment (e.g., tv to td)
- 
+
 
 ! The following name declarations will be easily unwired ...
     character(len=*), parameter :: incnames(7) = (/ 'sphu ', &
@@ -3618,7 +3618,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
       endif
 
     else                              ! typicall, will expect tendency at initial time
-                                      ! to be meaningful so, use what is in agcm_import 
+                                      ! to be meaningful so, use what is in agcm_import
                                       ! in the first pass, from then on analysis should
                                       ! be read in at desired frequency
       if(ifirst<1)then
@@ -3784,7 +3784,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
              myANA%phis_bkg=phis_bkg
          endif
       endif
-      
+
       myAna%Initialized=.true.
     endif
 
@@ -3943,7 +3943,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
            else
                gptr3d=aptr3d
            endif
-           if (fromANA2BKG) then 
+           if (fromANA2BKG) then
               if(trim(NAME)=='ozone') do3_inc=gptr3d
               if(trim(NAME)=='sphu' ) dq_inc =gptr3d
               if(trim(NAME)=='tv'   ) dt_inc =gptr3d
@@ -3955,7 +3955,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
               if(trim(NAME)=='delp'.and.l_use_ana_delp ) dp_aux =gptr3d
            endif
            if(.not.l_use_ana_delp) then
-              if(trim(NAME)=='delp') then 
+              if(trim(NAME)=='delp') then
                  dp_inc =gptr3d
               endif
            endif
@@ -3983,7 +3983,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
         du_aux=uptr
         dv_aux=vptr
     endif
- 
+
 !   Calculate 3d-pressure change
 !   -----------------------------
     if (l_use_ana_delp) then
@@ -4007,7 +4007,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
 !   -------------------------------------------------------------------
     EPS = MAPL_RVAP/MAPL_RGAS-1.0
     if (.not.l_nudge) then ! in this case, using the background fields is not
-                           ! quite legitimate since these refer to the really 
+                           ! quite legitimate since these refer to the really
                            ! current trajectory and not quite the original
                            ! background used by the analysis
        dt_inc = dt_inc /(1.0+eps*q_bkg) - eps*dq_inc*tv_bkg/((1.0+eps*q_bkg)*(1.0+eps*q_bkg)) ! now dt is inc in dry temperature
@@ -4102,7 +4102,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                    print *, 'Remapping ANA to Internal State Topography'
                    print *
                  endif
-   
+
                  allocate(pk_ana (IMana,JMana,  LMana),stat=STATUS);VERIFY_(STATUS)
                  allocate(pke_ana(IMana,JMana,0:LMana),stat=STATUS);VERIFY_(STATUS)
                  pke_ana(:,:,:)  = ple_ana(:,:,:)**MAPL_KAPPA
@@ -4110,10 +4110,10 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                     pk_ana(:,:,L)  = ( pke_ana(:,:,L)-pke_ana(:,:,L-1) ) &
                                    / ( MAPL_KAPPA*log(ple_ana(:,:,L)/ple_ana(:,:,L-1)) )
                  enddo
-   
+
                  allocate(thv_ana(IMana,JMana,LMana),stat=STATUS);VERIFY_(STATUS)
                  thv_ana = tv_ana/pk_ana
-    
+
                  call myremap ( ple_ana, &
                                   u_ana, &
                                   v_ana, &
@@ -4121,7 +4121,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                                   q_ana, &
                                  o3_ana, &
                                phis_ana,myANA%phis_bkg,ak,bk,IMana,JMana,LMana )
-    
+
                  ! Re-create ANA Dry Temperature
                  ! -----------------------------
                  pke_ana(:,:,:) = ple_ana(:,:,:)**MAPL_KAPPA
@@ -4130,7 +4130,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
                                   / ( MAPL_KAPPA*log(ple_ana(:,:,L)/ple_ana(:,:,L-1)) )
                  enddo
                  tv_ana= thv_ana*pk_ana
-   
+
                  deallocate(thv_ana,stat=STATUS);VERIFY_(STATUS)
                  deallocate(pke_ana,stat=STATUS);VERIFY_(STATUS)
                  deallocate(pk_ana ,stat=STATUS);VERIFY_(STATUS)
@@ -4258,7 +4258,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
              print *
           endif
 
-!         Calcuate T-skin increment 
+!         Calcuate T-skin increment
           if (IuseTS) then
              allocate(qdum2(IMana,JMana,1))
              allocate(qdum1(IMbkg,JMbkg,1))
@@ -4368,7 +4368,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
     if(allocated(uptr))  deallocate(uptr)
     if(allocated(vptr))  deallocate(vptr)
 
-  
+
     if ( (.not.l_store_transforms) ) then
       if (associated(myANA%phis_bkg)) then
           deallocate(myANA%phis_bkg,stat=STATUS);VERIFY_(STATUS)
@@ -4402,7 +4402,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
       myANA%do_transforms=.false.
       myANA%initialized=.false.
     endif
-    
+
     RETURN_(ESMF_SUCCESS)
     end subroutine update_ainc_
 
@@ -4415,11 +4415,11 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
        integer, intent(in) :: NY
        integer, intent(in) :: LM
        integer, optional, intent(out) :: rc
-       
+
        type (ESMF_Config) :: tmp_config
        integer :: status
        character(len=ESMF_MAXSTR) :: imstr, jmstr
-       
+
        write(imstr,*) IM_World
        write(jmstr,*) JM_World
        if(JM_World==6*IM_World) then
@@ -4477,7 +4477,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
     nhlf = (nsteps+1)/2
     do k = 1, nhlf-1
        n   = k-nhlf
-       arg = n*pi/nhlf            
+       arg = n*pi/nhlf
        wc  = sin(arg)/arg ! Lanczos window
        dfi(k) = wc*sin(n*2.0*pi*DT/FILE_FREQUENCY)/(n*pi)
     end do
@@ -4485,7 +4485,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
     do i = nhlf+1, nsteps
        dfi(i) = dfi(nsteps-i+1)
     end do
- 
+
 !   Normalize coefficients
 !   ----------------------
     dfi = dfi/sum(dfi)
@@ -4684,8 +4684,8 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
 
  !   write(6,'(1x,a,i8.8,a,i6.6,a,f5.3,a,a,i8.8,a,i6.6,a,i8.8,a,i6.6,a,i8.8,a,i6.6,a,f5.3,a,l)') &
  !                                            ' Current_Time: ',nymd,' ',nhms,' (',facm1,') ', &
- !                                            ' -Replay_Time: ',Mymd,' ',Mhms, & 
- !                                            '  Replay_Time: ',rymd,' ',rhms, & 
+ !                                            ' -Replay_Time: ',Mymd,' ',Mhms, &
+ !                                            '  Replay_Time: ',rymd,' ',rhms, &
  !                                            ' +Replay_Time: ',Pymd,' ',Phms,' (',facp0,') Begin_REPLAY_Cycle: ',Begin_REPLAY_Cycle
  ! endif
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
@@ -29,7 +29,7 @@ module GEOS_PhysicsGridCompMod
   use GEOS_UtilsMod, only: GEOS_Qsat
   use Bundle_IncrementMod
 
-! PGI Module that contains the initialization 
+! PGI Module that contains the initialization
 ! routines for the GPUs
 #ifdef _CUDA
   use cudafor
@@ -44,14 +44,14 @@ module GEOS_PhysicsGridCompMod
 
 !=============================================================================
 
-! !DESCRIPTION: This gridded component (GC) combines the Radiation (Short-Wave and Long-Wave), 
+! !DESCRIPTION: This gridded component (GC) combines the Radiation (Short-Wave and Long-Wave),
 !   Moist-Physics, Chem, Surface and Turbulence GCs into a new composite Physics GC.
 !   The Export Couplings of the Physics GC are the union of the Export
 !   Couplings of the individual child GCs, plus the combined tendencies needed by
 !   the dynamics. These last are the pressure-weighted tendencies of the atmospheric
 !   state variables U,V,T (due to external diabatic forcing), the tendency of the
 !   edge pressures, and a collection of "Friendly" tracers for advection. In the current
-!   version, the only friendly tracers are variables from Moist-Physics and Chem.  
+!   version, the only friendly tracers are variables from Moist-Physics and Chem.
 !
 !\begin{verbatim}
 !       DUDT .... Mass-Weighted U-Wind      Tendency (Pa m /s)
@@ -62,7 +62,7 @@ module GEOS_PhysicsGridCompMod
 !     If Non-Hydrostatic Dynamics
 !       DWDT .... Mass-Weighted W-Wind      Tendency (Pa m /s)
 !\end{verbatim}
- 
+
 !EOP
 
   integer ::        GWD
@@ -88,8 +88,8 @@ contains
     integer,             intent(  OUT) :: RC  ! return code
 
 ! !DESCRIPTION:  The SetServices for the Physics GC needs to register its
-!   Initialize and Run.  It uses the MAPL\_Generic construct for defining 
-!   state specs and couplings among its children.  In addition, it creates the   
+!   Initialize and Run.  It uses the MAPL\_Generic construct for defining
+!   state specs and couplings among its children.  In addition, it creates the
 !   children GCs (SURF, CHEM, RADIATION, MOIST, TURBULENCE) and runs their
 !   respective SetServices.
 
@@ -116,7 +116,7 @@ contains
     character(len=ESMF_MAXSTR), allocatable :: NAMES(:)
     character(len=ESMF_MAXSTR)              :: TendUnits
     character(len=ESMF_MAXSTR)              :: SURFRC
-    type(ESMF_Config)                       :: SCF 
+    type(ESMF_Config)                       :: SCF
 
 !=============================================================================
 
@@ -141,7 +141,7 @@ contains
 ! Create children`s gridded components and invoke their SetServices
 ! -----------------------------------------------------------------
 
-! Note chemistry must be added before surface so that chemistry has 
+! Note chemistry must be added before surface so that chemistry has
 ! a change to put the fields in the AERO_DP bundle. Otherwise when
 ! surface reads the import restart AERO_DP will be empty and it will
 ! not be properly restarted
@@ -175,7 +175,7 @@ contains
 
     SCF = ESMF_ConfigCreate(rc=status) ; VERIFY_(STATUS)
     call ESMF_ConfigLoadFile(SCF,'CO2_GridComp.rc',rc=status) ; VERIFY_(STATUS)
-    call ESMF_ConfigGetAttribute (SCF, label='USE_CNNEE:', value=DO_CO2CNNEE,   DEFAULT=0, __RC__ ) 
+    call ESMF_ConfigGetAttribute (SCF, label='USE_CNNEE:', value=DO_CO2CNNEE,   DEFAULT=0, __RC__ )
     call ESMF_ConfigDestroy      (SCF, __RC__)
 
 ! Get SYNCTQ flag from config to know whether to terminate some imports
@@ -383,7 +383,7 @@ contains
          VLOCATION  =  MAPL_VLocationCenter,                                          &
          RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddExportSpec(GC,                                     &
          SHORT_NAME = 'DTDTTOT',                                    &
          LONG_NAME  = 'tendency_of_air_temperature_due_to_physics', &
@@ -392,7 +392,7 @@ contains
          VLOCATION  =  MAPL_VLocationCenter,                        &
          RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddExportSpec(GC,                                       &
          SHORT_NAME = 'DTDTRAD',                                      &
          LONG_NAME  = 'tendency_of_air_temperature_due_to_radiation', &
@@ -401,7 +401,7 @@ contains
          VLOCATION  =  MAPL_VLocationCenter,                          &
          RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddExportSpec(GC,                                    &
          SHORT_NAME = 'DUDT',                                      &
          LONG_NAME  = 'tendency_of_eastward_wind_due_to_physics',  &
@@ -767,7 +767,7 @@ contains
          VLOCATION  =  MAPL_VLocationCenter,                          &
          RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddExportSpec(GC,                                       &
          SHORT_NAME = 'DQLDTSCL',                                     &
          LONG_NAME  = 'tendency_of_cloud_water_due_to_mass_scaling',  &
@@ -776,7 +776,7 @@ contains
          VLOCATION  =  MAPL_VLocationCenter,                          &
          RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddExportSpec(GC,                                       &
          SHORT_NAME = 'DQIDTSCL',                                     &
          LONG_NAME  = 'tendency_of_cloud_ice_due_to_mass_scaling',    &
@@ -785,7 +785,7 @@ contains
          VLOCATION  =  MAPL_VLocationCenter,                          &
          RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddExportSpec(GC,                                       &
          SHORT_NAME = 'DTDTUNPERT',                                   &
          LONG_NAME  = 'unperturbed_air_temperature_tendency',         &
@@ -927,7 +927,7 @@ contains
          CHILD_ID = MOIST,                                         &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'QCTOT',                                     &
          CHILD_ID = MOIST,                                         &
@@ -939,7 +939,7 @@ contains
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'V10M',                                      &
          CHILD_ID = SURF,                                          &
@@ -951,25 +951,25 @@ contains
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'V10N',                                      &
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'SNOMAS',                                    &
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'WET1',                                      &
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'TSOIL1',                                    &
          CHILD_ID = SURF,                                          &
@@ -981,37 +981,37 @@ contains
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'TS',                                        &
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'FRLAND',                                    &
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'FRLANDICE',                                 &
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'FRLAKE',                                    &
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'FROCEAN',                                   &
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
     call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'FRACI',                                     &
          CHILD_ID = SURF,                                          &
@@ -1023,7 +1023,7 @@ contains
          CHILD_ID = SURF,                                          &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
-                                                                                                                             
+
 !EOS
 
 
@@ -1070,8 +1070,9 @@ contains
 !-------------------
 
      call MAPL_AddConnectivity ( GC,                            &
-         SHORT_NAME  = (/  'QV','QL','QI','QR','QS','QG',      &
-                         'FCLD','RL','RI','RR','RS','RG' /),   &
+         SHORT_NAME  = [character(len=4) ::                     &
+                           'QV','QL','QI','QR','QS','QG',       &
+                         'FCLD','RL','RI','RR','RS','RG'],      &
          DST_ID      = RAD,                                     &
          SRC_ID      = MOIST,                                   &
                                                      RC=STATUS  )
@@ -1175,11 +1176,11 @@ contains
 
 ! Imports for GWD
 !----------------
-    call MAPL_AddConnectivity ( GC,                                &
-         SHORT_NAME  = (/'Q', 'DTDT_DC', 'DTDT_SC'/),              &
-         DST_ID      = GWD,                                        &
-         SRC_ID      = MOIST,                                      &
-                                                        RC=STATUS  )
+    call MAPL_AddConnectivity ( GC,                                    &
+         SHORT_NAME  = [character(len=7):: 'Q', 'DTDT_DC', 'DTDT_SC'], &
+         DST_ID      = GWD,                                            &
+         SRC_ID      = MOIST,                                          &
+                                                        RC=STATUS      )
     VERIFY_(STATUS)
     call MAPL_AddConnectivity ( GC,                                      &
          SRC_NAME    = 'DQIDT_micro',                                    &
@@ -1254,7 +1255,7 @@ contains
              DST_ID      = CHEM,                                  &
              SRC_ID      = SURF,                                  &
              RC=STATUS )
-        VERIFY_(STATUS)       
+        VERIFY_(STATUS)
      endif
 
      call MAPL_AddConnectivity ( GC,                              &
@@ -1321,11 +1322,11 @@ contains
 
 
     !-------------- DONIF Additional Moist Imports
-   
+
 
     call MAPL_AddConnectivity ( GC,                                &
-         SHORT_NAME  = (/'VSCSFC'/),                         & 
-         DST_ID      = MOIST,                                      & 
+         SHORT_NAME  = (/'VSCSFC'/),                         &
+         DST_ID      = MOIST,                                      &
          SRC_ID      = TURBL,                                      &
                                                         RC=STATUS  )
     VERIFY_(STATUS)
@@ -1345,7 +1346,7 @@ contains
          SRC_ID      =  GWD,                                      &
                                                         RC=STATUS  )
    VERIFY_(STATUS)
-   
+
     call MAPL_AddConnectivity ( GC,                                &
          SHORT_NAME  = (/'TAUGWY'/),                                 &
          DST_ID      =  MOIST,                                     &
@@ -1359,29 +1360,29 @@ contains
          SRC_ID      =  GWD,                                      &
                                                         RC=STATUS  )
    VERIFY_(STATUS)
-  
+
    call MAPL_AddConnectivity ( GC,                                &
          SHORT_NAME  = (/'TAUOROY'/),                                 &
          DST_ID      =  MOIST,                                     &
          SRC_ID      =  GWD,                                      &
                                                         RC=STATUS  )
    VERIFY_(STATUS)
-  
-    
+
+
    call MAPL_AddConnectivity ( GC,                                &
          SHORT_NAME  = (/'RADLW'/),                                 &
          DST_ID      =  MOIST,                                     &
          SRC_ID      =  RAD,                                      &
                                                        RC=STATUS  )
    VERIFY_(STATUS)
-    
+
    call MAPL_AddConnectivity ( GC,                                &
          SHORT_NAME  = (/'RADSW'/),                                 &
          DST_ID      =  MOIST,                                     &
          SRC_ID      =  RAD,                                      &
                                                        RC=STATUS  )
    VERIFY_(STATUS)
-    
+
    call MAPL_AddConnectivity ( GC,                                &
          SHORT_NAME  = (/'ALH'/),                                 &
          DST_ID      =  MOIST,                                     &
@@ -1396,11 +1397,11 @@ contains
                                                         RC=STATUS  )
 
    VERIFY_(STATUS)
-    
+
 
 !EOP
 
-! Disable connectivities of Surface imports that are filled manually from 
+! Disable connectivities of Surface imports that are filled manually from
 !  turbulence bundles.
 !------------------------------------------------------------------------
 
@@ -1414,7 +1415,7 @@ contains
 ! terminate imports to SURF for SYNCTQ
      if ( SYNCTQ.ge.1.) then
        call MAPL_TerminateImport    ( GC,  &
-          SHORT_NAME = (/ 'UA','VA','TA','QA','SPEED' /),        &
+          SHORT_NAME = [character(len=5) :: 'UA','VA','TA','QA','SPEED' ], &
           CHILD      = SURF,               &
           RC=STATUS  )
        VERIFY_(STATUS)
@@ -1429,7 +1430,7 @@ contains
 ! terminate imports to turb for SYNCTQ
      if ( SYNCTQ.ge.1.) then
        call MAPL_TerminateImport    ( GC,  &
-          SHORT_NAME = (/'U','V','T','TH' /),     & 
+          SHORT_NAME = (/'U ','V ','T ','TH' /),     &
           CHILD      = TURBL,              &
           RC=STATUS  )
        VERIFY_(STATUS)
@@ -1458,12 +1459,12 @@ contains
 ! terminate imports to RAD for SYNCTQ
      if ( SYNCTQ.ge.1.) then
        call MAPL_TerminateImport  ( GC,    &
-          SHORT_NAME = (/'T'/),            &     
+          SHORT_NAME = (/'T'/),            &
           CHILD = RAD,                     &
           RC=STATUS)
        VERIFY_(STATUS)
      endif
-   
+
     call MAPL_TimerAdd(GC, name="INITIALIZE"    ,RC=STATUS)
     VERIFY_(STATUS)
 
@@ -1481,7 +1482,7 @@ contains
     VERIFY_(STATUS)
 
     RETURN_(ESMF_SUCCESS)
-  
+
   end subroutine SetServices
 
 
@@ -1494,19 +1495,19 @@ contains
 
 ! !ARGUMENTS:
 
-  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component
   type(ESMF_State),    intent(inout) :: IMPORT ! Import state
   type(ESMF_State),    intent(inout) :: EXPORT ! Export state
   type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
   integer, optional,   intent(  out) :: RC     ! Error code
 
 ! !DESCRIPTION: The Initialize method of the Physics Composite Gridded Component.
-!  It acts as a driver for the initializtion of the five children: Radiation, 
+!  It acts as a driver for the initializtion of the five children: Radiation,
 !  Turbulence, Moist, Chem, and Surface. It also sets up the frieldly connections
-!  between the children and their sibling Turbulence, as well as with their 
+!  between the children and their sibling Turbulence, as well as with their
 !  ``uncles'' Advection and Analysis.
 !
-!   For the turbulence tracer bundle, U and V come from 
+!   For the turbulence tracer bundle, U and V come from
 !   the import state, S is computed here from T and Z and kept
 !   in the export state, the rest are friendlies from MOIST and CHEM.
 !
@@ -1516,7 +1517,7 @@ contains
 !   call; all others have to be done manually.
 !
 !   Any of the children`s exports that are friendly to advection or analysis
-!   are put in the respective bundles by a single MAPL_Generic call. Remember 
+!   are put in the respective bundles by a single MAPL_Generic call. Remember
 !   that friendly exports are were automatically allocated by the children
 !   during the initialization sequence of the entire tree below Physics, which
 !   is the first thing done here.
@@ -1528,7 +1529,7 @@ contains
 
 ! ErrLog Variables
 
-  character(len=ESMF_MAXSTR)           :: IAm 
+  character(len=ESMF_MAXSTR)           :: IAm
   integer                              :: STATUS
   character(len=ESMF_MAXSTR)           :: COMP_NAME
 
@@ -1562,7 +1563,7 @@ contains
 
 !=============================================================================
 
-! Begin... 
+! Begin...
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -1653,7 +1654,7 @@ contains
     VERIFY_(STATUS)
 
 
-!   Fill the turbulence tracer bundle: S, U, and V come from 
+!   Fill the turbulence tracer bundle: S, U, and V come from
 !   the import state, the rest are friendlies from MOIST and CHEM.
 !   For now, only S, U, V, and QV are non-default. Default tracers go last
 !   in the bundle. This will have to be done better later by using
@@ -1993,7 +1994,7 @@ contains
 
 ! !ARGUMENTS:
 
-  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component
   type(ESMF_State),    intent(inout) :: IMPORT ! Import state
   type(ESMF_State),    intent(inout) :: EXPORT ! Export state
   type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
@@ -2007,7 +2008,7 @@ contains
 
 ! ErrLog Variables
 
-   character(len=ESMF_MAXSTR)          :: IAm 
+   character(len=ESMF_MAXSTR)          :: IAm
    integer                             :: STATUS
    character(len=ESMF_MAXSTR)          :: COMP_NAME
 
@@ -2036,7 +2037,7 @@ contains
    real                                :: DT
    real                                :: SYNCTQ, DOPHYSICS
    real                                :: HGT_SURFACE
-  
+
    real, pointer, dimension(:,:,:)     :: S, T, ZLE, PLE, PK, U, V, W
    real, pointer, dimension(:,:,:)     :: DM, DPI, TOT, FRI, TTN, STN,TMP
    real, pointer, dimension(:,:,:)     :: QW, QV, QLLS, QLCN, QILS, QICN, QRAIN, QSNOW, QGRAUPEL
@@ -2063,7 +2064,7 @@ contains
    real, pointer, dimension(:,:,:)     :: RNDPERT,RNDPTR
    real, pointer, dimension(:,:,:)     :: SKEBU_WT,SKEBV_WT
    real, pointer, dimension(:,:,:)     :: SKEBU,SKEBV
-   real, pointer, dimension(:,:,:)     :: DUDTSTOCH, DVDTSTOCH, DTDTSTOCH, DQVDTSTOCH 
+   real, pointer, dimension(:,:,:)     :: DUDTSTOCH, DVDTSTOCH, DTDTSTOCH, DQVDTSTOCH
    real, pointer, dimension(:,:,:)     :: DQVDTPERT
    real, pointer, dimension(:,:,:)     :: QVPERT, QVUNPERT
    real, pointer, dimension(:,:,:)     :: DTDTUNPERT, DUDTUNPERT, DVDTUNPERT, DQVDTUNPERT
@@ -2111,7 +2112,7 @@ contains
    real(kind=MAPL_R8), allocatable, dimension(:,:,:) :: dq
 
    real, pointer, dimension(:,:,:)     :: DTDT_BL, DQDT_BL
- 
+
    real*8, allocatable, dimension(:,:)   :: sum_qdp_b4
    real*8, allocatable, dimension(:,:)   :: sum_qdp_af
    real,   allocatable, dimension(:,:,:) ::     qdp_b4
@@ -2127,7 +2128,7 @@ contains
 
 !=============================================================================
 
-! Begin... 
+! Begin...
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -2203,16 +2204,16 @@ contains
     if (isPresent) then
        call ESMFL_BundleGetPointerToData( BUNDLE, 'QSNOW', QSNOW, RC=STATUS )
        VERIFY_(STATUS)
-    else     
+    else
        QSNOW => zero
-    end if   
+    end if
     call ESMF_FieldBundleGet ( BUNDLE, fieldName='QGRAUPEL', isPresent=isPresent, RC=STATUS)
     if (isPresent) then
        call ESMFL_BundleGetPointerToData( BUNDLE, 'QGRAUPEL', QGRAUPEL, RC=STATUS )
        VERIFY_(STATUS)
-    else     
+    else
        QGRAUPEL => zero
-    end if   
+    end if
 
 ! Initialize Passive Tracer QW
 ! ----------------------------
@@ -2331,10 +2332,10 @@ contains
        call MAPL_GetPointer(GEX(MOIST) ,   TTN,   'DTDT', alloc=.true., RC=STATUS)
        VERIFY_(STATUS)
     end if
- 
+
     if(associated(DTDT) .or. associated(TIT) .or. associated(DTDTTOT)) then
        call MAPL_GetPointer(EXPORT     ,   SIT,     'SIT', alloc=.true., RC=STATUS)
-       VERIFY_(STATUS) 
+       VERIFY_(STATUS)
     end if
 
     if(associated(DTDT) .or. associated(DTDTRAD) .or. associated(DTDTTOT)) then
@@ -2380,7 +2381,7 @@ contains
        VERIFY_(STATUS)
        call MAPL_GetPointer (EXPORT, DQIDTSCL, 'DQIDTSCL', RC=STATUS)
        VERIFY_(STATUS)
-    if (DO_SPPT) then   
+    if (DO_SPPT) then
        call MAPL_GetPointer (EXPORT, RNDPTR,    'RNDPTR',    RC=STATUS)
        VERIFY_(STATUS)
        call MAPL_GetPointer (EXPORT, DTDTUNPERT, 'DTDTUNPERT',   RC=STATUS)
@@ -2405,13 +2406,13 @@ contains
        VERIFY_(STATUS)
        call MAPL_GetPointer (EXPORT, DQVDTSTOCH, 'DQVDTSTOCH', RC=STATUS)
        VERIFY_(STATUS)
-    endif 
+    endif
     if (DO_SKEB) then
        call MAPL_GetPointer (EXPORT, SKEBU,    'SKEBU',    alloc=.true., RC=STATUS)
        VERIFY_(STATUS)
        call MAPL_GetPointer (EXPORT, SKEBV,    'SKEBV',    alloc=.true., RC=STATUS)
        VERIFY_(STATUS)
-    endif 
+    endif
 
     if(associated(DOXDTCHMINT)) then
        call MAPL_GetPointer ( GEX(CHEM),  DOXDTCHM,  'OX_TEND', alloc=.true., RC=STATUS)
@@ -2434,8 +2435,8 @@ contains
       endif
      endif
 
-! Gravity Wave Drag 
-!  (must be first to use Q from dynamics, 
+! Gravity Wave Drag
+!  (must be first to use Q from dynamics,
 !    as it was when it was in superdyn.)
 !----------------------------------------
 
@@ -2605,7 +2606,7 @@ contains
     call MAPL_TimerOff(STATE,GCNames(I))
 
     if ( SYNCTQ.ge.1. ) then
-     ! From TURBL Stage 2 
+     ! From TURBL Stage 2
      call MAPL_GetPointer ( GEX(TURBL), SAFUPDATE,  'SAFUPDATE', RC=STATUS); VERIFY_(STATUS)
      ! For RAD
      call MAPL_GetPointer ( GIM(RAD), TFORRAD, 'T', RC=STATUS); VERIFY_(STATUS)
@@ -2630,7 +2631,7 @@ contains
 ! Aerosol/Chemistry Stage 2
 !--------------------------
 
-    I=CHEM   
+    I=CHEM
 
     call MAPL_TimerOn(STATE,GCNames(I))
      call ESMF_GridCompRun (GCS(I), importState=GIM(I), exportState=GEX(I), clock=CLOCK, PHASE=2, userRC=STATUS ); VERIFY_(STATUS)
@@ -2657,7 +2658,7 @@ contains
 
 !-------------------------------
 !-stochastic-physics
-! Update SPPT and/or SKEB pattern and perts 
+! Update SPPT and/or SKEB pattern and perts
 
     if(DO_SPPT) then
        allocate(RNDPERT(IM,JM,LM),stat=STATUS)
@@ -2678,12 +2679,12 @@ contains
        call MAPL_GetPointer ( GIM(GWD),  PREF,  'PREF', RC=STATUS)
        VERIFY_(STATUS)
 
-       SKEBU_WT = 0. ; SKEBV_WT = 0. 
+       SKEBU_WT = 0. ; SKEBV_WT = 0.
        call skeb_pattern(CF,grid,SKEBU_WT,SKEBV_WT,PREF,IM,JM,LM,DT)
-       if(associated (SKEBU) .and. associated(SKEBV)) then 
+       if(associated (SKEBU) .and. associated(SKEBV)) then
           SKEBU = SKEBU_WT
           SKEBV = SKEBV_WT
-       endif 
+       endif
     endif
 !-stochastic-physics
 
@@ -2694,8 +2695,8 @@ contains
 
 !   NEED_TOT = associated(DTDTTOT) .or. associated(DTDT)
     NEED_TOT = .TRUE.
-    NEED_FRI = associated(    TIF) .or. NEED_TOT 
-    NEED_STN = associated(    TIT) .or. NEED_TOT 
+    NEED_FRI = associated(    TIF) .or. NEED_TOT
+    NEED_STN = associated(    TIT) .or. NEED_TOT
 
     if(NEED_FRI) then
        allocate(FRI(IM,JM,LM),stat=STATUS)
@@ -2708,12 +2709,12 @@ contains
        VERIFY_(STATUS)
        STN = SIT*(1./MAPL_CP)
     end if
-  
+
     if(associated(DUDT   )) DUDT    = UIM + UIT + UIG
     if(associated(DVDT   )) DVDT    = VIM + VIT + VIG
     if(associated(DWDT   )) DWDT    = WIM
 !-stochastic-physics
-    IF( DO_SPPT ) THEN 
+    IF( DO_SPPT ) THEN
        allocate(TMP(IM,JM,LM),stat=STATUS)
        VERIFY_(STATUS)
        if( associated(DUDT) .and. associated(DVDT) ) then
@@ -2723,23 +2724,23 @@ contains
           DO L=1,LM
               TMP(:,:,L) = DUDT(:,:,L)*RNDPERT(:,:,L)
              DUDT(:,:,L) = DUDT(:,:,L) +   TMP(:,:,L)
-          ENDDO 
+          ENDDO
           if( associated(DUDTSTOCH) ) DUDTSTOCH = TMP
           TMP = 0.
           DO L=1,LM
               TMP(:,:,L) = DVDT(:,:,L)*RNDPERT(:,:,L)
              DVDT(:,:,L) = DVDT(:,:,L) +   TMP(:,:,L)
-          ENDDO 
+          ENDDO
           if( associated(DVDTSTOCH) ) DVDTSTOCH = TMP
        endif
     ENDIF
 
-    IF ( DO_SKEB .and. associated(DUDT) .and. associated(DVDT) ) THEN 
+    IF ( DO_SKEB .and. associated(DUDT) .and. associated(DVDT) ) THEN
        DO L=1,LM
           DUDT(:,:,L)= DUDT(:,:,L) + SKEBU(:,:,L)
           DVDT(:,:,L)= DVDT(:,:,L) + SKEBV(:,:,L)
-       ENDDO        
-    ENDIF 
+       ENDDO
+    ENDIF
 !-stochastic-physics
 
     if(associated(KEPHY   )) KEPHY = 0.0
@@ -2777,16 +2778,16 @@ contains
            + TIG   &  ! Mass-Weighted Temperature Tendency due to GWD
            + TICU     ! Mass-Weighted Temperature Tendency due to Cumulus Friction
 
-       IF(DO_SPPT) THEN 
+       IF(DO_SPPT) THEN
           allocate(TFORQS(IM,JM,LM))
           TFORQS = T + DT*TOT*DPI
           if( associated(DTDTUNPERT) ) DTDTUNPERT = TOT
           DO L=1,LM
-            TMP(:,:,L) = (TOT(:,:,L) - TIG(:,:,L) ) *RNDPERT(:,:,L) ! Remove contribution from GWD before rndpert 
+            TMP(:,:,L) = (TOT(:,:,L) - TIG(:,:,L) ) *RNDPERT(:,:,L) ! Remove contribution from GWD before rndpert
             TOT(:,:,L) =  TOT(:,:,L) + TMP(:,:,L)
-          ENDDO 
+          ENDDO
           if( associated(DTDTSTOCH) ) DTDTSTOCH = TMP * DPI
-       ENDIF 
+       ENDIF
 
        if(associated(PERAD   )) then
           do L=1,LM
@@ -2837,7 +2838,7 @@ contains
        if (DO_SPPT) then
           if(associated(DTDTUNPERT)) DTDTUNPERT = DTDTUNPERT * DPI
        end if
-       deallocate(TOT)  
+       deallocate(TOT)
     end if
 
 
@@ -2954,7 +2955,7 @@ contains
 
 ! QV Tendencies
 ! -------------
-    IF(DO_SPPT) THEN 
+    IF(DO_SPPT) THEN
 
         if ( .not.associated(DQVDTMST) .or. .not.associated(DQVDTTRB) .or. .not.associated(DQVDTCHM) ) then
            status=99
@@ -2999,7 +3000,7 @@ contains
                 QV(:,:,L) = TMP(:,:,L)
              endwhere
           ENDDO
-!         if( associated(DQVDTSTOCH) ) DQVDTSTOCH = (QV - DQVDTSTOCH)/DT 
+!         if( associated(DQVDTSTOCH) ) DQVDTSTOCH = (QV - DQVDTSTOCH)/DT
 
         ! Create Water Mass after Stochastic Perturbation
         ! -----------------------------------------------
@@ -3083,7 +3084,7 @@ contains
           deallocate( sum_qdp_af )
 
           deallocate(pmean,qs,TFORQS)
-    ENDIF 
+    ENDIF
 
     if(associated(DQVDTPHYINT)) then
        DQVDTPHYINT = 0.0

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF2020.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF2020.F90
@@ -14,7 +14,7 @@ MODULE ConvPar_GF2020
 USE module_gate
 USE MAPL
 USE ConvPar_GF_SharedParams
-USE GEOSmoist_Process_Library, only : ICE_FRACTION 
+USE GEOSmoist_Process_Library, only : ICE_FRACTION
 
  IMPLICIT NONE
  PRIVATE
@@ -32,7 +32,7 @@ USE GEOSmoist_Process_Library, only : ICE_FRACTION
         ,cum_fadj_massflx, cum_use_excess, cum_ave_layer, adv_trigger      &
         ,use_smooth_prof, evap_fix,output_sound,use_cloud_dissipation      &
         ,use_smooth_tend,GF_convpar_init,beta_sh,c0_shal                   &
-        ,use_linear_subcl_mf,cap_maxs                        
+        ,use_linear_subcl_mf,cap_maxs
 
 !PUBLIC GF2020_DRV,make_DropletNumber ,make_IceNumber,fract_liq_f &
 !      ,use_gustiness, use_random_num, dcape_threshold
@@ -202,7 +202,7 @@ CONTAINS
     REAL   ,DIMENSION(mxp,myp,mzp)   ,INTENT(IN)   :: ZLO, PLO, PK, MASS, OMEGA, KH,       &
                                                       T1,TH1,Q1,U1,V1,QLCN,QICN,QLLS,QILS, &
                                                       CLLS,CLCN
-                                                       
+
     REAL   ,DIMENSION(mxp,myp,0:mzp) ,INTENT(IN)   :: PLE_DYN_IN
 
     REAL   ,DIMENSION(mxp,myp,mzp)   ,INTENT(IN)   ::  QV_DYN_IN, U_DYN_IN, V_DYN_IN, T_DYN_IN, &
@@ -225,7 +225,7 @@ CONTAINS
     REAL   ,DIMENSION(mxp,myp,0:mzp) ,INTENT(OUT)  :: CNV_MFC
 
     REAL   ,DIMENSION(mxp,myp,mzp)   ,INTENT(OUT)  :: CNV_MF0 , CNV_PRC3 , CNV_MFD , CNV_DQCDT,  &
-                                                      CNV_UPDF, CNV_CVW  , CNV_QC  , ENTLAM   
+                                                      CNV_UPDF, CNV_CVW  , CNV_QC  , ENTLAM
 
 
     REAL   ,DIMENSION(mxp,myp)       ,INTENT(OUT)  :: CNPCPRATE, LIGHTN_DENS
@@ -797,7 +797,7 @@ CONTAINS
               !- update tracer mass mixing ratios
               DO ispc=1,mtp
 
-                 CNV_Tracers(ispc)%Q(i,j,k) = CNV_Tracers(ispc)%Q(i,j,k) + DT_moist * SRC_CHEM(ispc,flip(k),i,j) 
+                 CNV_Tracers(ispc)%Q(i,j,k) = CNV_Tracers(ispc)%Q(i,j,k) + DT_moist * SRC_CHEM(ispc,flip(k),i,j)
 
                  !-- final check for negative tracer mass mixing ratio
                  CNV_Tracers(ispc)%Q(i,j,k) = max(CNV_Tracers(ispc)%Q(i,j,k), mintracer)
@@ -898,7 +898,7 @@ ENDIF
       ENDDO
   ENDIF
 
-  
+
   !
   !--- cold pool/"convection tracer"
   IF(CONVECTION_TRACER==1) THEN
@@ -1516,7 +1516,7 @@ ENDIF
 
           enddo
          enddo
-       
+
        ENDIF
        !
        !--- deep convection
@@ -11440,7 +11440,7 @@ REAL FUNCTION fract_liq_f(temp2,cnvfrc,srftype) ! temp2 in Kelvin, fraction betw
        !--- source of enviroment moistening/cooling due to the 'remained' cloud dissipation into it.
        outqc_diss = ( qrc_diss * (1.-frh) ) / cloud_lifetime
 
-       if(versionx==1 .or. COUPL_MPHYSICS == .false.) then
+       if(versionx==1 .or. COUPL_MPHYSICS .eqv. .false.) then
 
          outt_diss  = -outqc_diss*(xlv/cp) !--- cooling
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF_GEOS5.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF_GEOS5.F90
@@ -58,6 +58,14 @@ USE ConvPar_GF_SharedParams
 
  !
 
+ !- physical constants
+ !- NOTE we need to define a T_ice local to
+ !- this code as it is *different* than the T_ice
+ !- that comes from ConvPar_GF_Shared. Without
+ !- doing this, the code is non-zero-diff
+ REAL, PARAMETER ::  &
+  T_ice_local   = 250.16 ! K
+
  !- proportionality constant to estimate pressure
  !- gradient of updraft (Zhang and Wu, 2003, JAS)
  REAL, PARAMETER ::    pgcd=1., pgcon=0.
@@ -545,7 +553,7 @@ IF(ITEST==0) CNPCPRATE(i,j) =  0.
               !- simple splitting of condensate tendency into liq/ice phases
               !- these are 'anvil' mixing ratio and not 'grid-scale' mix ratio
               !- (the convective source will be applied in progno_cloud, routine "consrc")
-              ! tem1 =  min(1., (max(0.,(T1(i,j,k)-T_ice))/(T_0-T_ice))**2)
+              ! tem1 =  min(1., (max(0.,(T1(i,j,k)-T_ice_local))/(T_0-T_ice_local))**2)
               ! QLCN (i,j,k) = QLCN (i,j,k) + DT_moist * SRC_CI(flip(k),i,j) * tem1
               ! QICN (i,j,k) = QICN (i,j,k) + DT_moist * SRC_CI(flip(k),i,j) * (1.0-tem1)
 IF(ITEST==3) then
@@ -4739,7 +4747,7 @@ ENDIF !- end of section for atmospheric composition
     real, parameter :: bdispm = 0.366       !berry--size dispersion (maritime)
     real, parameter :: bdispc = 0.146       !berry--size dispersion (continental)
     real, parameter :: T_BF  = 268.16   &
-                     , T_ice = 250.16
+                     , T_ice_local = 250.16
 !
 !  on input
 !
@@ -4957,7 +4965,7 @@ ENDIF !- end of section for atmospheric composition
 
                 if(qrc(i,k)>min_liq) then
                   cbf = 1.
-                  if(tempc(i,k) < T_BF) cbf=1.+0.5*sqrt (min(T_BF-tempc(i,k),T_BF-T_ICE))
+                  if(tempc(i,k) < T_BF) cbf=1.+0.5*sqrt (min(T_BF-tempc(i,k),T_BF-T_ice_local))
                   !cx0 = 0.002*cbf
                   cx0 = (c1d(i,k)+c0)*cbf !use this: c1d(i,k)+c0
                   !print*,'cbf=',k,cx0,cbf,dz
@@ -9102,14 +9110,14 @@ ENDIF
         DO k=kts,ktf
           DO i=its,itf
              if(ierr(i) /= 0) cycle
-             if    (tn(i,k) <= T_ice) then
+             if    (tn(i,k) <= T_ice_local) then
                 p_liq_ice(i,k) = 0.
-             elseif(  tn(i,k) > T_ice .and. tn(i,k) < T_0) then
-                p_liq_ice(i,k) =  ((tn(i,k)-T_ice)/(T_0-T_ice))**2
+             elseif(  tn(i,k) > T_ice_local .and. tn(i,k) < T_0) then
+                p_liq_ice(i,k) =  ((tn(i,k)-T_ice_local)/(T_0-T_ice_local))**2
              else
                 p_liq_ice(i,k) = 1.
              endif
-             !p_liq_ice(i,k) =  min(1., (max(0.,(tn(i,k)-T_ice))/(T_0-T_ice))**2)
+             !p_liq_ice(i,k) =  min(1., (max(0.,(tn(i,k)-T_ice_local))/(T_0-T_ice_local))**2)
 
          ENDDO
         ENDDO
@@ -9604,10 +9612,10 @@ end subroutine fct1d3
 
 	   !
 	   !--for future use (rain and snow precipitation fluxes)
-	   !if	 (tempco(i,k) <= T_ice) then
+	   !if	 (tempco(i,k) <= T_ice_local) then
            !   p_liq_ice(k) = 0.      ! only solid
-           !elseif(  tempco(i,k) > T_ice .and. tempco(i,k) < T_0) then
-           !   p_liq_ice(k) =  ((tempco(i,k)-T_ice)/(T_0-T_ice))**2
+           !elseif(  tempco(i,k) > T_ice_local .and. tempco(i,k) < T_0) then
+           !   p_liq_ice(k) =  ((tempco(i,k)-T_ice_local)/(T_0-T_ice_local))**2
            !else
            !   p_liq_ice(k) = 1.      ! only liquid
            !endif

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF_GEOS5.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF_GEOS5.F90
@@ -26,7 +26,7 @@ USE ConvPar_GF_SharedParams
  !------------------- internal variables
  !-- turn ON/OFF deep/shallow/mid plumes
  INTEGER, PARAMETER :: ON=1, OFF=0
-                  
+
 !-- General control for the diverse options in GF
  LOGICAL, PARAMETER :: ENTRNEW        = .TRUE.  !- new entr formulation
  LOGICAL, PARAMETER :: COUPL_MPHYSICS = .TRUE.  !- coupling with cloud microphysics
@@ -45,7 +45,7 @@ USE ConvPar_GF_SharedParams
  INTEGER, PARAMETER :: CLOUDMP = 1
 
  !-autonversion formulation: (1) Kessler, (2) Berry, (3) NOAA, (4) Sundvisqt
- INTEGER, PARAMETER :: autoconv = 1 
+ INTEGER, PARAMETER :: autoconv = 1
  !-rainfall evaporation(1) orig (2) mix orig+new (3) new
  INTEGER, PARAMETER :: aeroevap = 1
 
@@ -55,25 +55,8 @@ USE ConvPar_GF_SharedParams
                        maxens3 = 16, & !16 ensemble three done in cup_forcing_ens16 for G3d
                        ensdim  = maxens*maxens2*maxens3,&
                        ens4    = 1
- 
- !
 
- !- physical constants
- REAL, PARAMETER ::  &
-  rgas    = 287.,    & ! J K-1 kg-1
-  cp      = 1004.,   & ! J K-1 kg-1
-  rv      = 461.,    & ! J K-1 kg-1
-  p00     = 1.e5,    & ! hPa
-  tcrit   = 258.,    & ! K
-  g       = MAPL_GRAV,& ! m s-2
-  cpor    = cp/rgas, &
-  xlv     = 2.5e6,   & ! J kg-1
-  akmin   = 1.0,     & ! #
-  tkmin   = 1.e-5,   & ! m+2 s-2
-  ccnclean= 250.,    & ! # cm-3
-  T_0     = 273.16,  & ! K
-  T_ice   = 250.16,  & ! K
-  xlf     = 0.333e6    ! latent heat of freezing (J K-1 kg-1)
+ !
 
  !- proportionality constant to estimate pressure
  !- gradient of updraft (Zhang and Wu, 2003, JAS)
@@ -83,7 +66,7 @@ USE ConvPar_GF_SharedParams
  REAL, PARAMETER ::       &
   xmbmaxshal  =  0.05,    &  ! kg/m2/s
   mintracer   =  tiny(1.),&  ! kg/kg - tiny(x)
-  smallerQV   =  1.e-16      ! kg/kg  
+  smallerQV   =  1.e-16      ! kg/kg
 
  CHARACTER(LEN=10),PARAMETER  :: host_model = 'NEW_GEOS5'
 !
@@ -128,7 +111,7 @@ CONTAINS
     REAL   ,DIMENSION(mxp,myp,0:mzp) ,INTENT(OUT)  :: CNV_MFC
     REAL   ,DIMENSION(mxp,myp,mzp)   ,INTENT(OUT)  :: CNV_MF0 ,CNV_PRC3,CNV_MFD,CNV_DQCDT  &
                                                      ,CNV_UPDF, CNV_CVW, CNV_QC, ENTLAM
-                                                     
+
     REAL   ,DIMENSION(mxp,myp,mzp)   ,INTENT(OUT)  :: REVSU
     REAL   ,DIMENSION(mxp,myp,0:mzp) ,INTENT(OUT)  :: PRFIL
 
@@ -182,7 +165,7 @@ CONTAINS
 
 
     REAL,  ALLOCATABLE, DIMENSION(:,:,:,:) :: SRC_CHEM ! tracer mixing ratio tendencies from the parameterized convection
-    
+
     REAL,    DIMENSION(mxp,myp) :: CONPRR
 
     REAL,    DIMENSION(mxp,myp) ::  aot500  ,temp2m  ,sfc_press &
@@ -306,7 +289,7 @@ CONTAINS
     SRC_V	   =0.0
     REVSU_GF       =0.
     PRFIL_GF       =0.
-  
+
     !-
     !---temporary settings for debugging purposes
     !- special setting for SCM runs
@@ -331,7 +314,7 @@ CONTAINS
     call flipz(flip,mzp)
     !
     mtp = size(CNV_Tracers)
-    if(.not.allocated(SRC_CHEM)) THEN 
+    if(.not.allocated(SRC_CHEM)) THEN
        allocate(SRC_CHEM(mtp, mzp, mxp, myp),stat=alloc_stat) !- tendency from convection
        IF(alloc_stat==0) SRC_CHEM=0.0
     ENDIF
@@ -397,7 +380,7 @@ CONTAINS
         zt3d (k,i,j) = ZLO   (i,j,flip(k))! mid -layer level
         zm3d (k,i,j) = ZLE   (i,j,flip(k))! edge-layer level (check value at k=1 and k=mzp)
 	dm3d (k,i,j) = MASS  (i,j,flip(k))
-        curr_rvap (k,i,j) = rvap (k,i,j)  !current rvap 
+        curr_rvap (k,i,j) = rvap (k,i,j)  !current rvap
        ENDDO
       ENDDO
      ENDDO
@@ -508,7 +491,7 @@ CONTAINS
                      ,SRC_V       &
                      ,SRC_CHEM    &
                      ,REVSU_GF    &
-		     ,PRFIL_GF    & 
+		     ,PRFIL_GF    &
                      !
 		     ,do_this_column&
                      ,ierr4d       &
@@ -595,8 +578,8 @@ ENDIF
         ENDDO
       ENDIF
 
-      IF(USE_TRACER_TRANSP==1) THEN 
-              	
+      IF(USE_TRACER_TRANSP==1) THEN
+
         DO j=1,myp
           DO i=1,mxp
 	    IF(do_this_column(i,j) == 0) CYCLE
@@ -605,7 +588,7 @@ ENDIF
               !- update tracer mass mixing ratios
               DO ispc=1,mtp
 
-                 CNV_Tracers(ispc)%Q(i,j,k)=CNV_Tracers(ispc)%Q(i,j,k)+ DT_moist * SRC_CHEM(ispc,flip(k),i,j) 
+                 CNV_Tracers(ispc)%Q(i,j,k)=CNV_Tracers(ispc)%Q(i,j,k)+ DT_moist * SRC_CHEM(ispc,flip(k),i,j)
 	         !-- final check for negative tracer mass mixing ratio
                  CNV_Tracers(ispc)%Q(i,j,k)=max(mintracer, CNV_Tracers(ispc)%Q(i,j,k))
               ENDDO
@@ -799,8 +782,8 @@ ENDIF
               ,rucuten               &
               ,rvcuten               &
               ,rchemcuten            &
-              ,revsu_gf              & 
-              ,prfil_gf              & 
+              ,revsu_gf              &
+              ,prfil_gf              &
               !
               ,do_this_column        &
               ,ierr4d                &
@@ -843,7 +826,7 @@ ENDIF
    REAL,    INTENT(IN) :: DT
 
    INTEGER, INTENT(IN), dimension(mzp) :: flip
-   
+
    REAL,    DIMENSION(kts:kte,its:ite,jts:jte), INTENT(IN)  :: &
                                                           zm,   &
                                                           zt,   &
@@ -874,11 +857,11 @@ ENDIF
                                                    ,rucuten    &
                                                    ,rvcuten    &
 						   ,revsu_gf   &
-						   ,prfil_gf   
-						   
+						   ,prfil_gf
+
    !-***** rchemcuten uses the GF data structure (ispc,k,i,j) *********
    REAL,    DIMENSION(mtp,kts:kte,its:ite,jts:jte), INTENT(OUT)  :: rchemcuten
- 
+
    INTEGER, DIMENSION(its:ite,jts:jte), INTENT(INOUT) :: do_this_column
 
 !- for convective transport and cloud/radiation (OUT)
@@ -1042,7 +1025,7 @@ ENDIF
      IF(USE_TRACER_TRANSP==1) THEN
       DO k=kts,kte
        DO i=its,itf
-         kr=k   !+1 
+         kr=k   !+1
         !- atmos composition
         DO ispc=1,mtp
 	    se_chem(ispc,i,k) = max(mintracer, CNV_Tracers(ispc)%Q(i,j,flip(kr)))
@@ -1232,7 +1215,7 @@ ENDIF
 
          enddo
         enddo
-       
+
        CALL CUP_gf(its,ite,kts,kte, itf,ktf , mtp    &
                   ,cumulus_type   (deep)             &
                   ,closure_choice (deep)             &
@@ -1341,7 +1324,7 @@ ENDIF
 
           ENDDO
          ENDDO
-        
+
         CALL CUP_gf(its,ite,kts,kte, itf,ktf, mtp   &
                   ,cumulus_type  (mid)              &
                   ,closure_choice(mid)              &
@@ -1428,23 +1411,23 @@ loop1:  do n=1,maxiens
           if(ierr4d (i,j,n) == 0 ) then
 	    do_this_column(i,j) = 1
 	    exit loop1
-	  endif 
-        enddo loop1	
+	  endif
+        enddo loop1
      enddo
      !----------- check for negative water vapor mix ratio
      DO i=its,itf
           if(do_this_column(i,j) == 0) CYCLE
           do k = kts,ktf
-            temp_tendqv(i,k)= outq (i,k,shal) + outq (i,k,deep) + outq (i,k,mid ) 
+            temp_tendqv(i,k)= outq (i,k,shal) + outq (i,k,deep) + outq (i,k,mid )
 	  enddo
-	   
+
           do k = kts,ktf
 	    distance(k)= qv_curr(i,k) + temp_tendqv(i,k) * dt
 	  enddo
 
 	  if(minval(distance(kts:ktf)) < 0.) then
 	        zmax   =  MINLOC(distance(kts:ktf),1)
-		
+
 		if( abs(temp_tendqv(i,zmax) * dt) <  mintracer) then
 		  fixout_qv(i)= 0.999999
 !		  fixout_qv(i)= 0.
@@ -1487,12 +1470,12 @@ loop1:  do n=1,maxiens
              RVCUTEN (kr,i,j)= (outV(i,k,deep)+outV(i,k,mid)+outV(i,k,shal)) *fixout_qv(i)
        ENDDO
       ENDDO
-     ENDIF     
+     ENDIF
 
      IF(USE_TRACER_TRANSP==1) THEN
       DO i = its,itf
        if(do_this_column(i,j) == 0) CYCLE
-      
+
        do k = kts,kte
          kr=k!+1
          RCHEMCUTEN (:,kr,i,j)= (out_CHEM(:,i,k,deep) +out_CHEM(:,i,k,mid)+out_CHEM(:,i,k,shal)) *fixout_qv(i)
@@ -1502,16 +1485,16 @@ loop1:  do n=1,maxiens
       !- constrain positivity for tracers
       DO i = its,itf
          if(do_this_column(i,j) == 0) CYCLE
-         
+
 	 do ispc=1,mtp
 	   do k=kts,ktf
 	      distance(k)= se_chem(ispc,i,k) + RCHEMCUTEN(ispc,k,i,j)* dt
 	   enddo
-	  	    
-           !-- fixer for mass of tracer 
-           IF(minval(distance(kts:ktf)) < 0.) THEN 
+
+           !-- fixer for mass of tracer
+           IF(minval(distance(kts:ktf)) < 0.) THEN
 	        zmax   =  MINLOC(distance(kts:ktf),1)
-		
+
 		if( abs(RCHEMCUTEN(ispc,zmax,i,j)*dt) <  mintracer) then
 		  fixouts= 0.999999
 !		  fixouts= 0.
@@ -1519,8 +1502,8 @@ loop1:  do n=1,maxiens
 	          fixouts=  ( (mintracer - se_chem(ispc,i,zmax))) / (RCHEMCUTEN(ispc,zmax,i,j)*dt)
 		endif
 		if(fixouts > 1. .or. fixouts <0.)fixouts=0.
-		
-		RCHEMCUTEN(ispc,kts:ktf,i,j)=fixouts*RCHEMCUTEN(ispc,kts:ktf,i,j)		
+
+		RCHEMCUTEN(ispc,kts:ktf,i,j)=fixouts*RCHEMCUTEN(ispc,kts:ktf,i,j)
            ENDIF
          enddo
       ENDDO
@@ -1634,18 +1617,18 @@ loop1:  do n=1,maxiens
   ! convection for this call only and at that particular gridpoint
   !
      REAL,    DIMENSION (its:ite,kts:kte)       ,INTENT (IN   )    ::   &
-        dhdt,rho,t,po,us,vs,tn,dm2d 
+        dhdt,rho,t,po,us,vs,tn,dm2d
      REAL,    DIMENSION (its:ite,kts:kte,1:ens4),INTENT (INOUT)    ::   &
         omeg
      REAL,    DIMENSION (its:ite,kts:kte)       ,INTENT (INOUT)    ::   &
          q,qo
      REAL,    DIMENSION (its:ite)               ,INTENT (IN   )    ::   &
         ccn,Z1,PSUR,xland,xlons,xlats, h_sfc_flux,le_sfc_flux,tsur,dx,  &
-        stochastic_sig 
+        stochastic_sig
      REAL,    DIMENSION (its:ite)               ,INTENT (INOUT)    ::   &
         zws,ztexec,zqexec
      REAL                                       ,INTENT (IN   )    ::   &
-        dtime,entr_rate_input 
+        dtime,entr_rate_input
   !
   ! local ensemble dependent variables in this routine
      real,    dimension (its:ite,1:maxens2) ::                         &
@@ -1812,9 +1795,9 @@ loop1:  do n=1,maxiens
      !-locals
      integer :: ispc
      real, dimension (mtp,its:ite,kts:kte) ::   se_cup_chem,sc_up_chem,sc_dn_chem,pw_up_chem &
-                                               ,pw_dn_chem 
+                                               ,pw_dn_chem
      real, dimension (mtp) ::   min_tend_chem
-     real, dimension (mtp,its:ite)         ::  tot_pw_up_chem,tot_pw_dn_chem 
+     real, dimension (mtp,its:ite)         ::  tot_pw_up_chem,tot_pw_dn_chem
      real, dimension (mtp,kts:kte)         ::  trcflx_in,sub_tend,ddtr,ddtr_upd,zenv_diff,fp_mtp,fm_mtp
      real, dimension (kts:kte)             ::  aa,bb,cc,ddu,ddv,ddh,ddq,fp,fm
      real, dimension (its:ite,kts:kte)     ::  massflx,zenv
@@ -1965,7 +1948,7 @@ loop1:  do n=1,maxiens
            us,vs,u_cup,v_cup,                                     &
            hes_cup,z_cup,p_cup,gamma_cup,t_cup,psur,tsur,         &
            ierr,z1,itf,ktf,its,ite, kts,kte, host_model)
-	   
+
       call cup_env_clev(tn,qeso,qo,heo,heso,zo,po,qeso_cup,qo_cup, heo_cup,   &
            us,vs,u_cup,v_cup,                                           &
            heso_cup,zo_cup,po_cup,gammao_cup,tn_cup,psur,tsur,          &
@@ -1985,7 +1968,7 @@ loop1:  do n=1,maxiens
 !--- partition between liq/ice cloud contents
       call get_partition_liq_ice(ierr,tn,z1,zo_cup,po_cup,p_liq_ice,melting_layer,&
                                  itf,ktf,its,ite,kts,kte,cumulus)
-!     
+!
       do i=its,itf
         if(ierr(i).eq.0)then
           do k=kts,ktf
@@ -2035,7 +2018,7 @@ loop1:  do n=1,maxiens
 
            call get_lcl(tlll,100.*plll,rlll,tlcl,plcl,dzlcl)
            !print*,"MID",tlll,100.*plll,rlll,tlcl,plcl,dzlcl; flush(6)
-           
+
 	   !-get LCL index
            if(dzlcl >= 0.) then ! LCL found (if dzlcl<0 => not found)
              call get_cloud_bc(cumulus,kts,kte,ktf,xland(i),po(i,kts:kte),z_cup (i,kts:kte),zlll,k22(i))
@@ -2169,7 +2152,7 @@ l_SIG:DO fase = 1,2
                  !print*,"frh2=",frh,effec_entrain,rescale_entrain(i)
             endif
             !- scale dependence factor
-            sig (i)=(1.-frh)**2 
+            sig (i)=(1.-frh)**2
             !print*,"FORM1=",sig(i),dx(i)
           enddo
         endif
@@ -2696,10 +2679,10 @@ ENDIF
            !wmean(i) = min(max(vvel1d(i),1.),15.)
             !- time-scale cape removal from Bechtold et al. 2008
             tau_ecmwf(i)=( zo_cup(i,ktop(i))- zo_cup(i,kbcon(i)) ) / wmean(i)
-    
+
             if(trim(cumulus)=='deep') tau_ecmwf(i)=max(tau_ecmwf(i),tau_deep)
             if(trim(cumulus)=='mid' ) tau_ecmwf(i)=max(tau_ecmwf(i),tau_mid)
-  
+
             tau_ecmwf(i)= tau_ecmwf(i) * (1. + 1.66 * (dx(i)/(125*1000.)))! dx must be in meters
       enddo
       !
@@ -3468,7 +3451,7 @@ ENDIF ! vertical discretization formulation
             xf_dicycle,outu,outv,dellu,dellv,dtime,po_cup,kbcon )
 
 
-!--- get the net precipitation flux (after downdraft evaporation) 
+!--- get the net precipitation flux (after downdraft evaporation)
        call get_precip_fluxes(cumulus,klcl,kbcon,ktop,k22,ierr,xland,pre,xmb  &
                              ,pwo,pwavo,edto,pwevo,pwdo,t_cup,tempco          &
                              ,prec_flx,evap_flx                               &
@@ -3526,7 +3509,7 @@ IF(USE_TRACER_TRANSP==1)  THEN
 	up_massentro(i,:) = xmb(i)*up_massentro(i,:)
 	up_massdetro(i,:) = xmb(i)*up_massdetro(i,:)
 	dd_massentro(i,:) = xmb(i)*dd_massentro(i,:)
-	dd_massdetro(i,:) = xmb(i)*dd_massdetro(i,:) 
+	dd_massdetro(i,:) = xmb(i)*dd_massdetro(i,:)
 	zenv        (i,:) = xmb(i)*zenv        (i,:)
    enddo
 
@@ -3545,7 +3528,7 @@ IF(USE_TRACER_TRANSP==1)  THEN
 
 ! b) chem - downdraft
    call get_incloud_sc_chem_dd(cumulus,mtp,se_chem,se_cup_chem,sc_dn_chem,pw_dn_chem ,pw_up_chem,sc_up_chem &
-                             ,tot_pw_up_chem,tot_pw_dn_chem                                                       & 
+                             ,tot_pw_up_chem,tot_pw_dn_chem                                                       &
                              ,zo_cup,rho,po_cup,qrcdo,pwdo,pwevo,edto,zdo,dd_massentro,dd_massdetro ,pwavo,pwo     &
                              ,jmin,ierr,itf,ktf,its,ite, kts,kte)
 !
@@ -3554,25 +3537,25 @@ IF(USE_TRACER_TRANSP==1)  THEN
 !---a) change per unit mass that a model cloud would modify the environment
    do i=its,itf
         if(ierr(i) /= 0) cycle
-        
+
         !- flux form + source/sink terms + time explicit + FCT
-        IF(USE_FLUX_FORM == 1 .and. alp1 == 0. ) THEN 
-	
-	  if(use_fct == 0 ) then 
+        IF(USE_FLUX_FORM == 1 .and. alp1 == 0. ) THEN
+
+	  if(use_fct == 0 ) then
 	    do k=kts,ktop(i)
                 dp=100.*(po_cup(i,k)-po_cup(i,k+1))
-            
+
                 out_chem(:,i,k) =-(zuo(i,k+1)*(sc_up_chem(:,i,k+1)-se_cup_chem(:,i,k+1) ) -                 &
                                    zuo(i,k  )*(sc_up_chem(:,i,k  )-se_cup_chem(:,i,k  ) ))*g/dp             &
                                  +(zdo(i,k+1)*(sc_dn_chem(:,i,k+1)-se_cup_chem(:,i,k+1) ) -                 &
                                    zdo(i,k  )*(sc_dn_chem(:,i,k  )-se_cup_chem(:,i,k  ) ))*g/dp*edto(i)
             enddo
 
-	  else 
+	  else
 
             !-- FCT scheme for the subsidence transport: d(M_env*S_env)/dz
             sub_tend  = 0.
-            trcflx_in = 0. 
+            trcflx_in = 0.
             dtime_max = dtime
             massflx  (i,kts)=0.
 
@@ -3580,11 +3563,11 @@ IF(USE_TRACER_TRANSP==1)  THEN
                dp  	       = 100.*(po_cup(i,k)-po_cup(i,k+1))
                trcflx_in (:,k) =-(zuo(i,k)  -edto(i)*zdo(i,k))*se_cup_chem(:,i,k) !* xmb(i)
                massflx   (i,k) =-(zuo(i,k)  -edto(i)*zdo(i,k))		       !* xmb(i)
-               dtime_max=min(dtime_max,.5*dp) 
+               dtime_max=min(dtime_max,.5*dp)
             enddo
             !- if dtime_max<dtime => needs a loop to update from t to t+dtime (check this!)
             !if( dtime_max < dtime ) stop "dtime_max < dtime in GF scheme"
-         
+
             do ispc=1,mtp
                call fct1d3 (ktop(i),kte,dtime_max,po_cup(i,:),se_chem(ispc,i,:),massflx(i,:),trcflx_in(ispc,:),sub_tend(ispc,:))
             enddo
@@ -3599,7 +3582,7 @@ IF(USE_TRACER_TRANSP==1)  THEN
 
             enddo
 	  endif
-	  
+
 	  !- include evaporation
           if(USE_TRACER_EVAP == 1 .and. trim(cumulus) /= 'shallow') then
             do k=kts,ktop(i)
@@ -3608,7 +3591,7 @@ IF(USE_TRACER_TRANSP==1)  THEN
                                  - 0.5*edto(i)*(zdo(i,k)*pw_dn_chem(:,i,k)+zdo(i,k+1)*pw_dn_chem(:,i,k+1))*g/dp !&  ! evaporated ( pw_dn < 0 => E_dn > 0)
             enddo
 	  endif
-             
+
           !- include scavenging
           if(USE_TRACER_SCAVEN > 0 .and. trim(cumulus) /= 'shallow') then
             do k=kts,ktop(i)
@@ -3620,59 +3603,59 @@ IF(USE_TRACER_TRANSP==1)  THEN
         ENDIF
 
         !- flux form + source/sink terms + time explicit/implicit + upstream
-        IF(USE_FLUX_FORM == 1 .and. alp1 > 0. ) THEN 
+        IF(USE_FLUX_FORM == 1 .and. alp1 > 0. ) THEN
 
             alp0=1.-alp1
             do k=kts,ktop(i)+1
                 fp(k) = 0.5*(zenv(i,k)+abs(zenv(i,k)))
                 fm(k) = 0.5*(zenv(i,k)-abs(zenv(i,k)))
             enddo
-            
+
 	    do k=kts,ktop(i)
               dp=100.*(po_cup(i,k)-po_cup(i,k+1))
               beta1 = dtime*g/dp
               aa(k) =    alp1*beta1*fm(k)
 	      bb(k) = 1.+alp1*beta1*(fp(k)-fm(k+1))
 	      cc(k) =   -alp1*beta1*fp(k+1)
-            
+
 	      ddtr(:,k) = se_chem(:,i,k) - (zuo(i,k+1)*sc_up_chem(:,i,k+1) - zuo(i,k)*sc_up_chem(:,i,k))*beta1      &
                                          + (zdo(i,k+1)*sc_dn_chem(:,i,k+1) - zdo(i,k)*sc_dn_chem(:,i,k))*beta1*edto(i)
-             
+
               !- include evaporation
               if(USE_TRACER_EVAP == 1 .and. trim(cumulus) /= 'shallow') then
                  out_chem(:,i,k) = out_chem(:,i,k)    &
                                  - 0.5*edto(i)*(zdo(i,k)*pw_dn_chem(:,i,k)+zdo(i,k+1)*pw_dn_chem(:,i,k+1))*beta1 !&  ! evaporated ( pw_dn < 0 => E_dn > 0)
 	      endif
-             
+
               !- include scavenging
               if(USE_TRACER_SCAVEN > 0 .and. trim(cumulus) /= 'shallow') then
                  out_chem(:,i,k) = out_chem(:,i,k) &
                                  - 0.5*(zuo(i,k)*pw_up_chem(:,i,k)+zuo(i,k+1)*pw_up_chem(:,i,k+1))*beta1  ! incorporated in rainfall (<0)
               endif
-           
-	      ddtr(:,k) = ddtr(:,k) + out_chem(:,i,k) + & 
+
+	      ddtr(:,k) = ddtr(:,k) + out_chem(:,i,k) + &
 	                  alp0*beta1*(-fm(k)*se_chem(:,i,max(kts,k-1)) +(fm(k+1)-fp(k))*se_chem(:,i,k) +fp(k+1)*se_chem(:,i,k+1))
-	   
+
             enddo
             do ispc = 1, mtp
 		call tridiag (ktop(i),aa (kts:ktop(i)),bb (kts:ktop(i)),cc (kts:ktop(i)),ddtr (ispc,kts:ktop(i)))
 	        out_chem(ispc,i,kts:ktop(i))=(ddtr(ispc,kts:ktop(i))-se_chem(ispc,i,kts:ktop(i)))/dtime
-            enddo	    
+            enddo
         ENDIF
-	
+
         !- flux form + source/sink terms + time explicit + upstream with anti-diffusion step (Smolarkiewicz 1983)
-        IF(USE_FLUX_FORM == 2 .or. USE_FLUX_FORM == 3) THEN 
+        IF(USE_FLUX_FORM == 2 .or. USE_FLUX_FORM == 3) THEN
            if(USE_FLUX_FORM == 2)  lstep = -1 ! upstream + anti-diffusion step
 	   if(USE_FLUX_FORM == 3)  lstep =  1 ! only upstream
 	   alp0=1.
-           
+
 	   if(ierr(i) /= 0) cycle
            !--- Zenv here have the following reference:  < 0 => downward motion
            zenv(i,:) = -(zuo(i,:)-edto(i)*zdo(i,:))
 
 	   do istep=1,lstep,-2
 
-	    if(istep == 1) then 
+	    if(istep == 1) then
 	       ddtr_upd(:,:) = se_chem(:,i,:)
 	       do k=kts,ktop(i)+1
                   fp_mtp(:,k) = 0.5*(zenv(i,k)+abs(zenv(i,k)))
@@ -3682,17 +3665,17 @@ IF(USE_TRACER_TRANSP==1)  THEN
 	       ddtr_upd(:,kts:ktop(i)+1) = se_chem(:,i,kts:ktop(i)+1) + out_chem(:,i,kts:ktop(i)+1)*dtime
 	       zenv_diff(:,kts) = 0.
 	       do k=kts,ktop(i)+1
-		  dz =  zo_cup(i,k+1)-zo_cup(i,k) 
+		  dz =  zo_cup(i,k+1)-zo_cup(i,k)
 		  zenv_diff (:,k+1) = 1.08*( dz*abs(zenv(i,k+1)) - dtime * zenv(i,k+1)**2 ) &
 		                    * (ddtr_upd(:,k+1) - ddtr_upd(:,k))               &
-                                    /((ddtr_upd(:,k+1) + ddtr_upd(:,k) + 1.e-16)*dz) 
+                                    /((ddtr_upd(:,k+1) + ddtr_upd(:,k) + 1.e-16)*dz)
  	       enddo
 	       do k=kts,ktop(i)+1
                   fp_mtp(:,k) = 0.5*(zenv_diff(:,k)+abs(zenv_diff(:,k)))
                   fm_mtp(:,k) = 0.5*(zenv_diff(:,k)-abs(zenv_diff(:,k)))
                enddo
 	    endif
-	                	    
+
 	    do k=kts,ktop(i)
               dp=-100.*(po_cup(i,k)-po_cup(i,k+1))
               beta1 = dtime*g/dp
@@ -3719,7 +3702,7 @@ IF(USE_TRACER_TRANSP==1)  THEN
                  out_chem(:,i,k) = out_chem(:,i,k)    &
                                  - 0.5*edto(i)*(zdo(i,k)*pw_dn_chem(:,i,k)+zdo(i,k+1)*pw_dn_chem(:,i,k+1))*beta1 !&  ! evaporated ( pw_dn < 0 => E_dn > 0)
 	      endif
-             
+
               !- include scavenging
               if(USE_TRACER_SCAVEN > 0 .and. trim(cumulus) /= 'shallow') then
                  out_chem(:,i,k) = out_chem(:,i,k) &
@@ -3730,32 +3713,32 @@ IF(USE_TRACER_TRANSP==1)  THEN
 
         ENDIF
 
-        !--- check mass conservation for tracers 
+        !--- check mass conservation for tracers
         do ispc = 1, mtp
 	  evap_  (:) = 0.
 	  wetdep_(:) = 0.
 	  residu_(:) = 0.
           do k=kts,ktop(i)
              dp=100.*(po_cup(i,k)-po_cup(i,k+1))
-             evap   =  -0.5*(zdo(i,k)*pw_dn_chem(ispc,i,k)+zdo(i,k+1)*pw_dn_chem(ispc,i,k+1))*g/dp*edto(i) 
+             evap   =  -0.5*(zdo(i,k)*pw_dn_chem(ispc,i,k)+zdo(i,k+1)*pw_dn_chem(ispc,i,k+1))*g/dp*edto(i)
              wetdep =   0.5*(zuo(i,k)*pw_up_chem(ispc,i,k)+zuo(i,k+1)*pw_up_chem(ispc,i,k+1))*g/dp
 
-             evap_  (ispc) =   evap_  (ispc) + evap  *dp/g 
-             wetdep_(ispc) =   wetdep_(ispc) + wetdep*dp/g 
+             evap_  (ispc) =   evap_  (ispc) + evap  *dp/g
+             wetdep_(ispc) =   wetdep_(ispc) + wetdep*dp/g
 	     residu_(ispc) =   residu_(ispc) + (wetdep - evap)*dp/g
-	     	 
+
            enddo
-	   if(residu_(ispc) < 0.) then 
-	     beta1 = g/(po_cup(i,kts)-po_cup(i,ktop(i)+1)) 
+	   if(residu_(ispc) < 0.) then
+	     beta1 = g/(po_cup(i,kts)-po_cup(i,ktop(i)+1))
 	     do k=kts,ktop(i)
 	        out_chem(ispc,i,k)=out_chem(ispc,i,k)+residu_(ispc)*beta1
              enddo
 	   endif
         enddo
 
-   
+
    enddo ! loop 'i'
-   
+
 
 
 !-4) convert back mass fluxes, etc...
@@ -3807,12 +3790,12 @@ ENDIF !- end of section for atmospheric composition
        C_up  = dellaqc(i,k)+(zuo(i,k+1)* qrco(i,k+1) - zuo(i,k  )* qrco(i,k  )  )*g/dp &
                        +0.5*(pwo (i,k)+pwo (i,k+1))*g/dp
        C_up = - C_up*86400.*xlv/cp*xmb(i)
-      
+
        trash =-(zuo(i,k+1)*(qco (i,k+1)-qo_cup(i,k+1) ) -                 &
-                zuo(i,k  )*(qco (i,k  )-qo_cup(i,k  ) ) )*g/dp            
+                zuo(i,k  )*(qco (i,k  )-qo_cup(i,k  ) ) )*g/dp
        trash2=+(zdo(i,k+1)*(qcdo(i,k+1)-qo_cup(i,k+1) ) -                 &
-                zdo(i,k  )*(qcdo(i,k  )-qo_cup(i,k  ) ) )*g/dp*edto(i)    
-			   
+                zdo(i,k  )*(qcdo(i,k  )-qo_cup(i,k  ) ) )*g/dp*edto(i)
+
        trash  = trash *86400.*xlv/cp*xmb(i); trash2 = trash2*86400.*xlv/cp*xmb(i)
 
        nvar=nvarbegin
@@ -4056,7 +4039,7 @@ ENDIF !- end of section for atmospheric composition
   ! entr= entrainment rate
   !
      real,    dimension (its:ite) ,intent (in  )          ::           &
-        pwavo       
+        pwavo
      real,    dimension (its:ite,kts:kte) ,intent (in   ) ::           &
         zd,t_cup,hes_cup,hcd,qes_cup,q_cup,z_cup,                      &
         dd_massentr,dd_massdetr,gamma_cup,q,he
@@ -4347,10 +4330,10 @@ ENDIF !- end of section for atmospheric composition
       gamma_cup=0.
       u_cup    =0.
       v_cup    =0.
-      
+
 !      IF(.NOT. present(host_model)) THEN
       IF( present(host_model) .and. trim(host_model)=='OLD_GEOS5') THEN
-      
+
       do k=kts+1,ktf
       do i=its,itf
         if(ierr(i).eq.0)then
@@ -4366,7 +4349,7 @@ ENDIF !- end of section for atmospheric composition
                        *t_cup(i,k)))*qes_cup(i,k)
         u_cup  (i,k)=.5*(us(i,k-1)+us(i,k))
         v_cup  (i,k)=.5*(vs(i,k-1)+vs(i,k))
-		       
+
         endif
       enddo
       enddo
@@ -4387,14 +4370,14 @@ ENDIF !- end of section for atmospheric composition
                        *t_cup(i,1)))*qes_cup(i,1)
         u_cup(i,1)=us(i,1)
         v_cup(i,1)=vs(i,1)
-       
+
         endif
       enddo
       ELSE
         IF(trim(host_model)=='XXXGEOS5') THEN
          do i=its,itf
             if(ierr(i) > 0) cycle
-       	
+
 	    qes_cup(i,1)=qes(i,1)
             q_cup  (i,1)=q(i,1)
             hes_cup(i,1)=g*z1(i)+1004.*t(i,1)+2.5e6*qes(i,1)
@@ -4406,7 +4389,7 @@ ENDIF !- end of section for atmospheric composition
             u_cup  (i,1)=us(i,1)
             v_cup  (i,1)=vs(i,1)
             gamma_cup(i,1)=xlv/cp*(xlv/(rv*t_cup(i,1)*t_cup(i,1)))*qes_cup(i,1)
-            
+
 	    do k=kts,ktf-1
 	         z_cup  (i,k+1)=2.0*z  (i,k)-z_cup  (i,k)
 	         p_cup  (i,k+1)=2.0*p  (i,k)-p_cup  (i,k)
@@ -4415,12 +4398,12 @@ ENDIF !- end of section for atmospheric composition
 	         v_cup  (i,k+1)=2.0*vs (i,k)-v_cup  (i,k)
 	         q_cup  (i,k+1)=2.0*q  (i,k)-q_cup  (i,k)
 	         he_cup (i,k+1)=2.0*he (i,k)-he_cup (i,k)
-	    
+
                  qes_cup(i,k+1)=2.0*qes(i,k)-qes_cup(i,k)
 	         hes_cup(i,k+1)=2.0*hes(i,k)-hes_cup(i,k)
-	       
+
 	         if(he_cup(i,k+1).gt.hes_cup(i,k+1))he_cup(i,k+1)=hes_cup(i,k+1)
-		 
+
 	         gamma_cup(i,k+1)=(xlv/cp)*(xlv/(rv*t_cup(i,k+1) &
 	           		  *t_cup(i,k+1)))*qes_cup(i,k+1)
             enddo
@@ -4434,72 +4417,72 @@ ENDIF !- end of section for atmospheric composition
 	    	 p_cup (i,k+1) = 2.0*p(i,k) - p_cup(i,k)
 	    	 z_cup (i,k+1) = 2.0*z(i,k) - z_cup(i,k)
 	    enddo
-	    
+
 	    ! ----------- p,T	       k+1
-	    !p1 
+	    !p1
 	    ! ----------- p_cup,T_cup  k+1
-	    !p2 
+	    !p2
 	    ! ----------- p,T	       k
-	    ! 
+	    !
 	    ! ----------- p_cup,T_cup  k
-	    
-            do k=kts,ktf-1							  	      
-               p1=abs((p    (i,k+1) - p_cup(i,k+1))/(p(i,k+1)-p(i,k)))		  	      
-               p2=abs((p_cup(i,k+1) - p    (i,k  ))/(p(i,k+1)-p(i,k)))		  	      
-                								  	      
-               t_cup  (i,k+1) = p1*t  (i,k) + p2*t  (i,k+1) 				  	      
-										  	      
-               u_cup  (i,k+1) = p1*us (i,k) + p2*us (i,k+1)			  	      
-               v_cup  (i,k+1) = p1*vs (i,k) + p2*vs (i,k+1)			  	      
-               q_cup  (i,k+1) = p1*q  (i,k) + p2*q  (i,k+1)			  	      
-               he_cup (i,k+1) = p1*he (i,k) + p2*he (i,k+1)			  	      
-            									  	      
-               qes_cup(i,k+1) = p1*qes(i,k) + p2*qes(i,k+1)			  	      
-               hes_cup(i,k+1) = p1*hes(i,k) + p2*hes(i,k+1)			  	      
-										  	      
-               if(he_cup(i,k+1).gt.hes_cup(i,k+1))he_cup(i,k+1)=hes_cup(i,k+1)	  	      
- 										  	      
-               gamma_cup(i,k+1)=(xlv/cp)*(xlv/(rv*t_cup(i,k+1) &		  	      
-                                *t_cup(i,k+1)))*qes_cup(i,k+1)			  	      
-										  	      
-            enddo								  	      
-	    !--- surface level from X(kts) and X_cup(kts+1) determine X_cup(kts)	      
-            k=kts								  	      
-	    p1=abs(p    (i,k  )-p_cup(i,k))					  	      
-	    p2=abs(p_cup(i,k+1)-p_cup(i,k))					  	      
-	    									  	      
-            c1=(p1+p2)/p2							  	      
-	    c2=p1/p2								  	      
-	    									  	      
-	    t_cup  (i,k) = c1*t  (i,k) - c2*t_cup(i,k+1)			  	      
-            q_cup  (i,k) = c1*q  (i,k) - c2*q_cup(i,k+1)			  	      
-	   									  	      
-            u_cup  (i,k) = c1*us (i,1) - c2*u_cup(i,k+1)			  	      
-            v_cup  (i,k) = c1*vs (i,1) - c2*v_cup(i,k+1)			  	      
-            qes_cup(i,k) = c1*qes(i,k) - c2*qes_cup(i,k+1)			  	      
-	    									  	      
-            hes_cup(i,k)=g*z_cup(i,k)+1004.*t_cup(i,k)+2.5e6*qes_cup(i,k)		  	      
-            he_cup (i,k)=g*z_cup(i,k)+1004.*t_cup(i,k)+2.5e6*q_cup  (i,k)		  	      
-            
-	    if(he_cup(i,k).gt.hes_cup(i,k))he_cup(i,k)=hes_cup(i,k)	  	      
-            
-	    gamma_cup(i,k)=xlv/cp*(xlv/(rv*t_cup(i,k)*t_cup(i,k)))*qes_cup(i,k)   	      
+
+            do k=kts,ktf-1
+               p1=abs((p    (i,k+1) - p_cup(i,k+1))/(p(i,k+1)-p(i,k)))
+               p2=abs((p_cup(i,k+1) - p    (i,k  ))/(p(i,k+1)-p(i,k)))
+
+               t_cup  (i,k+1) = p1*t  (i,k) + p2*t  (i,k+1)
+
+               u_cup  (i,k+1) = p1*us (i,k) + p2*us (i,k+1)
+               v_cup  (i,k+1) = p1*vs (i,k) + p2*vs (i,k+1)
+               q_cup  (i,k+1) = p1*q  (i,k) + p2*q  (i,k+1)
+               he_cup (i,k+1) = p1*he (i,k) + p2*he (i,k+1)
+
+               qes_cup(i,k+1) = p1*qes(i,k) + p2*qes(i,k+1)
+               hes_cup(i,k+1) = p1*hes(i,k) + p2*hes(i,k+1)
+
+               if(he_cup(i,k+1).gt.hes_cup(i,k+1))he_cup(i,k+1)=hes_cup(i,k+1)
+
+               gamma_cup(i,k+1)=(xlv/cp)*(xlv/(rv*t_cup(i,k+1) &
+                                *t_cup(i,k+1)))*qes_cup(i,k+1)
+
+            enddo
+	    !--- surface level from X(kts) and X_cup(kts+1) determine X_cup(kts)
+            k=kts
+	    p1=abs(p    (i,k  )-p_cup(i,k))
+	    p2=abs(p_cup(i,k+1)-p_cup(i,k))
+
+            c1=(p1+p2)/p2
+	    c2=p1/p2
+
+	    t_cup  (i,k) = c1*t  (i,k) - c2*t_cup(i,k+1)
+            q_cup  (i,k) = c1*q  (i,k) - c2*q_cup(i,k+1)
+
+            u_cup  (i,k) = c1*us (i,1) - c2*u_cup(i,k+1)
+            v_cup  (i,k) = c1*vs (i,1) - c2*v_cup(i,k+1)
+            qes_cup(i,k) = c1*qes(i,k) - c2*qes_cup(i,k+1)
+
+            hes_cup(i,k)=g*z_cup(i,k)+1004.*t_cup(i,k)+2.5e6*qes_cup(i,k)
+            he_cup (i,k)=g*z_cup(i,k)+1004.*t_cup(i,k)+2.5e6*q_cup  (i,k)
+
+	    if(he_cup(i,k).gt.hes_cup(i,k))he_cup(i,k)=hes_cup(i,k)
+
+	    gamma_cup(i,k)=xlv/cp*(xlv/(rv*t_cup(i,k)*t_cup(i,k)))*qes_cup(i,k)
          enddo
 	ELSE
 
-            STOP "cup_env_clev" 
+            STOP "cup_env_clev"
         ENDIF
-        
+
       ENDIF
 !------------------------------------------------
    RETURN
    IF( MAPL_AM_I_ROOT()) then
      DO i=its,itf
-           IF(ierr(i) == 0) then 
+           IF(ierr(i) == 0) then
 	    do k=kts,kte
               write(23,101) i,k,z_cup(i,k),p_cup(i,k),t_cup(i,k),u_cup(i,k),v_cup(i,k),q_cup(i,k),he_cup(i,k)
               write(25,101) i,k,z    (i,k),p    (i,k),t    (i,k),us   (i,k),vs   (i,k),q    (i,k),he    (i,k)
- 
+
               101 format(2i3,7F15.4)
 	    ENDDO
             GOTO 400
@@ -4507,7 +4490,7 @@ ENDIF !- end of section for atmospheric composition
      ENDDO
     ENDIF
  400 continue
- 
+
    END SUBROUTINE cup_env_clev
 !------------------------------------------------------------------------------------
 
@@ -4584,7 +4567,7 @@ ENDIF !- end of section for atmospheric composition
              xff_mid(i,3)=max(0., -(AA1(i)/tau_ecmwf(i))/xk(1))
              xff_mid(i,4)=xf_dicycle(i)
           endif
-	  
+
           !IF( ichoice == 3) xf_dicycle(i) =0. ! No dicycle for congestus
        ENDDO
 
@@ -4877,7 +4860,7 @@ ENDIF !- end of section for atmospheric composition
             do k=kts,start_level(i)!k22(i)
               qc (i,k)=qaver
               qch(i,k)=qc(i,k)
-            
+
             enddo
           endif
         enddo
@@ -4955,7 +4938,7 @@ ENDIF !- end of section for atmospheric composition
                 else
                   aux = 1. * exp(0.03* (t_cup(i,k) - 273.16 + DELT))
                 endif
-        
+
                 cx0 = aux*(c1d(i,k)+c0)*DZ!*zu(i,k) !exp B1a3x2
                 !-v1 -  do not conserve total water:     QRCH+PW (i,k)+QRC(i,k)
                 !.. QRC(i,k)=max(0.,  QC(i,k)- QRCH + cx0*DZ*qrc_crit)/(1.+cx0*DZ)
@@ -5314,8 +5297,8 @@ ENDIF !- end of section for atmospheric composition
 
       character(len=1):: cty
       logical, parameter :: USE_LCL       =.FALSE.
-    ! logical, parameter :: USE_INV_LAYERS=.TRUE. 
-      logical, parameter :: USE_INV_LAYERS=.FALSE. ! P9_P6 
+    ! logical, parameter :: USE_INV_LAYERS=.TRUE.
+      logical, parameter :: USE_INV_LAYERS=.FALSE. ! P9_P6
 
       do i=its,itf
         ierr(i)=0
@@ -5338,7 +5321,7 @@ ENDIF !- end of section for atmospheric composition
 !--- maximum depth (mb) of capping
 !--- inversion (larger cap = no convection)
 !
-     !cap_maxs=150. 
+     !cap_maxs=150.
       cap_maxs= 50. !P9_P6
       do i=its,itf
         cap_max(i)=cap_maxs
@@ -5461,7 +5444,7 @@ loop0:        do k=kts,ktf
          do k=kts,ktf
             frh = min(qo_cup(i,k)/qeso_cup(i,k),1.)
             entr_rate_2d(i,k)=entr_rate*(1.3-frh)*max(min(1.,(qeso_cup(i,max(k,klcl(i)))&
-!                                                             /qeso_cup(i,klcl(i)))**3)   ,0.1) ! 
+!                                                             /qeso_cup(i,klcl(i)))**3)   ,0.1) !
                                                               /qeso_cup(i,klcl(i)))**1.25),0.1) ! P9_P6
          enddo
       enddo
@@ -5801,7 +5784,7 @@ loop0:        do k=kts,ktf
                125     format(1X,i2,5E12.4)
             endif
             dp=100.*(po_cup(i,k)-po_cup(i,k+1))
- 
+
             dellu (i,k) =-(zuo(i,k+1)*(uc (i,k+1)-us(i,k+1) ) -      &
                            zuo(i,k  )*(uc (i,k  )-us(i,k  ) ))*g/dp
 
@@ -6042,11 +6025,11 @@ loop0:        do k=kts,ktf
 IF(USE_TRACER_TRANSP==1) THEN
 
 !-- for debug only
-!if(jl==1) then 
+!if(jl==1) then
 !  se_chem_update(1,:,:) = se_chem(1,:,:)
 !else
 !  se_chem(1,:,:) = se_chem_update(1,:,:)
-!endif   
+!endif
 !do i=its,itf
 !     if(ierr(i) /= 0) cycle
 !      massi=0.
@@ -6112,26 +6095,26 @@ IF(USE_TRACER_TRANSP==1) THEN
          enddo
    enddo
 !
-!-4) determine the vertical transport 
+!-4) determine the vertical transport
 !
 !---a) change per unit mass that a model cloud would modify the environment
    do i=its,itf
         if(ierr(i) /= 0) cycle
-        
+
 	if(USE_FLUX_FORM == 1 .and. alp1 == 0. ) then !- flux form + source/sink terms + time explicit + FCT
-	
-	  if(use_fct == 0 ) then 
+
+	  if(use_fct == 0 ) then
 	    do k=kts,ktop(i)
                 dp=100.*(po_cup(i,k)-po_cup(i,k+1))
                 out_chem(:,i,k) =-(zuo(i,k+1)*(sc_up_chem(:,i,k+1)-se_cup_chem(:,i,k+1) ) -                 &
-                                   zuo(i,k  )*(sc_up_chem(:,i,k  )-se_cup_chem(:,i,k  ) ))*g/dp             
+                                   zuo(i,k  )*(sc_up_chem(:,i,k  )-se_cup_chem(:,i,k  ) ))*g/dp
             enddo
-          
-	  else 
+
+	  else
 
             !-- FCT scheme for the subsidence transport: d(M_env*S_env)/dz
             sub_tend  = 0.
-            trcflx_in = 0. 
+            trcflx_in = 0.
             dtime_max = dtime
             massflx  (i,kts)=0.
 
@@ -6139,25 +6122,25 @@ IF(USE_TRACER_TRANSP==1) THEN
                dp  	       = 100.*(po_cup(i,k)-po_cup(i,k+1))
                trcflx_in (:,k) =-zuo(i,k) *se_cup_chem(:,i,k)  !* xmb(i)
                massflx   (i,k) =-zuo(i,k) 		       !* xmb(i)
-               dtime_max=min(dtime_max,.5*dp) 
+               dtime_max=min(dtime_max,.5*dp)
             enddo
             !--if dtime_max<dtime => needs a loop to update from t to t+dtime (check this!)
             !if( dtime_max < dtime ) stop "dtime_max < dtime in GF scheme"
-         
+
             do ispc=1,mtp
                call fct1d3 (ktop(i),kte,dtime_max,po_cup(i,:),se_chem(ispc,i,:),massflx(i,:),trcflx_in(ispc,:),sub_tend(ispc,:))
             enddo
 
             do k=kts,ktop(i)
               dp=100.*(po_cup(i,k)-po_cup(i,k+1))
-              out_chem(:,i,k) =-(zuo(i,k+1)*(sc_up_chem(:,i,k+1)) - zuo(i,k)*(sc_up_chem(:,i,k)))*g/dp  	
+              out_chem(:,i,k) =-(zuo(i,k+1)*(sc_up_chem(:,i,k+1)) - zuo(i,k)*(sc_up_chem(:,i,k)))*g/dp
 
               !- update with subsidence term from FCT scheme
               out_chem(:,i,k) = out_chem(:,i,k) + sub_tend(:,k)
             enddo
 	  endif
         endif
-        
+
 
        if(USE_FLUX_FORM == 1 .and. alp1 > 0. ) then !- flux form + source/sink terms + time explicit/implicit + upstream
             alp0=1.-alp1
@@ -6167,17 +6150,17 @@ IF(USE_TRACER_TRANSP==1) THEN
               beta1 = dtime*g/dp
 	      bb(k) = 1.+alp1*beta1*zenv(i,k)
 	      cc(k) =   -alp1*beta1*zenv(i,k+1)
-            
-	      ddtr(:,k) = se_chem(:,i,k) - (zuo(i,k+1)*sc_up_chem(:,i,k+1) - zuo(i,k)*sc_up_chem(:,i,k))*beta1 
-             
+
+	      ddtr(:,k) = se_chem(:,i,k) - (zuo(i,k+1)*sc_up_chem(:,i,k+1) - zuo(i,k)*sc_up_chem(:,i,k))*beta1
+
 	      ddtr(:,k) = ddtr(:,k) + alp0*beta1*(-zenv(i,k)*se_chem(:,i,k) +zenv(i,k+1)*se_chem(:,i,k+1))
-	   
+
             enddo
             do ispc = 1, mtp
 		call bidiag (ktop(i),bb (kts:ktop(i)),cc (kts:ktop(i)),ddtr (ispc,kts:ktop(i)))
 	        out_chem(ispc,i,kts:ktop(i))=(ddtr(ispc,kts:ktop(i))-se_chem(ispc,i,kts:ktop(i)))/dtime
-            enddo	    
-	    
+            enddo
+
         endif
        !
 
@@ -6193,7 +6176,7 @@ IF(USE_TRACER_TRANSP==1) THEN
 !            dp=100.*(po_cup(i,k)-po_cup(i,k+1))
 !            massf = massf + se_chem_update(1,i,k)*dp/g
 !        enddo
-!        !if(abs((massf-massi)/(1.e-12+massi))>1.e-6) then 
+!        !if(abs((massf-massi)/(1.e-12+massi))>1.e-6) then
 !          print*,"mass con=>",(massf-massi)/(1.e-12+massi)
 !          !stop "MASS CON"
 !        !endif
@@ -6203,10 +6186,10 @@ IF(USE_TRACER_TRANSP==1) THEN
 !-4) convert back mass fluxes
    do i=its,itf
         if(ierr(i) /= 0) cycle
-            zuo         (i,:) = zuo(i,:)          / (xmb(i) + 1.e-16)                                          
-            up_massentro(i,:) = up_massentro(i,:) / (xmb(i) + 1.e-16)        
-            up_massdetro(i,:) = up_massdetro(i,:) / (xmb(i) + 1.e-16)         
-            zenv        (i,:) = zenv        (i,:) / (xmb(i) + 1.e-16)        
+            zuo         (i,:) = zuo(i,:)          / (xmb(i) + 1.e-16)
+            up_massentro(i,:) = up_massentro(i,:) / (xmb(i) + 1.e-16)
+            up_massdetro(i,:) = up_massdetro(i,:) / (xmb(i) + 1.e-16)
+            zenv        (i,:) = zenv        (i,:) / (xmb(i) + 1.e-16)
    enddo
 !
 !--------------------------------------------------------------------------------------------!
@@ -6455,7 +6438,7 @@ ENDIF !- end of section for atmospheric composition
      integer :: i,k, incr1,incr2,turn
      real :: dz
      logical, parameter :: SMOOTH = .FALSE.
-     integer, parameter :: mass_U_option = 1  
+     integer, parameter :: mass_U_option = 1
      !---
      if(draft == 'deep' ) then
       incr1=1
@@ -6558,7 +6541,7 @@ ENDIF !- end of section for atmospheric composition
            up_massdetr(i,k)=up_massdetro(i,k)
          enddo
 	 IF(present(up_massentru) .and. present(up_massdetru))THEN
-           if(mass_U_option==1) then 
+           if(mass_U_option==1) then
               do k=kts+1,kte
               !--       for weaker mixing
                 up_massentru(i,k-1)=up_massentro(i,k-1)+lambau(i)*up_massdetro(i,k-1)
@@ -6577,8 +6560,8 @@ ENDIF !- end of section for atmospheric composition
 	        up_massentru(i,k-1)=up_massentro(i,k-1)+lambau(i)*up_massdetro(i,k-1)
 	        up_massdetru(i,k-1)=up_massdetro(i,k-1)+lambau(i)*up_massdetro(i,k-1)
 	      enddo
-	   endif	 
-	 ENDIF    
+	   endif
+	 ENDIF
          do k=ktop(i)+1,kte
            cd          (i,k)=0.
            entr_rate_2d(i,k)=0.
@@ -6776,11 +6759,11 @@ ENDIF !- end of section for atmospheric composition
                     ! overshoting (cheque AA0 calculation)
                     ! rainfall is too sensible this parameter
                     ! for now, keep =1.
-     
-     
+
+
      dby =0.0
      hcot=0.0
-     
+
      if(name == 'shallow'.or. name == 'mid')then
          dbythresh=1.0
      endif
@@ -6858,14 +6841,14 @@ ENDIF !- end of section for atmospheric composition
   integer:: itest                ! 5=gamma+beta, 4=gamma, 1=beta
 
   integer:: minzu,maxzul,maxzuh
-  logical, parameter :: do_smooth = .TRUE. 
+  logical, parameter :: do_smooth = .TRUE.
 
   !-------- gama pdf
   real, parameter :: beta_deep=1.25,g_beta_deep=0.8974707
   INTEGER :: k1
   real :: lev_start,g_alpha2,g_a,y1,x1,g_b,a,b,alpha2,csum,zubeg,wgty
   real, dimension(30) :: x_alpha,g_alpha
-  data  (x_alpha(k),k=1,30)/                                    & 
+  data  (x_alpha(k),k=1,30)/                                    &
                 3.699999,3.699999,3.699999,3.699999,            &
                   3.024999,2.559999,2.249999,2.028571,1.862500, &
                   1.733333,1.630000,1.545454,1.475000,1.415385, &
@@ -6927,7 +6910,7 @@ ENDIF !- end of section for atmospheric composition
       do k=kb_adj,min(kte,kt)
          kratio= (po_cup(k)-po_cup(kb_adj))/(po_cup(kt)-po_cup(kb_adj))
          zu(k) = zubeg+FZU*kratio**(alpha2-1.0) * (1.0-kratio)**(beta_deep-1.0)
-        
+
       enddo
       !- normalize ZU
       zu(kts:min(kte,kt+1))= zu(kts:min(kte,kt+1))/ (1.e-12+maxval(zu(kts:min(kte,kt+1))))
@@ -6990,7 +6973,7 @@ ENDIF !- end of section for atmospheric composition
           do k=kt-2,kt-min(maxloc(zu,1),5),-1
              zul(k)=(zul(k+1)+zu(k))*0.5
           enddo
-	  wgty=0.	  
+	  wgty=0.
           do k=kt,kt-min(maxloc(zu,1),5),-1
 	     wgty=wgty+1./(float(min(maxloc(zu,1),5))+1)
 	     zu(k)=zul(k)*(1.-wgty)+ zu(k)*wgty
@@ -7123,9 +7106,9 @@ ENDIF !- end of section for atmospheric composition
           zul(kt)=zu(kt)*0.1
           do k=kt-1,kt-min(maxloc(zu,1),5),-1
              zul(k)=(zul(k+1)+zu(k))*0.5
-          enddo	     
-	  
-	  wgty=0.	  
+          enddo
+
+	  wgty=0.
           do k=kt,kt-min(maxloc(zu,1),5),-1
 	     wgty=wgty+1./(float(min(maxloc(zu,1),5))+1)
 	     zu(k)=zul(k)*(1.-wgty)+ zu(k)*wgty
@@ -7211,7 +7194,7 @@ ENDIF !- end of section for atmospheric composition
 
       !- this alpha constrains the location of the maximun ZU to be at "kb_adj" vertical level
       alpha=1. + (beta-1.0)*(float(kb_adj)/float(kt+1))/(1.0-(float(kb_adj)/float(kt+1)))
-      
+
       do k=kts+1,min(kt+1,ktf)
               kratio= float(k)/float(kt+1)
               zu(k)= kratio**(alpha-1.0) * (1.0-kratio)**(beta-1.0)
@@ -7220,14 +7203,14 @@ ENDIF !- end of section for atmospheric composition
       !-- smooth section
       IF(do_smooth) then
         zul(kts+1)=zu(kts+1)*0.1
-	wgty=0.	  
+	wgty=0.
         do k=kts+2,maxloc(zu,1)
 	   wgty=wgty+1./(float(max(2,maxloc(zu,1)))-1.)
            wgty=0.5
 	   !print*,"zD1=",k,zu(k),zul(k-1),wgty,zul(k-1)*(1.-wgty)+ zu(k)*wgty
 	   zul(k)=zul(k-1)*(1.-wgty)+ zu(k)*wgty
         enddo
-	wgty=0.	  
+	wgty=0.
         do k=kts+1,maxloc(zu,1)
 	   wgty=wgty+1./(float(max(2,maxloc(zu,1)))-1.)
 	   wgty=0.5
@@ -7248,7 +7231,7 @@ ENDIF !- end of section for atmospheric composition
     !- normalize ZU
     zu(kts:min(kte,kt+1))= zu(kts:min(kte,kt+1))/ (1.e-9+maxval(zu(kts:min(kte,kt+1)),1))
   ENDIF
-  
+
  end SUBROUTINE get_zu_zd_pdf
 !------------------------------------------------------------------------------------
 
@@ -7583,7 +7566,7 @@ SUBROUTINE get_inversion_layers(cumulus,ierr,psur,po_cup,to_cup,zo_cup,k_inv_lay
         INTEGER, DIMENSION (its:ite,kts:kte)  :: local_k_inv_layers
         !
         !-initialize k_inv_layers as 1 (non-existent layer)_
-        k_inv_layers= 1 !integer 
+        k_inv_layers= 1 !integer
         dtempdz     = 0.0
 	first_deriv = 0.0
 	sec_deriv   = 0.0
@@ -7624,11 +7607,11 @@ SUBROUTINE get_inversion_layers(cumulus,ierr,psur,po_cup,to_cup,zo_cup,k_inv_lay
          ix=1
          DO kk=kts+ist+2,ktf-ist-2
              if(sec_deriv(kk) < sec_deriv(kk+1) .and. sec_deriv(kk) < sec_deriv(kk-1)) then
-                local_k_inv_layers(i,ix)=kk 
+                local_k_inv_layers(i,ix)=kk
                 ix  =ix+1
              endif
          ENDDO
- 
+
          !- 2nd criteria
          DO k=kts+ist+2,ktf-ist-2
            kk=local_k_inv_layers(i,k)
@@ -7653,7 +7636,7 @@ SUBROUTINE get_inversion_layers(cumulus,ierr,psur,po_cup,to_cup,zo_cup,k_inv_lay
 !k_inv_layers(i,mid)=21
 !cycle
 !----------------
-         IF( trim(cumulus)=='shallow') THEN 
+         IF( trim(cumulus)=='shallow') THEN
 	    !- now find the closest layers of 800 and 550 hPa.
             !- this is for shallow convection k800
             DO k=kts,ktf
@@ -7668,18 +7651,18 @@ SUBROUTINE get_inversion_layers(cumulus,ierr,psur,po_cup,to_cup,zo_cup,k_inv_lay
               !-save k800 in the k_inv_layers array
               k_inv_layers(i,shal)=local_k_inv_layers(i,k800) +extralayer
             endif
-            if(  k_inv_layers(i,shal) <= kts .or. k_inv_layers(i,shal) >= ktf-4) then 
+            if(  k_inv_layers(i,shal) <= kts .or. k_inv_layers(i,shal) >= ktf-4) then
 	     !print*,"SHAL_k_inv_layers=",k_inv_layers(i,shal),ierr(i)
 	     ierr(i)=11
             endif
-         
-         ELSEIF( trim(cumulus)=='mid') THEN 
+
+         ELSEIF( trim(cumulus)=='mid') THEN
 	    !- this is for mid/congestus convection k500
             DO k=kts,ktf
               distance(k)=abs(po_cup(i,local_k_inv_layers(i,k))-(550.-delp))
             ENDDO
             k550=minloc(abs(distance(kts:ktf)),1)
-	    
+
             if( k550 <= kts .or. k550 >= ktf - 4) then
                k_inv_layers(i,mid) = 1
                ierr(i)=8
@@ -7687,7 +7670,7 @@ SUBROUTINE get_inversion_layers(cumulus,ierr,psur,po_cup,to_cup,zo_cup,k_inv_lay
                !-save k550 in the k_inv_layers array
                k_inv_layers(i,mid )=local_k_inv_layers(i,k550) +extralayer
             endif
-            if(  k_inv_layers(i,mid) <= kts .or. k_inv_layers(i,mid) >= ktf-4) then 
+            if(  k_inv_layers(i,mid) <= kts .or. k_inv_layers(i,mid) >= ktf-4) then
 	     !print*,"MID_k_inv_layers=",k_inv_layers(i,MID),ierr(i)
 	     ierr(i)=12
             endif
@@ -7695,13 +7678,13 @@ SUBROUTINE get_inversion_layers(cumulus,ierr,psur,po_cup,to_cup,zo_cup,k_inv_lay
 	     k_inv_layers(i,:)=1
 	     ierr(i)=88
 	 ENDIF
-	    
+
          !-set the rest to undef (not in use)
          !where(k_inv_layers(i,:) =/ 1) k_inv_layers(i,:)=1
-	 
+
 	 !k_inv_layers(i,4:kte)= 1
          !k_inv_layers(i,kts  )= 1
-	 
+
 	 !~ write(13,100) k_inv_layers(i,1:maxloc(k_inv_layers(i,:),1))
          !~ write(13,101) po_cup(i,k_inv_layers(i,1:7))
          !~ write(14,102) 'shall',k_inv_layers(i,shal),po_cup(i,k_inv_layers(i,shal))
@@ -8334,7 +8317,7 @@ SUBROUTINE get_inversion_layers(cumulus,ierr,psur,po_cup,to_cup,zo_cup,k_inv_lay
 !
       DO i=its,itf
         IF(ierr(i) /= 0) cycle
-	
+
         do k=k22(i),klcl(i)
            hcot(i,k) = HKBO(I) ! assumed no entraiment between these layers
            !~ if(hcot(i,k) < heso_cup(i,k) )then
@@ -8523,7 +8506,7 @@ loop2:        DO while (hcot(i,kbcon(i)) < HESO_cup(i,kbcon(i)))
         !-- initialize arrays to zero.
         vvel1d(i  ) = 0.0
         vvel2d(i,:) = 0.0
-      
+
         if(ierr(i) /= 0) cycle
         vvel2d(i,kts:kbcon(i))= max(1.,zws(i)**2)
 
@@ -8566,19 +8549,19 @@ loop0:  do k= kbcon(i),ktop(i)
 	      vs =  vs + vvel2d(i,k1)
 	   enddo
 	   vvel2d(i,k) = vs/(1.e-16+float(nvs))
-         enddo 
-       enddo 
+         enddo
+       enddo
      endif
-     
+
      !-- convert to vertical velocity
      do i=its,itf
          if(ierr(i) /= 0)cycle
          vvel2d(i,:)= sqrt(vvel2d(i,:))
-         
+
 	 !-- sanity check
          where(vvel2d(i,:) < 1. ) vvel2d(i,:)=1.
          where(vvel2d(i,:) > 20.) vvel2d(i,:)=20.
-	 
+
 	 !-- get the column average vert velocity
 	 do k= kbcon(i),ktop(i)
             dz=z_cup(i,k+1)-z_cup(i,k)
@@ -8849,7 +8832,7 @@ loop0:  do k= kbcon(i),ktop(i)
         mconv
      real,    dimension (its:ite)                                      &
         ,intent (in   )                   ::                           &
-        aa0 
+        aa0
      real,    dimension (its:ite)                                      &
         ,intent (in   )                   ::                           &
         mbdt
@@ -9339,12 +9322,12 @@ ENDIF
 
   ! --- massflx and trflx_in  must be provided independently to allow the
   ! --- algorithm to generate an auxiliary low-order (diffusive) tracer flux
-  ! --- as a stepping stone toward the final product trflx_out.  
+  ! --- as a stepping stone toward the final product trflx_out.
 
    implicit none
    integer,intent(IN) :: n,ktop                        ! number of grid cells
    real   ,intent(IN) :: dt                            ! transport time step
-   real   ,intent(IN) :: z(n+0)                        ! location of cell interfaces 
+   real   ,intent(IN) :: z(n+0)                        ! location of cell interfaces
    real   ,intent(IN) :: tracr(n)                      ! the transported variable
    real   ,intent(IN) :: massflx  (n+0)                ! mass flux across interfaces
    real   ,intent(IN) :: trflx_in (n+0)                ! original tracer flux
@@ -9355,18 +9338,18 @@ ENDIF
         soln_hi(n),totlin(n),totlout(n),soln_lo(n),clipin(n),clipout(n),arg
    real,parameter :: epsil=1.e-22           ! prevent division by zero
    real,parameter :: damp=1.                ! damper of antidff flux (1=no damping)
-   
+
    NaN(arg) = .not. (arg.ge.0. .or. arg.le.0.)        ! NaN detector
    soln_lo(:)=0.
    antifx (:)=0.
    clipout(:)=0.
-   
+
    do k=1,ktop
      dtovdz(k)=.01*dt/abs(z(k+1)-z(k))                ! time step / grid spacing
      if (z(k).eq.z(k+1)) error=.true.
    end do
    if (vrbos .or. error) print '(a/(8es10.3))','(fct1d) dtovdz =',dtovdz(1:ktop)
-   
+
    do k=2,ktop
      if (massflx(k).gt.0.) then
        flx_lo(k)=massflx(k)*tracr(k-1)              ! low-order flux, upstream
@@ -9396,7 +9379,7 @@ ENDIF
    if (massflx(ktop+1).gt.0.) flx_lo(ktop+1)=flx_lo(ktop+1)*clipout(ktop)
 
 ! --- a positive-definite low-order (diffusive) solution can now be  constructed
-  
+
    do k=1,ktop
      soln_lo  (k)=tracr(k)-(flx_lo(k+1)-flx_lo(k))*dtovdz(k)        ! low-ord solutn
      trflx_out(k)=-g*(flx_lo(k+1)-flx_lo(k))*dtovdz(k)/dt
@@ -9405,7 +9388,7 @@ ENDIF
    return
    soln_hi(:)=0.
    clipin (:)=0.
-   
+
    do k=1,ktop
      km1=max(1,k-1)
      kp1=min(n,k+1)
@@ -9490,7 +9473,7 @@ ENDIF
      end do
      if (error) stop '(fct1d error)'
    end if
-       
+
    return
 end subroutine fct1d3
 !---------------------------------------------------------------------------------------------------
@@ -9505,7 +9488,7 @@ end subroutine fct1d3
    real, dimension(m) :: q
    integer :: k
    real :: p
-   
+
    c(m)=0.
    q(1)=-c(1)/b(1)
    f(1)= f(1)/b(1)
@@ -9517,7 +9500,7 @@ end subroutine fct1d3
    do k=m-1,1,-1
     f(k) = f(k) +q(k)*f(k+1)
    enddo
-  
+
   END SUBROUTINE tridiag
 !---------------------------------------------------------------------------------------------------
   SUBROUTINE bidiag (m,b,c,f)
@@ -9531,7 +9514,7 @@ end subroutine fct1d3
    real, dimension(m) :: q
    integer :: k
    real :: p
-   
+
    c(m)=0.
    q(1)=-c(1)/b(1)
    f(1)= f(1)/b(1)
@@ -9543,7 +9526,7 @@ end subroutine fct1d3
    do k=m-1,1,-1
     f(k) = f(k) +q(k)*f(k+1)
    enddo
-  
+
   END SUBROUTINE bidiag
 !---------------------------------------------------------------------------------------------------
   SUBROUTINE cup_env_clev_chem(mtp,se_chem,se_cup_chem,ierr,itf,ktf,its,ite, kts,kte)
@@ -9592,51 +9575,51 @@ end subroutine fct1d3
                       ,itf,ktf,its,ite, kts,kte)
 
      implicit none
-     character *(*)            , intent (in) :: cumulus        
+     character *(*)            , intent (in) :: cumulus
      integer                    ,intent (in) :: itf,ktf,its,ite,kts,kte
      integer, dimension(its:ite),intent (in) :: kbcon,ktop,k22,klcl,ierr
      real,    dimension(its:ite),intent (in) :: xland,pwavo,pwevo,edto,pre,xmb
-     real,    dimension(its:ite,kts:kte),intent (in)  :: pwo,pwdo,t_cup,tempco 
+     real,    dimension(its:ite,kts:kte),intent (in)  :: pwo,pwdo,t_cup,tempco
      real,    dimension(its:ite,kts:kte),intent (out) :: prec_flx,evap_flx !-- units kg[water]/m2/s
-    
+
     !-- locals
      integer :: i,k
      prec_flx = 0.0
      evap_flx = 0.0
      if(trim(cumulus) == 'shallow') return
-     
+
      DO i=its,itf
          if (ierr(i)  /= 0) cycle
 
          do k=ktop(i),kts,-1
-           
+
 	   !--- precipitation flux (at 'cup' levels), units: kg[water]/m2/s
 	   prec_flx(i,k) = prec_flx(i,k+1) + xmb(i)*(pwo(i,k) + edto(i)*pwdo(i,k))
 	   prec_flx(i,k) = max(0.,prec_flx(i,k))
-	   
+
 	   !--- evaporation flux (at 'cup' levels), units: kg[water]/m2/s
-	   evap_flx(i,k) = evap_flx(i,k+1) - xmb(i)*edto(i)*pwdo(i,k) 
+	   evap_flx(i,k) = evap_flx(i,k+1) - xmb(i)*edto(i)*pwdo(i,k)
 	   evap_flx(i,k) = max(0.,evap_flx(i,k))
-	   
-	   
+
+
 	   !
 	   !--for future use (rain and snow precipitation fluxes)
 	   !if	 (tempco(i,k) <= T_ice) then
-           !   p_liq_ice(k) = 0.      ! only solid 
+           !   p_liq_ice(k) = 0.      ! only solid
            !elseif(  tempco(i,k) > T_ice .and. tempco(i,k) < T_0) then
            !   p_liq_ice(k) =  ((tempco(i,k)-T_ice)/(T_0-T_ice))**2
            !else
-           !   p_liq_ice(k) = 1.      ! only liquid 
+           !   p_liq_ice(k) = 1.      ! only liquid
            !endif
 	   !prec_flx_rain(k) = prec_flx(i,k)*(1.-p_liq_ice(k))
 	   !prec_flx_snow(k) = prec_flx(i,k)*    p_liq_ice(k)
          enddo
-	 
-	 !if(prec_flx   (i,kts) .ne. pre(i)) then 
+
+	 !if(prec_flx   (i,kts) .ne. pre(i)) then
 	 !print*,"error=",100.*(prec_flx   (i,kts) - pre(i))/(1.e-16+pre(i)),pre(i),prec_flx   (i,kts)
-	 !STOP 'problem with water balance' 
+	 !STOP 'problem with water balance'
 	 !endif
-     ENDDO	   
+     ENDDO
    END   SUBROUTINE get_precip_fluxes
 
 END MODULE ConvPar_GF_GEOS5


### PR DESCRIPTION
This PR has changes to allow the GNU compiler to build the `feature/sdrabenh/merge_v10.25.0_MSTRF` code from @sdrabenh and @wmputman 

Most of it is pretty simple Fortran Standards issues that GNU trips on. However, a more substantial change was needed in `ConvPar_GF_GEOS5.F90` as that code has a *different* `T_ice` value than provided by `ConvPar_GF_Shared.F90`. So to keep things zero-diff, we must define a local constant, `T_ice_local`.

NOTE: Things look a lot more different only because my editor cleans up whitespace. Please hide whitespace when looking at the file changes.

NOTE2: The AGCM GridComp is a *substantive* code change that involves white space but it disappears when you compare without whitespace:

```diff
@@ -1064,7 +1064,7 @@ contains

      call MAPL_TerminateImport    ( GC,                                                     &
           SHORT_NAME = (/'DUDT  ','DVDT  ','DWDT  ','DTDT  ','DPEDT ','DQVANA','DQLANA',    &
-                         'DQIANA','DQRANA','DQSANA','DQGANA','DOXANA','PHIS','VARFLT'/),  &
+                         'DQIANA','DQRANA','DQSANA','DQGANA','DOXANA','PHIS  ','VARFLT'/),  &
           CHILD      = SDYN,                                                                &
           RC=STATUS  )
      VERIFY_(STATUS)
```