### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--- These lines are comments. You can delete or ignore them -->
+<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
+<!---       "Testing" or other sections. -->
+
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- This project primarily accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please add the issue number below or delete the Closes line if this is not relevant -->
+
+Closes #
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? -->
+<!--- Put an `x` in all the boxes that apply so that it looks like [x] -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Trivial change (affects only documentation or cleanup)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+<!--- For the required labels: -->
+<!---   0 diff trivial: this change is to documentation or obviously does not affect the results -->
+<!---   0 diff structural: this change only moves code around -->
+<!---   0 diff: this change is to code and has no impact on the results -->
+<!---   non 0-diff: this change affects the results -->
+- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
+- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)


### PR DESCRIPTION
This PR adds a PR template to GEOSgcm_GridComp.

This is done against `main` because GitHub only sees PR templates when on `main`. We'll need to pull this up to develop after merging.