### PR TITLE
Added -DAQUA_PLANET for compiling Surface GridComp

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
@@ -9,7 +9,11 @@ set (alldirs
 
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_SurfaceGridComp.F90)
 
-  add_compile_definitions(AQUA_PLANET)
+  option(AQUAPLANET "Build for Aquaplanet simulation" OFF)
+  if (AQUAPLANET)
+    add_compile_definitions(AQUA_PLANET)
+  endif()
+
   esma_add_library (${this}
     SRCS GEOS_SurfaceGridComp.F90
     SUBCOMPONENTS ${alldirs}

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
@@ -9,6 +9,7 @@ set (alldirs
 
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_SurfaceGridComp.F90)
 
+  add_compile_definitions(AQUA_PLANET)
   esma_add_library (${this}
     SRCS GEOS_SurfaceGridComp.F90
     SUBCOMPONENTS ${alldirs}

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
@@ -10,15 +10,14 @@ set (alldirs
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_SurfaceGridComp.F90)
 
   option(AQUAPLANET "Build for Aquaplanet simulation" OFF)
-  if (AQUAPLANET)
-    add_compile_definitions(AQUA_PLANET)
-  endif()
 
   esma_add_library (${this}
     SRCS GEOS_SurfaceGridComp.F90
     SUBCOMPONENTS ${alldirs}
     SUBDIRS Shared
     DEPENDENCIES GEOS_SurfaceShared MAPL GMAO_mpeu esmf)
+
+  target_compile_definitions (${this} PRIVATE $<$<BOOL:${AQUAPLANET}>:AQUA_PLANET>)
 
 else ()
 


### PR DESCRIPTION
With this preprocessor macro, we completely ignore Lake, LandIce and Land GridComps. Results are zero-diff to the case where codepath includes these components.