### PR TITLE
Allow for option tolerance for SSTs and seaice fractions

### DIFF
--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
@@ -587,7 +587,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
        call MAPL_GetResource ( MAPL, STRICT_ICE_FRACTION, Label="STRICT_ICE_FRACTION:", DEFAULT=.FALSE., __RC__)
        if (STRICT_ICE_FRACTION) then
           if (any(FR < 0.0) .or. any(FR > 1.0)) then
-             _ASSERT(.FALSE.,'Error in fraci file. Negative or larger-than-one fraction found')
+             _FAIL('Error in fraci file. Negative or larger-than-one fraction found')
           endif
        else
           call MAPL_GetResource ( MAPL, ICE_FRACTION_TOLERANCE, Label="ICE_FRACTION_TOLERANCE:", DEFAULT=1.0e-2, __RC__)
@@ -610,8 +610,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
            f=FRT(I,J)
            if (f==MAPL_UNDEF) cycle
            if ((f < 0.0) .or. (f > 1.0)) then
-              print *, 'Error in fraci file. Negative or larger-than-one fraction found'
-              _ASSERT(.FALSE.,'needs informative message')
+              _FAIL('Error in fraci file. Negative or larger-than-one fraction found')
            end if
         end do
      end do

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
@@ -588,14 +588,24 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 
        call MAPL_GetResource ( MAPL, STRICT_ICE_FRACTION, Label="STRICT_ICE_FRACTION:", DEFAULT=.TRUE., __RC__)
        if (STRICT_ICE_FRACTION) then
-          if (any(FR < 0.0) .or. any(FR > 1.0)) then
-             _FAIL('Error in fraci file. Negative or larger-than-one fraction found')
+          if (any(FR < 0.0)) then
+             _FAIL('Error in fraci file. Negative fraction found')
+          endif
+          if (any(FR > 1.0)) then
+             _FAIL('Error in fraci file. Fraction larger than one found')
           endif
        else
           call MAPL_GetResource ( MAPL, ICE_FRACTION_TOLERANCE, Label="ICE_FRACTION_TOLERANCE:", DEFAULT=1.0e-2, __RC__)
-          ! Now we can use a tolerance to allow the code to run with ice fraction slight higher than 1.0
-          where (FR < (0.0-ICE_FRACTION_TOLERANCE)) FR = 0.0
-          where (FR > (1.0+ICE_FRACTION_TOLERANCE)) FR = 1.0
+          ! First we look to see if we fail even with a tolerance
+          if (any (FR < (0.0 - ICE_FRACTION_TOLERANCE)) ) then
+             _FAIL('Error in fraci file. Negative fraction found with tolerance allowed')
+          end if
+          if (any (FR > (1.0 + ICE_FRACTION_TOLERANCE)) ) then
+             _FAIL('Error in fraci file. Fraction larger than one found with tolerance allowed')
+          end if
+          ! Now we can use a tolerance to allow the code to run with ice fraction with a tolerance
+          where ( ( FR < 0.0 ) .and. ( FR > (0.0 - ICE_FRACTION_TOLERANCE) ) ) FR = 0.0
+          where ( ( FR > 1.0 ) .and. ( FR < (1.0 + ICE_FRACTION_TOLERANCE) ) ) FR = 1.0
        end if
 
      end if

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
@@ -596,8 +596,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
           _ASSERT(all(FR > (0.0 - ICE_FRACTION_TOLERANCE)), 'Error in fraci file. Negative fraction found with tolerance allowed')
           _ASSERT(all(FR < (1.0 + ICE_FRACTION_TOLERANCE)), 'Error in fraci file. Fraction larger than one found with tolerance allowed')
           ! If we get past those, we can just force FR to be in the range [0,1]
-          FR = max(FR, 0.0)
-          FR = min(FR, 1.0)
+          FR = max(0.0, min(1.0, FR))
        end if
 
      end if

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
@@ -586,7 +586,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
          call MAPL_ReadForcing(MAPL,'FRT',DataFrtFile, CURRENTTIME, FR, INIT_ONLY=FCST, __RC__)
        end if
 
-       call MAPL_GetResource ( MAPL, STRICT_ICE_FRACTION, Label="STRICT_ICE_FRACTION:", DEFAULT=.FALSE., __RC__)
+       call MAPL_GetResource ( MAPL, STRICT_ICE_FRACTION, Label="STRICT_ICE_FRACTION:", DEFAULT=.TRUE., __RC__)
        if (STRICT_ICE_FRACTION) then
           if (any(FR < 0.0) .or. any(FR > 1.0)) then
              _FAIL('Error in fraci file. Negative or larger-than-one fraction found')

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
@@ -448,6 +448,8 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
    real, pointer :: DATA_ice(:,:) => null()
 ! above were for CICE Thermo
 
+   logical :: STRICT_ICE_FRACTION
+   real :: ICE_FRACTION_TOLERANCE
 
 !  Begin...
 !----------

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
@@ -588,24 +588,16 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 
        call MAPL_GetResource ( MAPL, STRICT_ICE_FRACTION, Label="STRICT_ICE_FRACTION:", DEFAULT=.TRUE., __RC__)
        if (STRICT_ICE_FRACTION) then
-          if (any(FR < 0.0)) then
-             _FAIL('Error in fraci file. Negative fraction found')
-          endif
-          if (any(FR > 1.0)) then
-             _FAIL('Error in fraci file. Fraction larger than one found')
-          endif
+          _ASSERT(all(FR >= 0.0), 'Error in fraci file. Negative fraction found')
+          _ASSERT(all(FR <= 1.0), 'Error in fraci file. Fraction larger than one found')
        else
           call MAPL_GetResource ( MAPL, ICE_FRACTION_TOLERANCE, Label="ICE_FRACTION_TOLERANCE:", DEFAULT=1.0e-2, __RC__)
           ! First we look to see if we fail even with a tolerance
-          if (any (FR < (0.0 - ICE_FRACTION_TOLERANCE)) ) then
-             _FAIL('Error in fraci file. Negative fraction found with tolerance allowed')
-          end if
-          if (any (FR > (1.0 + ICE_FRACTION_TOLERANCE)) ) then
-             _FAIL('Error in fraci file. Fraction larger than one found with tolerance allowed')
-          end if
-          ! Now we can use a tolerance to allow the code to run with ice fraction with a tolerance
-          where ( ( FR < 0.0 ) .and. ( FR > (0.0 - ICE_FRACTION_TOLERANCE) ) ) FR = 0.0
-          where ( ( FR > 1.0 ) .and. ( FR < (1.0 + ICE_FRACTION_TOLERANCE) ) ) FR = 1.0
+          _ASSERT(all(FR > (0.0 - ICE_FRACTION_TOLERANCE)), 'Error in fraci file. Negative fraction found with tolerance allowed')
+          _ASSERT(all(FR < (1.0 + ICE_FRACTION_TOLERANCE)), 'Error in fraci file. Fraction larger than one found with tolerance allowed')
+          ! If we get past those, we can just force FR to be in the range [0,1]
+          FR = max(FR, 0.0)
+          FR = min(FR, 1.0)
        end if
 
      end if


### PR DESCRIPTION
Runs by @acollow using the CERES SSTs and ice fractions were triggering the protections against FR being less-than-zero or more-than-one.

Further tests confirmed this and by using wide prints it was found that the files seem to have values juuuuust bigger than one:
```
$ rg fracice allieSST-2023Sep18-1day-c90-OPSEmiss/1day.prints.precision.out
2205:[45] FRACICE:   0.000000000000E+00  1.000000119209E+00
2223:[48] FRACICE:   7.207512855530E-01  1.000000238419E+00
2224:[50] FRACICE:   2.898840308189E-01  1.000000238419E+00
2225:[51] FRACICE:   7.837977409363E-01  1.000000238419E+00
2226:[52] FRACICE:   4.546182751656E-01  1.000000119209E+00
2227:[53] FRACICE:   8.661046028137E-01  1.000000238419E+00
2239:[42] FRACICE:   0.000000000000E+00  1.000000119209E+00
```
My guess is these are due to how the files were made/processed values like this snuck in. The "right" thing to do is reprocess the files (in my opinion), but that is a lot of work and if someone has used them, well, we'd change the answers perhaps.

So, in consultation with @sanAkel, this PR adds the ability to "loosen" the restrictions on ice fraction. A new setting, `STRICT_ICE_FRACTION` is added which defaults to `.TRUE.` which mirrors the current handling. If you are above 1 or below 0, error out.

But, if you set that to `.FALSE.` then it allows for tolerance, `ICE_FRACTION_TOLERANCE` which in this PR is defaulted to 0.01. Then any values the code sees from 0.0-TOL to 0.0 are set to 0.0, and anything from 1.0 to 1.0+TOL are set to 1.0.

Note that unless you trigger this bug, this is zero-diff.