### PR TITLE
added support for CICE6 thermo state rewind for replay

### DIFF
--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_cmake/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_cmake/CMakeLists.txt
@@ -106,6 +106,7 @@ list( APPEND CICE6_SRCS
    cicecore/drivers/mapl/geos/ice_import_export.F90
    cicecore/drivers/mapl/geos/ice_shr_methods.F90
    cicecore/drivers/mapl/geos/ice_prescribed_mod.F90
+   cicecore/drivers/mapl/geos/ice_record_mod.F90
 )
 
 


### PR DESCRIPTION
This PR adds a customized entry point method to support restoring CICE6 state variables such that they can be reset before ```corrector``` step starts. The reason for saving and restoring CICE6 states is that ```predictor``` step updates these states via callbacks even though the ```seaice_gridcomp``` is not running.

This PR also fixed a bug in  ```Record``` method which doesn't handle dumping MAPL states properly.

This PR is zero diff and it depends on https://github.com/GEOS-ESM/GEOSgcm/pull/702