### PR TITLE
add ocean version to tile file header info

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_shared.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_shared.py
@@ -50,7 +50,7 @@ cd geometry/{GRIDNAME}/
 if( {TRIPOL_OCEAN} == True ) then
 cat > sedfile << EOF
 s/CF{NC}x6C/PE{nc}x{nc6}-CF/g
-s/{OCEAN_VERSION}{DATENAME}{IMO}x{POLENAME}{JMO}-Pfafstetter/PE{imo}x{jmo}-{DATENAME}/g
+s/{OCEAN_VERSION}{DATENAME}{IMO}x{POLENAME}{JMO}-Pfafstetter/PE{imo}x{jmo}-{OCEAN_VERSION}/g
 EOF
 sed -f sedfile       {GRIDNAME}{RS}.til > tile.file
 /bin/mv -f tile.file {GRIDNAME}{RS}.til


### PR DESCRIPTION
In one of the previous merges, PR #695, we also changed the tile header information to update the ocean grid name. 
To minimize confusion and help people better understand tile files and what they see in boundary conditions, we are adding an ocean version descriptor to coupled tile file header info.  This tile header change is not a bug; users can run experiments and use these new sets of boundary conditions by adjusting the `AGCM.rc` file; this PR is to make it cleaner and easier to understand; with this change, it is easier for `MAPL` and `AGCM.rc` to recognize coupled grid based on tile header information.  

_**In legacy, how it used to be: (MOM6/CF0090x6C_TM0540xTM0458/CF0090x6C_TM0540xTM0458-Pfafstetter.til)**_

  841477  291284  43200  21600
     2
 PE90x540-CF
    90
    540
 **PE540x458-TM**
    540
    458

_**Now on develop (Nov 2023): 
( NL3/geometry/CF0090x6C_M6TP0540x0458/CF0090x6C_M6TP0540x0458-Pfafstetter.til )**_

  841477  291284  43200  21600
     2
 PE90x540-CF
    90
    540
 **PE540x458-**
    540
    458

_**With this PR :**_

  841477  291284  43200  21600
     2
 PE90x540-CF
    90
    540
 **PE540x458-M6TP**
    540
    458

Changes for this PR are zero diff trivial since all changes are within the boundary conditions package (we are just adding info to the header of the coupled tile file as seen in the example above)

Boundary conditions in `bcs_shared` area created with these new ocean names will be updated to match information package will produce in tile file.  @mathomp4 @gmao-rreichle 
