### PR TITLE
bugfix in boundary conditions for coupled T3MOM6 option

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_questionary.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_questionary.py
@@ -312,7 +312,7 @@ def ask_questions(default_grid="Cubed-Sphere"):
                  "T3     --  Tripolar (MOM5-Tripolar-Ocean:   $720x410$ )", \
                  "T4     --  Tripolar (MOM5-Tripolar-Ocean:  $1440x1080$)", \
                  "T1MOM6 --  Tripolar (MOM6-Tripolar-Ocean:    $72x36$  )", \
-                 "T3MOM6 --  Tripolar (MOM6-Tripolar-Ocean:   $580x458$ )", \
+                 "T3MOM6 --  Tripolar (MOM6-Tripolar-Ocean:   $540x458$ )", \
                  "T4MOM6 --  Tripolar (MOM6-Tripolar-Ocean:  $1440x1080$)", \
                  "CS     --  Cubed-Sphere Ocean  (Cubed-Sphere Data-Ocean)"],
             "when": lambda x:  "Stretched_CS" == x['grid_type'] or "Cubed-Sphere" == x['grid_type'],


### PR DESCRIPTION
Boundary conditions package for option `T3MOM6` should use input files `MOM6/540x458`  but due to typo we were trying to use `MOM6/580x458`  which produce code to fail since i's and j's information are picked from that line. 
Somehow during testing this was missed and this is a bug fix. 

This PR is zero diff for AGCM. 

This code is run with boundary conditions package run, so its bug fix for boundary conditions package for MOM6 grid option T3MOM6 in package.  

@yvikhlya @sanAkel @gmao-rreichle 