### PR TITLE
Added connectivity for a few fields from MOIST to CHEM

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
@@ -1212,7 +1212,8 @@ contains
                          'REV_LS  ',  'REV_AN  ', 'REV_CN  ', 'TPREC   ', &
                          'Q       ',  'DQDT    ', 'DQRL    ', 'DQRC    ', &
                          'CNV_MFC ',  'CNV_MFD ', 'CNV_CVW ', 'CNV_FRC ', &
-                         'LFR_GCC ',  'RH2     ', 'CN_PRCP ' /),          &
+                         'LFR_GCC ',  'RH2     ', 'CN_PRCP ',             &
+                         'BYNCY   ',  'CAPE    ', 'INHB    ' /),          &
         DST_ID      = CHEM,                                               &
         SRC_ID      = MOIST,                                              &
                                                        RC=STATUS  )


### PR DESCRIPTION
Added connectivity, from MOIST to CHEM, for CAPE, BYNCY and INHB, for use in lightning-related work.
This is zero-diff.