### PR TITLE
Enable STDC ifdef for zip.c for Spack builds

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CMakeLists.txt
@@ -33,6 +33,9 @@ if (Baselibs_FOUND)
 else ()
   find_package(ZLIB)
   target_link_libraries(${this} PRIVATE ZLIB::zlib)
+  # Spack testing shows we need stdlib.h, so this ifdef will
+  # enable it in zip.c
+  target_compile_definitions(${this} PRIVATE STDC)
 endif ()
 
 ecbuild_add_executable (TARGET CombineRasters.x SOURCES CombineRasters.F90 LIBS MAPL ${this})


### PR DESCRIPTION
This is a "safe" fix for #887 in that in non-Baselibs builds, we enable the `STDC` macro which enables code in zip.c:

https://github.com/GEOS-ESM/GEOSgcm_GridComp/blob/d1830cd96e220a19f7d906ba671165c90063a07a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/zip.c#L3-L9

so that Spack can find stdlib.h.

As this does not affect Baselibs builds, this is trivially zero-diff.