### PR TITLE
fix for CatchCN CLM4.5 fail on SLES15 GNU

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CNFireMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CNFireMod.F90
@@ -296,7 +296,7 @@ subroutine CNFireArea (num_soilc, filter_soilc, num_soilp, filter_soilp)
 data     fire_m_fac    /  SHR_CONST_PI, SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI/
 
 ! only allow fires in very dry conditions in PFTs 4 and 6 (jkolassa 08/2020)
-! note on 02/2014, value for fire_m_fac was changed from 10.e15 to 10.e5 due fail in line for fire_m_tmp calculation on SLES15 GNU.
+! 02/2024: changed value for fire_m_fac(4,6) from 10.e15 to 10.e5 to avoid floating point exception in fire_m_tmp calculation with GNU on NCCS/SLES15.
 fire_m_fac(4) = 10.e5 
 fire_m_fac(6) = 10.e5 
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CNFireMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CNFireMod.F90
@@ -695,8 +695,16 @@ fire_m_fac(6) = 10.e15
               fire_m_tmp = exp(-fire_m_fac(ivt(p))*(m/0.69_r8)**2)*(1.0_r8 - max(0._r8, &
                       min(1._r8,(forc_rh(g)-30._r8)/(80._r8-30._r8))))*  &
                       min(1._r8,exp(SHR_CONST_PI*(forc_t(g)-SHR_CONST_TKFRZ)/10._r8))
+              print*,'Biljana fire_m_tmp 1',fire_m_tmp
+              print*,'Biljana fire_m_fac 1',fire_m_fac
+              print*,'Biljana fire_m_fac(4) 1',fire_m_fac(4)
+              print*,'Biljana fire_m_fac(6) 1',fire_m_fac(6)
               fire_m = fire_m + (fire_m_tmp*wtcol(p))
            end do
+              print*,'Biljana fire_m_tmp 2',fire_m_tmp
+              print*,'Biljana fire_m_fac 2',fire_m_fac
+              print*,'Biljana fire_m_fac(4) 2',fire_m_fac(4)
+              print*,'Biljana fire_m_fac(6) 2',fire_m_fac(6)
            lh       = 0.0035_r8*6.8_r8*hdmlf**(0.43_r8)/30._r8/24._r8
            fs       = 1._r8-(0.01_r8+0.98_r8*exp(-0.025_r8*hdmlf))
 !          ig       = (lh+forc_lnfm(g)/24/(5.16_r8+2.16_r8*cos(3._r8*grc%latdeg(g)))*0.25_r8)*(1._r8-fs)*(1._r8-cropf_col(c))                         ! There is a bug here. The input of "cos" must be in radians!! fzeng, 2 Aug 2019              

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CNFireMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CNFireMod.F90
@@ -296,8 +296,9 @@ subroutine CNFireArea (num_soilc, filter_soilc, num_soilp, filter_soilp)
 data     fire_m_fac    /  SHR_CONST_PI, SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI/
 
 ! only allow fires in very dry conditions in PFTs 4 and 6 (jkolassa 08/2020)
-fire_m_fac(4) = 10.e5 ! 10.e15
-fire_m_fac(6) = 10.e5 ! 10.e15
+! note on 02/2014, value for fire_m_fac was changed from 10.e15 to 10.e5 due fail in line for fire_m_tmp calculation on SLES15 GNU.
+fire_m_fac(4) = 10.e5 
+fire_m_fac(6) = 10.e5 
 
 ! assign local pointers to derived type members (pft-level)
   wtcol              =>pft%wtcol
@@ -695,16 +696,8 @@ fire_m_fac(6) = 10.e5 ! 10.e15
               fire_m_tmp = exp(-fire_m_fac(ivt(p))*(m/0.69_r8)**2)*(1.0_r8 - max(0._r8, &
                       min(1._r8,(forc_rh(g)-30._r8)/(80._r8-30._r8))))*  &
                       min(1._r8,exp(SHR_CONST_PI*(forc_t(g)-SHR_CONST_TKFRZ)/10._r8))
-              print*,'Biljana fire_m_tmp 1',fire_m_tmp
-              print*,'Biljana fire_m_fac 1',fire_m_fac
-              print*,'Biljana fire_m_fac(4) 1',fire_m_fac(4)
-              print*,'Biljana fire_m_fac(6) 1',fire_m_fac(6)
               fire_m = fire_m + (fire_m_tmp*wtcol(p))
            end do
-              print*,'Biljana fire_m_tmp 2',fire_m_tmp
-              print*,'Biljana fire_m_fac 2',fire_m_fac
-              print*,'Biljana fire_m_fac(4) 2',fire_m_fac(4)
-              print*,'Biljana fire_m_fac(6) 2',fire_m_fac(6)
            lh       = 0.0035_r8*6.8_r8*hdmlf**(0.43_r8)/30._r8/24._r8
            fs       = 1._r8-(0.01_r8+0.98_r8*exp(-0.025_r8*hdmlf))
 !          ig       = (lh+forc_lnfm(g)/24/(5.16_r8+2.16_r8*cos(3._r8*grc%latdeg(g)))*0.25_r8)*(1._r8-fs)*(1._r8-cropf_col(c))                         ! There is a bug here. The input of "cos" must be in radians!! fzeng, 2 Aug 2019              

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CNFireMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CNFireMod.F90
@@ -296,8 +296,8 @@ subroutine CNFireArea (num_soilc, filter_soilc, num_soilp, filter_soilp)
 data     fire_m_fac    /  SHR_CONST_PI, SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI,SHR_CONST_PI/
 
 ! only allow fires in very dry conditions in PFTs 4 and 6 (jkolassa 08/2020)
-fire_m_fac(4) = 10.e15
-fire_m_fac(6) = 10.e15
+fire_m_fac(4) = 10.e5 ! 10.e15
+fire_m_fac(6) = 10.e5 ! 10.e15
 
 ! assign local pointers to derived type members (pft-level)
   wtcol              =>pft%wtcol


### PR DESCRIPTION
During SLES15 testing we got CatchCN clm 4.5 model run fail due to floating-point exception. 
Issue happens during specific calculation where exponent is too large. 

Error is in this calculation:
https://github.com/GEOS-ESM/GEOSgcm_GridComp/blob/e2b79bdd24df30ab49889596f8fd97f4ab7271fb/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CNFireMod.F90#L695-L697

Issue: https://github.com/GEOS-ESM/GEOSgcm_GridComp/issues/896

@gmao-jkolassa this fix works and results in round off difference for CatchCN. Maybe there is better way to do it I am not sure. 

For GCM this is zero diff trivial since fix is in CLM4.5 module. 

fyi: @gmao-rreichle @rdkoster 