### PR TITLE
Refactor DataSea/DataIce IS_FCST to OGCM_IS_FCST

### DIFF
--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp.F90
@@ -539,7 +539,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 ! In atmospheric forecast mode we do not have future Sea Ice Conc
 !---------------------------------------------------------------
 
-    call MAPL_GetResource(MAPL,IFCST,LABEL="IS_FCST:",default=0,   RC=STATUS)
+    call MAPL_GetResource(MAPL,IFCST,LABEL="OGCM_IS_FCST:",default=0,   RC=STATUS)
     VERIFY_(STATUS)
 
     FCST = IFCST==1

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp_ExtData.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/GEOS_DataSeaIceGridComp_ExtData.F90
@@ -318,7 +318,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
 ! In atmospheric forecast mode we do not have future Sea Ice Conc
 !----------------------------------------------------------------
 
-    call MAPL_GetResource(MAPL,IFCST,LABEL="IS_FCST:",default=0, _RC )
+    call MAPL_GetResource(MAPL,IFCST,LABEL="OGCM_IS_FCST:",default=0, _RC )
     FCST = IFCST==1
 
 ! Get relaxation time


### PR DESCRIPTION
Testing by @sanAkel and @rtodling found that `IS_FCST` was a resource parameter in both the AGCM Grid Comp and in the DataSea and DataIce Grid Comps that was doing different things. In the DataSea and DataIce Grid Comps, it determined persistence of SST/ICE via `MAPL_ReadForcing`. But in the AGCM, it altered IAU handling (I think?).

Either way, there was no good way to set one without setting the other. So, for separability, we rename all the oceanic `IS_FCST` to be `OGCM_IS_FCST`. We keep the AGCM `IS_FCST` as it currently is named unless there is a desire to refactor it from @sdrabenh or others.

This PR has companion PRs:

- https://github.com/GEOS-ESM/GEOS_OceanGridComp/pull/66
- https://github.com/GEOS-ESM/GEOSgcm_App/pull/583
