### PR TITLE
Enable EASE M01 option in Boundary Conditions Package 

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_ease.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_ease.py
@@ -29,14 +29,15 @@ def make_bcs_ease(config):
      return
 
   grid_type  = config['grid_type']
+  resolution = config['resolution']
+  GRIDNAME  = grid_type+'_'+ resolution
+
   if 'EASEv' not in grid_type :
      print("                                                                  ")
      print("******************************************************************")
      print("ERROR: " + GRIDNAME + " is not an EASE grid.                      ")
      print("******************************************************************")
      return
-
-  resolution = config['resolution']
 
   # if resolution is M01 in EASEv1 or EASEv2, do not execute
   # Instead, exist and print an on-screen message to the user
@@ -50,7 +51,6 @@ def make_bcs_ease(config):
      print("                                                                  ")
      return 
 
-  GRIDNAME  = grid_type+'_'+ resolution
   now     = datetime.now()
   tmp_dir = now.strftime("%Y%m%d%H%M%S") 
   tmp_dir = f"{resolution}_{tmp_dir}"

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_ease.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_ease.py
@@ -32,6 +32,18 @@ def make_bcs_ease(config):
 
   resolution = config['resolution']
 
+  # if resolution is M01 in EASEv1 or EASEv2, do not execute
+  # Instead, exist and print an on-screen message to the user
+  if resolution == "M01":
+      print("               ")
+      print("**********************************************")
+      print("The M01 resolution (1km) run is not submitted.")
+      print("Any other resolutions (if chosen) are submitted.")
+      print("If you need M01 (1km) output, please get in touch with Land Group (GMAO) for assistance.")
+      print("**********************************************")
+      print("               ")
+      return 
+
   GRIDNAME  = grid_type+'_'+ resolution
   now     = datetime.now()
   tmp_dir = now.strftime("%Y%m%d%H%M%S") 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_ease.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_ease.py
@@ -22,12 +22,18 @@ bin/create_README.csh
 def make_bcs_ease(config):
   bin_dir = os.getcwd()
   if '/bin' not in bin_dir:
-    print("please run this program in installed bin directory")
-    return
+     print("                                                                  ")
+     print("******************************************************************")
+     print("ERROR: Must run this program in installed bin directory.          ")
+     print("******************************************************************")
+     return
 
   grid_type  = config['grid_type']
   if 'EASEv' not in grid_type :
-     print('This is not a EASE grid')
+     print("                                                                  ")
+     print("******************************************************************")
+     print("ERROR: " + GRIDNAME + " is not an EASE grid.                      ")
+     print("******************************************************************")
      return
 
   resolution = config['resolution']
@@ -35,14 +41,14 @@ def make_bcs_ease(config):
   # if resolution is M01 in EASEv1 or EASEv2, do not execute
   # Instead, exist and print an on-screen message to the user
   if resolution == "M01":
-      print("               ")
-      print("**********************************************")
-      print("The EASE M01 resolution (~1km) run is not submitted.")
-      print("Any other resolutions (if chosen) are submitted.")
-      print("If you need M01 output, please get in touch with Land Group (GMAO) for assistance.")
-      print("**********************************************")
-      print("               ")
-      return 
+     print("                                                                  ")
+     print("******************************************************************")
+     print("WARNING: Job for " + GRIDNAME + " not submitted!                  ")
+     print("         EASEv[x]_M01 (~1 km) resolution requires custom process. ")
+     print("         Contact GMAO Land Group for assistance.                  ")     
+     print("******************************************************************")
+     print("                                                                  ")
+     return 
 
   GRIDNAME  = grid_type+'_'+ resolution
   now     = datetime.now()

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_ease.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_ease.py
@@ -37,9 +37,9 @@ def make_bcs_ease(config):
   if resolution == "M01":
       print("               ")
       print("**********************************************")
-      print("The M01 resolution (1km) run is not submitted.")
+      print("The EASE M01 resolution (~1km) run is not submitted.")
       print("Any other resolutions (if chosen) are submitted.")
-      print("If you need M01 (1km) output, please get in touch with Land Group (GMAO) for assistance.")
+      print("If you need M01 output, please get in touch with Land Group (GMAO) for assistance.")
       print("**********************************************")
       print("               ")
       return 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_questionary.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_questionary.py
@@ -279,7 +279,7 @@ def ask_questions(default_grid="Cubed-Sphere"):
             "name": "EASEv1",
             "message": "Select EASEv1 grid resolution: \n ",
             "choices": [ \
-                 #"M01  --  1km $34668x14688$", \
+                 "M01  --  1km $34668x14688$", \
                  "M03  --  3km $11556x4896$", \
                  "M09  --  9km  $3852x1632$", \
                  "M25  -- 25km  $1383x586$", \
@@ -292,7 +292,7 @@ def ask_questions(default_grid="Cubed-Sphere"):
             "name": "EASEv2",
             "message": "Select EASEv2 grid resolution: \n ",
             "choices": [ \
-                 #"M01  --  1km $34704x14616$", \
+                 "M01  --  1km $34704x14616$", \
                  "M03  --  3km $11568x4872$", \
                  "M09  --  9km  $3856x1624$", \
                  "M25  -- 25km  $1388x584$", \


### PR DESCRIPTION
This grid and resolution combination is very computationally expensive to run. 
With this message in the BCS package, we want to let users know this resolution is available to use or to run and create with the package, but they need special instructions on how to do it on Discover. 

There is a draft readme file with a bit more information located here:
/discover/nobackup/projects/gmao/bcs_shared/test/NL3/readme_ease_m01

This PR is 0-diff Trivial since change is part of the boundary conditions package. 
