### PR TITLE
SHOCMF updates

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
@@ -1053,9 +1053,9 @@ contains
     VERIFY_(STATUS)
 
     call MAPL_AddConnectivity ( GC,                   &
-         SHORT_NAME  = [character(len=6) ::           &
-                         'QV','QLTOT','QITOT','FCLD', &
-                         'WTHV2','WQT_DC'],           &
+         SHORT_NAME  = [character(len=7) ::           &
+                         'QV','QLLS','QILS','FCLD', &
+                         'WTHV2','WQT_DC','CNV_MFC'],           &
          DST_ID      = TURBL,                         &
          SRC_ID      = MOIST,                         &
                                            RC=STATUS  )

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_BACM_1M_InterfaceMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_BACM_1M_InterfaceMod.F90
@@ -343,7 +343,7 @@ subroutine BACM_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
     real, pointer, dimension(:,:,:) :: ALPHT, ALPH1, ALPH2
     real, pointer, dimension(:,:,:) :: CFPDF, RHCLR
     real, pointer, dimension(:,:,:) :: DQRL, WTHV2
-    real, pointer, dimension(:,:,:) :: PDFITERS
+    real, pointer, dimension(:,:,:) :: PDFITERS,S2
     real, pointer, dimension(:,:  ) :: CNV_FRC, SRF_TYPE
     real, pointer, dimension(:,:  ) :: LS_PRCP, CN_PRCP, AN_PRCP, SC_PRCP
     real, pointer, dimension(:,:  ) :: LS_ARF,  CN_ARF,  AN_ARF,  SC_ARF
@@ -596,6 +596,7 @@ subroutine BACM_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
     call MAPL_GetPointer(EXPORT, RHCLR,     'RHCLR'  , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, DQRL,      'DQRL'   , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, PDFITERS, 'PDFITERS', ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(EXPORT, S2, 'S2', ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, WTHV2,     'WTHV2'  , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, WQL,       'WQL'    , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
 
@@ -713,7 +714,7 @@ subroutine BACM_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
               VFALLWAT_AN  ,VFALLWAT_LS  , &
                VFALLSN_AN  , VFALLSN_LS  ,VFALLSN_CN  ,VFALLSN_SC  ,  &
                VFALLRN_AN  , VFALLRN_LS  ,VFALLRN_CN  ,VFALLRN_SC  ,  &
-              PDF_A, PDFITERS, &
+              PDF_A, PDFITERS, s2, &
               DQVDT_macro, DQLDT_macro, DQIDT_macro, DQADT_macro, &
 #ifdef PDFDIAG
               PDF_SIGW1, PDF_SIGW2, PDF_W1, PDF_W2, &
@@ -725,6 +726,7 @@ subroutine BACM_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
               NACTL,    &
               NACTI,    &
               "GF" )
+
          ! update T
          T = TH*PK
          ! Exports

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_GFDL_1M_InterfaceMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_GFDL_1M_InterfaceMod.F90
@@ -80,9 +80,9 @@ subroutine GFDL_1M_Setup (GC, CF, RC)
       FRIENDLIES%CLLS     = "DYNAMICS"
       FRIENDLIES%CLCN     = "DYNAMICS"
       FRIENDLIES%QLLS     = "DYNAMICS:TURBULENCE"
-      FRIENDLIES%QLCN     = "DYNAMICS:TURBULENCE"
+      FRIENDLIES%QLCN     = "DYNAMICS"
       FRIENDLIES%QILS     = "DYNAMICS:TURBULENCE"
-      FRIENDLIES%QICN     = "DYNAMICS:TURBULENCE"
+      FRIENDLIES%QICN     = "DYNAMICS"
       FRIENDLIES%QRAIN    = "DYNAMICS:TURBULENCE"
       FRIENDLIES%QSNOW    = "DYNAMICS:TURBULENCE"
       FRIENDLIES%QGRAUPEL = "DYNAMICS:TURBULENCE"
@@ -338,7 +338,7 @@ subroutine GFDL_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
     real, pointer, dimension(:,:,:) :: RHX, REV_LS, RSU_LS
     real, pointer, dimension(:,:,:) :: PFL_LS, PFL_AN
     real, pointer, dimension(:,:,:) :: PFI_LS, PFI_AN
-    real, pointer, dimension(:,:,:) :: PDFITERS
+    real, pointer, dimension(:,:,:) :: PDFITERS,S2
     real, pointer, dimension(:,:,:) :: RHCRIT3D
     real, pointer, dimension(:,:)   :: EIS, LTS
     real, pointer, dimension(:,:)   :: DBZ_MAX, DBZ_1KM, DBZ_TOP, DBZ_M10C
@@ -503,6 +503,7 @@ subroutine GFDL_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
     call MAPL_GetPointer(EXPORT, WTHV2,    'WTHV2'   , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, WQL,      'WQL'     , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, PDFITERS, 'PDFITERS', ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(EXPORT, S2,       'S2', ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     ! Unused Exports (forced to 0.0)
     call MAPL_GetPointer(EXPORT, PTR2D,  'CN_PRCP'   , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS); PTR2D=0.0
     call MAPL_GetPointer(EXPORT, PTR2D,  'AN_PRCP'   , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS); PTR2D=0.0
@@ -639,6 +640,7 @@ subroutine GFDL_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
                       SL3(I,J,L)     , &
                       PDF_A(I,J,L)   , &
                       PDFITERS(I,J,L), &
+                      S2(I,J,L),       &
 #ifdef PDFDIAG
                       PDF_SIGW1(I,J,L),  &
                       PDF_SIGW2(I,J,L),  &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MGB2_2M_InterfaceMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MGB2_2M_InterfaceMod.F90
@@ -504,7 +504,7 @@ subroutine MGB2_2M_Run  (GC, IMPORT, EXPORT, CLOCK, RC)
     real, pointer, dimension(:,:,:) :: RHX, REV_LS, RSU_LS
     real, pointer, dimension(:,:,:) :: PFL_LS, PFL_AN
     real, pointer, dimension(:,:,:) :: PFI_LS, PFI_AN
-    real, pointer, dimension(:,:,:) :: PDF_A, PDFITERS
+    real, pointer, dimension(:,:,:) :: PDF_A, PDFITERS,S2
     real, pointer, dimension(:,:,:) :: RHCRIT3D
     real, pointer, dimension(:,:,:) :: PTR3D
     real, pointer, dimension(:,:  ) :: PTR2D
@@ -1388,6 +1388,7 @@ subroutine MGB2_2M_Run  (GC, IMPORT, EXPORT, CLOCK, RC)
     call MAPL_GetPointer(EXPORT, WTHV2,     'WTHV2'  , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, WQL,       'WQL'    , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, PDFITERS, 'PDFITERS', ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(EXPORT, S2,       'S2', ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     ! Unused Exports (foreced to 0.0)
     call MAPL_GetPointer(EXPORT, PTR2D,  'CN_PRCP'   , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS); PTR2D=0.0
     call MAPL_GetPointer(EXPORT, PTR2D,  'AN_PRCP'   , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS); PTR2D=0.0
@@ -1496,6 +1497,7 @@ subroutine MGB2_2M_Run  (GC, IMPORT, EXPORT, CLOCK, RC)
                       SL3(I,J,L)     , &
                       PDF_A(I,J,L)   , &
                       PDFITERS(I,J,L), &
+                      S2(I,J,L), &
 #ifdef PDFDIAG
                       PDF_SIGW1(I,J,L),  &
                       PDF_SIGW2(I,J,L),  &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
@@ -746,6 +746,15 @@ contains
                                                                   RC=STATUS  )
     VERIFY_(STATUS)
 
+    call MAPL_AddExportSpec(GC,                                              &
+       LONG_NAME  = 'subsaturation_std_dev',                                 &
+       UNITS      = '1',                                                     &
+       SHORT_NAME = 'S2',                                                    &
+       DIMS       = MAPL_DimsHorzVert,                                       &
+       VLOCATION  = MAPL_VLocationCenter,                                    &
+                                                                  RC=STATUS  )
+    VERIFY_(STATUS)
+
 #ifdef PDFDIAG
     call MAPL_AddExportSpec(GC,                                              &
        LONG_NAME  = 'SHOC_PDF_vertical_velocity_standard_deviation_first_plume', &
@@ -5256,6 +5265,8 @@ contains
     call ESMF_AlarmGet(ALARM, RingInterval=TINT, RC=STATUS); VERIFY_(STATUS)
     call ESMF_TimeIntervalGet(TINT,   S_R8=DT_R8,RC=STATUS); VERIFY_(STATUS)
     DT_MOIST = DT_R8
+
+
 
     if ( ESMF_AlarmIsRinging( ALARM, RC=STATUS) ) then
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_THOM_1M_InterfaceMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_THOM_1M_InterfaceMod.F90
@@ -347,7 +347,7 @@ subroutine THOM_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
     real, pointer, dimension(:,:,:) :: RHX, REV_LS, RSU_LS
     real, pointer, dimension(:,:,:) :: PFL_LS, PFL_AN
     real, pointer, dimension(:,:,:) :: PFI_LS, PFI_AN
-    real, pointer, dimension(:,:,:) :: PDFITERS
+    real, pointer, dimension(:,:,:) :: PDFITERS,S2
     real, pointer, dimension(:,:,:) :: RHCRIT3D
     real, pointer, dimension(:,:)   :: EIS, LTS
     real, pointer, dimension(:,:)   :: DBZ_MAX, DBZ_1KM, DBZ_TOP, DBZ_M10C
@@ -641,6 +641,7 @@ subroutine THOM_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
     call MAPL_GetPointer(EXPORT, WTHV2,    'WTHV2'   , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, WQL,      'WQL'     , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, PDFITERS, 'PDFITERS', ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(EXPORT, S2, 'S2', ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, DBZ3D,    'DBZ'     , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, SNOW_RATIO,'SNOW_RATIO', ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     ! Unused Exports (foreced to 0.0)
@@ -777,6 +778,7 @@ subroutine THOM_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
                       SL3(I,J,L)     , &
                       PDF_A(I,J,L)   , &
                       PDFITERS(I,J,L), &
+                      S2(I,J,L), &
 #ifdef PDFDIAG
                       PDF_SIGW1(I,J,L),  &
                       PDF_SIGW2(I,J,L),  &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/cloudnew.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/cloudnew.F90
@@ -487,7 +487,7 @@ contains
          VFALLWAT_AN_dev,VFALLWAT_LS_dev,   &
          VFALLSN_AN_dev,VFALLSN_LS_dev,VFALLSN_CN_dev,VFALLSN_SC_dev, &
          VFALLRN_AN_dev,VFALLRN_LS_dev,VFALLRN_CN_dev,VFALLRN_SC_dev,  &
-         PDF_A_dev, PDFITERS_dev, & 
+         PDF_A_dev, PDFITERS_dev,s2_dev, & 
          DQVDTMAC_dev, DQLDTMAC_dev, DQIDTMAC_dev, DQADTMAC_dev, &
 #ifdef PDFDIAG
          PDF_SIGW1_dev, PDF_SIGW2_dev, PDF_W1_dev, PDF_W2_dev, & 
@@ -635,6 +635,7 @@ contains
       real, intent(  out), dimension(IRUN,  LM) :: VFALLRN_SC_dev ! VFALLRN_SC
       real, intent(inout), dimension(IRUN,  LM) :: PDF_A_dev
       real, intent(  out), dimension(IRUN,  LM) :: PDFITERS_dev
+      real, intent(  out), dimension(IRUN,  LM) :: s2_dev
 #ifdef PDFDIAG
       real, intent(  out), dimension(IRUN,  LM) :: PDF_SIGW1_dev
       real, intent(  out), dimension(IRUN,  LM) :: PDF_SIGW2_dev
@@ -1052,6 +1053,7 @@ contains
                   hl3_dev(I,K),        &
                   PDF_A_dev(I,K),      &  ! can remove these after development
                   PDFITERS_dev(I,K),   &
+                  S2_dev(I,K),         &
 #ifdef PDFDIAG
                   PDF_SIGW1_dev(I,K),  &
                   PDF_SIGW2_dev(I,K),  &
@@ -1101,6 +1103,7 @@ contains
                   hl3_dev(I,K),        &
                   PDF_A_dev(I,K),      &  ! can remove these after development
                   PDFITERS_dev(I,K),   &
+                  s2_dev(I,K),         &
 #ifdef PDFDIAG
                   PDF_SIGW1_dev(I,K),  &
                   PDF_SIGW2_dev(I,K),  &
@@ -1869,6 +1872,7 @@ contains
          MFHL3       , &
          PDF_A,      &  ! can remove these after development
          PDFITERS,   &
+         S2,         &
 #ifdef PDFDIAG
          PDF_SIGW1,  &
          PDF_SIGW2,  &
@@ -1900,7 +1904,7 @@ contains
                              PDF_SIGQT1, PDF_SIGQT2, PDF_QT1, PDF_QT2, &
                              PDF_RHLQT,  PDF_RWHL, PDF_RWQT
 #endif
-      real, intent(out)   :: WTHV2, WQL, PDFITERS
+      real, intent(out)   :: WTHV2, WQL, PDFITERS, s2
 
       ! internal arrays
       real :: QCO, QVO, CFO, QAO, TAU,HL
@@ -2011,6 +2015,7 @@ contains
                                  MFQT3,        &
                                  MFHL3,        &
                                  PDF_A,        &
+                                 S2,           &
 #ifdef PDFDIAG
                                  PDF_SIGW1,    &
                                  PDF_SIGW2,    &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/GEOS_TurbulenceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/GEOS_TurbulenceGridComp.F90
@@ -3206,7 +3206,7 @@ end if
        call MAPL_GetResource (MAPL, SHOCPARAMS%LENFAC1, trim(COMP_NAME)//"_SHC_LENFAC1:",     default=10.0,  RC=STATUS); VERIFY_(STATUS)       
        call MAPL_GetResource (MAPL, SHOCPARAMS%LENFAC2, trim(COMP_NAME)//"_SHC_LENFAC2:",     default=2.0,  RC=STATUS); VERIFY_(STATUS)       
        call MAPL_GetResource (MAPL, SHOCPARAMS%LENFAC3, trim(COMP_NAME)//"_SHC_LENFAC3:",     default=3.0,  RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetResource (MAPL, SHOCPARAMS%BUOYOPT, trim(COMP_NAME)//"_SHC_BUOY_OPTION:", default=2,    RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetResource (MAPL, SHOCPARAMS%BUOYOPT, trim(COMP_NAME)//"_SHC_BUOY_OPTION:", default=1,    RC=STATUS); VERIFY_(STATUS)
      end if
 
      call MAPL_GetResource (MAPL, PDFSHAPE,   'PDFSHAPE:',   DEFAULT = 1.0   , RC=STATUS); VERIFY_(STATUS)
@@ -3630,6 +3630,7 @@ end if
       call MAPL_GetResource (MAPL, MFPARAMS%IMPLICIT,  "EDMF_IMPLICIT:",      default=1,     RC=STATUS)
       call MAPL_GetResource (MAPL, MFPARAMS%PRCPCRIT,  "EDMF_PRCPCRIT:",      default=-1.,   RC=STATUS)
       call MAPL_GetResource (MAPL, MFPARAMS%UPABUOYDEP,"EDMF_UPABUOYDEP:",    default=1,     RC=STATUS)
+      call MAPL_GetResource (MAPL, MFPARAMS%TREFF,     "EDMF_TREFF:",         default=100.,  RC=STATUS)
 
       ! Future options
 !      call MAPL_GetResource (MAPL, EDMF_THERMAL_PLUME, "EDMF_THERMAL_PLUME:", default=0,  RC=STATUS)
@@ -3751,8 +3752,8 @@ end if
                     QI,                       & 
                     SH,                       & 
                     EVAP,                     & 
-                    FRLAND,                   & 
-                    ZPBL,                     & 
+                    FRLAND,                   &
+                    ZPBL,                     &
 !                   MFTHSRC, MFQTSRC, MFW, MFAREA, & ! CLASP inputs
                     !== Outputs for trisolver ==
                     ae3,                      &
@@ -4766,10 +4767,12 @@ end if
          PPBL = MAX(PPBL,PLO(:,:,KPBLMIN))
       end if
 
+      RHOAW3=RHOE*AW3
+
       ! Second difference coefficients for scalars; RDZ is RHO/DZ, DMI is (G DT)/DP
       ! ---------------------------------------------------------------------------
 
-      CKS(:,:,1:LM-1) = -KH(:,:,1:LM-1) * RDZ(:,:,1:LM-1)
+      CKS(:,:,1:LM-1) = -(KH(:,:,1:LM-1)+MFPARAMS%TREFF*RHOAW3(:,:,1:LM-1)) * RDZ(:,:,1:LM-1)
       AKS(:,:,1     ) = 0.0
       AKS(:,:,2:LM  ) = CKS(:,:,1:LM-1) * DMI(:,:,2:LM  )
       CKS(:,:,1:LM-1) = CKS(:,:,1:LM-1) * DMI(:,:,1:LM-1)
@@ -4820,7 +4823,6 @@ end if
      AKSS(:,:,1)=0.0
      AKUU(:,:,1)=0.0
 
-     RHOAW3=RHOE*AW3
 
      if (MFPARAMS%IMPLICIT == 1 .and. MFPARAMS%DISCRETE == 0) then
         AKSS(:,:,2:LM) = - KH(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,2:LM) &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/GEOS_TurbulenceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/GEOS_TurbulenceGridComp.F90
@@ -328,6 +328,17 @@ contains
                                                         RC=STATUS  )
       VERIFY_(STATUS)
 
+
+      call MAPL_AddImportSpec(GC,                                 &
+         SHORT_NAME = 'CNV_MFC',                                        &
+         LONG_NAME  = 'mass_flux',                          &
+         UNITS      = 'K',                                        &
+         DIMS       = MAPL_DimsHorzVert,                          &
+         VLOCATION  = MAPL_VLocationEdge,                         &
+         RESTART    = MAPL_RestartSkip,                           &
+                                                        RC=STATUS  )
+      VERIFY_(STATUS)
+
      call MAPL_AddImportSpec(GC,                                  &
         SHORT_NAME = 'TH',                                        &
         LONG_NAME  = 'potential_temperature',                     &
@@ -349,7 +360,7 @@ contains
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC,                                  &
-        SHORT_NAME = 'QLTOT',                                     &
+        SHORT_NAME = 'QLLS',                                      &
         LONG_NAME  = 'liquid_condensate_mixing_ratio',            &
         UNITS      = 'kg kg-1',                                   &
         DIMS       = MAPL_DimsHorzVert,                           &
@@ -359,7 +370,7 @@ contains
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC,                                  &
-        SHORT_NAME = 'QITOT',                                     &
+        SHORT_NAME = 'QILS',                                      &
         LONG_NAME  = 'frozen_condensate_mixing_ratio',            &
         UNITS      = 'kg kg-1',                                   &
         DIMS       = MAPL_DimsHorzVert,                           &
@@ -1123,6 +1134,15 @@ end if
                                                                   RC=STATUS  )
     VERIFY_(STATUS)
 
+    call MAPL_AddExportSpec(GC,                              &
+         SHORT_NAME = 'W_DIAG',                                        &
+         LONG_NAME  = 'Diagnostic_vertical_velocity',                  &
+         UNITS      = 'm s-1',                                        &
+         DIMS       = MAPL_DimsHorzVert,                              &
+         VLOCATION  = MAPL_VLocationCenter,                           &
+         RC=STATUS  )
+    VERIFY_(STATUS)
+
     call MAPL_AddExportSpec(GC,                                  &
         SHORT_NAME = 'TRI',                                       &
         LONG_NAME  = 'diffusion_tendencies',                      &
@@ -1347,6 +1367,15 @@ end if
          DIMS       = MAPL_DimsHorzOnly,                          &
          VLOCATION  = MAPL_VLocationNone,              RC=STATUS  )
      VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec(GC,                              &
+         SHORT_NAME = 'W_ENTR',                                   &
+         LONG_NAME  = 'PBL_top_entrainment_velocity',             &
+         UNITS      = 'm s-1',                                    &
+         DIMS       = MAPL_DimsHorzOnly,                          &
+         VLOCATION  = MAPL_VLocationNone,                         &
+         RC=STATUS  )
+    VERIFY_(STATUS)
 
     call MAPL_AddExportSpec ( gc,                                 &
          SHORT_NAME = 'QT',                                       &
@@ -1968,6 +1997,61 @@ end if
        LONG_NAME  = 'center_height_above_surface',               &
        SHORT_NAME = 'ZLS',                                       &
        UNITS      = 'm',                                         &
+       DIMS       = MAPL_DimsHorzVert,                           &
+       VLOCATION  = MAPL_VLocationCenter,                        &
+                                                        RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec(GC,                                  &
+       LONG_NAME  = 'AKQQ_matrix',                           &
+       SHORT_NAME = 'AKQQX',                                      &
+       UNITS      = 's-1',                                   &
+       DIMS       = MAPL_DimsHorzVert,                           &
+       VLOCATION  = MAPL_VLocationCenter,                        &
+                                                        RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec(GC,                                  &
+       LONG_NAME  = 'BKQQ_matrix',                           &
+       SHORT_NAME = 'BKQQX',                                      &
+       UNITS      = 's-1',                                   &
+       DIMS       = MAPL_DimsHorzVert,                           &
+       VLOCATION  = MAPL_VLocationCenter,                        &
+                                                        RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec(GC,                                  &
+       LONG_NAME  = 'CKQQ_matrix',                           &
+       SHORT_NAME = 'CKQQX',                                      &
+       UNITS      = 's-1',                                   &
+       DIMS       = MAPL_DimsHorzVert,                           &
+       VLOCATION  = MAPL_VLocationCenter,                        &
+                                                        RC=STATUS  )
+    VERIFY_(STATUS)
+
+
+    call MAPL_AddExportSpec(GC,                                  &
+       LONG_NAME  = 'YQV_coefficient',                           &
+       SHORT_NAME = 'YQVX',                                      &
+       UNITS      = 'kg kg-1',                                   &
+       DIMS       = MAPL_DimsHorzVert,                           &
+       VLOCATION  = MAPL_VLocationCenter,                        &
+                                                        RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec(GC,                                  &
+       LONG_NAME  = 'YQL_coefficient',                           &
+       SHORT_NAME = 'YQLX',                                      &
+       UNITS      = 'kg kg-1',                                   &
+       DIMS       = MAPL_DimsHorzVert,                           &
+       VLOCATION  = MAPL_VLocationCenter,                        &
+                                                        RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec(GC,                                  &
+       LONG_NAME  = 'YQI_coefficient',                           &
+       SHORT_NAME = 'YQIX',                                      &
+       UNITS      = 'kg kg-1',                                   &
        DIMS       = MAPL_DimsHorzVert,                           &
        VLOCATION  = MAPL_VLocationCenter,                        &
                                                         RC=STATUS  )
@@ -2927,12 +3011,13 @@ end if
      real, dimension(:,:,:), pointer     :: TH, U, V, OMEGA, Q, T, RI, DU, RADLW, RADLWC, LWCRT
      real, dimension(:,:  ), pointer     :: AREA, VARFLT
      real, dimension(:,:,:), pointer     :: KH, KM, QLTOT, QITOT, FCLD
-     real, dimension(:,:,:), pointer     :: ALH
+     real, dimension(:,:,:), pointer     :: ALH, CNV_MFC
      real, dimension(:    ), pointer     :: PREF
 
      real, dimension(IM,JM,1:LM-1)       :: TVE, RDZ
      real, dimension(IM,JM,LM)           :: THV, TV, Z, DMI, PLO, QL, QI, QA, TSM, USM, VSM
      real, dimension(IM,JM,0:LM)         :: ZL0
+     real, dimension(IM,JM)              :: drycblh
      integer, dimension(IM,JM)           :: SMTH_LEV
 
 !     real, dimension(:,:,:), pointer     :: MFQTSRC, MFTHSRC, MFW, MFAREA
@@ -2958,7 +3043,12 @@ end if
      real, dimension(:,:,:), pointer     :: AKSODT, CKSODT
      real, dimension(:,:,:), pointer     :: AKQODT, CKQODT
      real, dimension(:,:,:), pointer     :: AKVODT, CKVODT
+     real, dimension(:,:,:), pointer     :: W_DIAG
+     real, dimension(:,:  ), pointer     :: W_ENTR
 
+     real, dimension(:,:,:), pointer     :: YQVX,YQLX,YQIX,AKQQX,BKQQX,CKQQX
+
+! SHOC variables
      real, dimension(:,:,:), pointer     :: LSHOC,BRUNTSHOC,BRUNTDRY, BRUNTEDGE,ISOTROPY, &
                                             LSHOC1,LSHOC2,LSHOC3, & 
                                             SHOCPRNUM,&
@@ -3111,6 +3201,8 @@ end if
 
 ! Get Sounding from the import state
 !-----------------------------------
+     call MAPL_GetPointer(IMPORT,  CNV_MFC,   'CNV_MFC',     RC=STATUS)
+     VERIFY_(STATUS)
 
      call MAPL_GetPointer(IMPORT,     T,       'T', RC=STATUS); VERIFY_(STATUS)
      call MAPL_GetPointer(IMPORT,     Q,      'QV', RC=STATUS); VERIFY_(STATUS)
@@ -3123,8 +3215,8 @@ end if
      call MAPL_GetPointer(IMPORT,  PREF,    'PREF', RC=STATUS); VERIFY_(STATUS)
      call MAPL_GetPointer(IMPORT, RADLW,   'RADLW', RC=STATUS); VERIFY_(STATUS)
      call MAPL_GetPointer(IMPORT,RADLWC,  'RADLWC', RC=STATUS); VERIFY_(STATUS)
-     call MAPL_GetPointer(IMPORT, QLTOT,   'QLTOT', RC=STATUS); VERIFY_(STATUS)
-     call MAPL_GetPointer(IMPORT, QITOT,   'QITOT', RC=STATUS); VERIFY_(STATUS)
+     call MAPL_GetPointer(IMPORT, QLTOT,    'QLLS', RC=STATUS); VERIFY_(STATUS)
+     call MAPL_GetPointer(IMPORT, QITOT,    'QILS', RC=STATUS); VERIFY_(STATUS)
      call MAPL_GetPointer(IMPORT,  FCLD,    'FCLD', RC=STATUS); VERIFY_(STATUS)
      call MAPL_GetPointer(IMPORT, BSTAR,   'BSTAR', RC=STATUS); VERIFY_(STATUS)
      call MAPL_GetPointer(IMPORT, USTAR,   'USTAR', RC=STATUS); VERIFY_(STATUS)
@@ -3183,7 +3275,7 @@ end if
      if (JASON_TRB) then
        call MAPL_GetResource (MAPL, KHSFCFAC_LND, trim(COMP_NAME)//"_KHSFCFAC_LND:", default=0.60,         RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetResource (MAPL, KHSFCFAC_OCN, trim(COMP_NAME)//"_KHSFCFAC_OCN:", default=0.30,         RC=STATUS); VERIFY_(STATUS)
-     else  
+     else
        call MAPL_GetResource (MAPL, KHSFCFAC_LND, trim(COMP_NAME)//"_KHSFCFAC_LND:", default=0.60,         RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetResource (MAPL, KHSFCFAC_OCN, trim(COMP_NAME)//"_KHSFCFAC_OCN:", default=0.60,         RC=STATUS); VERIFY_(STATUS)
      endif
@@ -3197,15 +3289,15 @@ end if
      call MAPL_GetResource (MAPL, DO_SHOC,      trim(COMP_NAME)//"_DO_SHOC:",       default=0,           RC=STATUS); VERIFY_(STATUS)
      if (DO_SHOC /= 0) then
        call MAPL_GetResource (MAPL, SHOCPARAMS%PRNUM,   trim(COMP_NAME)//"_SHC_PRNUM:",       default=-1.0, RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetResource (MAPL, SHOCPARAMS%LAMBDA,  trim(COMP_NAME)//"_SHC_LAMBDA:",      default=0.08, RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetResource (MAPL, SHOCPARAMS%LAMBDA,  trim(COMP_NAME)//"_SHC_LAMBDA:",      default=0.12, RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetResource (MAPL, SHOCPARAMS%TSCALE,  trim(COMP_NAME)//"_SHC_TSCALE:",      default=400., RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetResource (MAPL, SHOCPARAMS%CKVAL,   trim(COMP_NAME)//"_SHC_CK:",          default=0.1,  RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetResource (MAPL, SHOCPARAMS%CEFAC,   trim(COMP_NAME)//"_SHC_CEFAC:",       default=1.0,  RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetResource (MAPL, SHOCPARAMS%CESFAC,  trim(COMP_NAME)//"_SHC_CESFAC:",      default=4.,   RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetResource (MAPL, SHOCPARAMS%LENOPT,  trim(COMP_NAME)//"_SHC_LENOPT:",      default=3,    RC=STATUS); VERIFY_(STATUS)
-       call MAPL_GetResource (MAPL, SHOCPARAMS%LENFAC1, trim(COMP_NAME)//"_SHC_LENFAC1:",     default=10.0,  RC=STATUS); VERIFY_(STATUS)       
-       call MAPL_GetResource (MAPL, SHOCPARAMS%LENFAC2, trim(COMP_NAME)//"_SHC_LENFAC2:",     default=2.0,  RC=STATUS); VERIFY_(STATUS)       
-       call MAPL_GetResource (MAPL, SHOCPARAMS%LENFAC3, trim(COMP_NAME)//"_SHC_LENFAC3:",     default=3.0,  RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetResource (MAPL, SHOCPARAMS%LENFAC1, trim(COMP_NAME)//"_SHC_LENFAC1:",     default=8.0,  RC=STATUS); VERIFY_(STATUS)       
+       call MAPL_GetResource (MAPL, SHOCPARAMS%LENFAC2, trim(COMP_NAME)//"_SHC_LENFAC2:",     default=2.5,  RC=STATUS); VERIFY_(STATUS)       
+       call MAPL_GetResource (MAPL, SHOCPARAMS%LENFAC3, trim(COMP_NAME)//"_SHC_LENFAC3:",     default=0.7,  RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetResource (MAPL, SHOCPARAMS%BUOYOPT, trim(COMP_NAME)//"_SHC_BUOY_OPTION:", default=1,    RC=STATUS); VERIFY_(STATUS)
      end if
 
@@ -3221,7 +3313,7 @@ end if
 ! Get pointers from export state...
 !-----------------------------------
 
-     PDFALLOC = (PDFSHAPE.eq.5)
+     PDFALLOC = (PDFSHAPE.ge.5)
 
      call MAPL_GetPointer(EXPORT,      KH,      'KH', ALLOC=.TRUE., RC=STATUS)
      VERIFY_(STATUS)
@@ -3464,6 +3556,24 @@ end if
      call MAPL_GetPointer(EXPORT, SHOCPRNUM,'SHOCPRNUM', RC=STATUS)
      VERIFY_(STATUS)
 
+     call MAPL_GetPointer(EXPORT, W_DIAG, 'W_DIAG', RC=STATUS)
+     VERIFY_(STATUS)
+     call MAPL_GetPointer(EXPORT, W_ENTR, 'W_ENTR', RC=STATUS)
+     VERIFY_(STATUS)
+
+     call MAPL_GetPointer(EXPORT, YQVX,    'YQVX', RC=STATUS)
+     VERIFY_(STATUS)
+     call MAPL_GetPointer(EXPORT, YQLX,    'YQLX', RC=STATUS)
+     VERIFY_(STATUS)
+     call MAPL_GetPointer(EXPORT, YQIX,    'YQIX', RC=STATUS)
+     VERIFY_(STATUS)
+     call MAPL_GetPointer(EXPORT, AKQQX,   'AKQQX', RC=STATUS)
+     VERIFY_(STATUS)
+     call MAPL_GetPointer(EXPORT, BKQQX,   'BKQQX', RC=STATUS)
+     VERIFY_(STATUS)
+     call MAPL_GetPointer(EXPORT, CKQQX,   'CKQQX', RC=STATUS)
+     VERIFY_(STATUS)
+ 
 ! Initialize some arrays
 
       LWCRT = RADLW - RADLWC
@@ -3824,6 +3934,15 @@ end if
       if (associated(edmf_tke))       edmf_tke     = mftke
       if (associated(EDMF_FRC))       EDMF_FRC     = 0.5*(edmfdrya(:,:,0:LM-1)+edmfdrya(:,:,1:LM) &
                                                      + edmfmoista(:,:,0:LM-1)+edmfmoista(:,:,1:LM)) 
+      do i = 1,IM
+        do j = 1,JM
+          k = LM
+          do while (edmfdrya(i,j,k).gt.0.01 .and. k.gt.1)
+            k = k-1
+          end do
+          drycblh(i,j) = ZL0(i,j,k+1)
+        end do
+      end do
 
     ELSE            ! if there is no mass-flux
       ae3   = 1.0
@@ -3872,6 +3991,8 @@ end if
      
    ENDIF
 
+   ae3 = 1.0
+
    call MAPL_TimerOff(MAPL,"---MASSFLUX")
 
 
@@ -3910,7 +4031,7 @@ end if
                        WTHV2(:,:,1:LM),       &
                        BUOYF(:,:,1:LM),       &
                        MFTKE(:,:,0:LM),       &
-                       ZPBL(:,:),             &
+                       DRYCBLH(:,:),          &    
                        !== Input-Outputs ==
                        TKESHOC(:,:,1:LM),     &
                        TKH(:,:,1:LM),         &
@@ -3932,7 +4053,18 @@ end if
                        !== Tuning params ==
                        SHOCPARAMS )
 
+        do I = 1,IM
+           do J = 1,JM
+              L=LM
+              do while (edmfmoista(I,J,L).lt.1e-5 .and. L.gt.2)
+                 L = L-1
+              end do
+              TKH(I,J,1:L) = min(0.25,TKH(I,J,1:L))
+           end do
+        end do
+
         KH(:,:,1:LM) = TKH(:,:,1:LM)
+!        KM(:,:,1:LM) = 0.5*TKH(:,:,1:LM)
 
         call MAPL_TimerOff (MAPL,name="---SHOC" ,RC=STATUS)
         VERIFY_(STATUS)
@@ -4408,7 +4540,7 @@ end if
       end if ! TKE
 
       ! Update the higher order moments required for the ADG PDF
-      if ( (PDFSHAPE.eq.5) .AND. (DO_SHOC /= 0) ) then
+      if ( (PDFSHAPE.ge.5) ) then
       SL = T + (MAPL_GRAV*Z - MAPL_ALHL*QLTOT - MAPL_ALHS*QITOT)/MAPL_CP
       call update_moments(IM, JM, LM, DT, &
                           SH,             &  ! in
@@ -4422,6 +4554,7 @@ end if
                           QT,             &
                           SL,             &
                           EDMF_FRC,       &
+                          CNV_MFC,        &
 !                          edmf_mf(:,:,1:LM)/rhoe(:,:,1:LM),   &
 !                          MFQT2,          &
                           MFQT3,          &
@@ -4458,6 +4591,8 @@ end if
        end if
 
       KPBLMIN  = count(PREF < 50000.)
+
+      if (associated(W_ENTR)) W_ENTR = ZPBL
 
                             ZPBL = MAPL_UNDEF
       if (associated(PPBL)) PPBL = MAPL_UNDEF
@@ -4702,6 +4837,7 @@ end if
 
      end if ! SBITOP, SBIFRQ
 
+     if (associated(W_DIAG).or.associated(W_ENTR)) W_DIAG = OMEGA*(ZLE(:,:,1:LM)-ZLE(:,:,0:LM-1))/(PLE(:,:,1:LM)-PLE(:,:,0:LM-1))
 
       SELECT CASE(PBLHT_OPTION)
 
@@ -4732,7 +4868,16 @@ end if
 
       ZPBL = MIN(ZPBL,Z(:,:,KPBLMIN))
       KPBL = MAX(KPBL,float(KPBLMIN))
-  
+
+     ! PBL top entrainment velocity, diagnosed from PBLH tendency and large-scale ascent
+     if (associated(W_ENTR)) then
+        do I = 1, IM
+          do J = 1, JM
+             W_ENTR(I,J) = (ZPBL(I,J)-W_ENTR(I,J))/DT - W_DIAG(I,J,INT(KPBL(I,J)))
+          end do
+        end do
+     end if
+
      ! Calc KPBL using surface turbulence, for use in shallow scheme
       if(associated(KPBL_SC) .OR. associated(ZPBL_SC)) then
        KPBL_SC = MAPL_UNDEF
@@ -4767,7 +4912,7 @@ end if
          PPBL = MAX(PPBL,PLO(:,:,KPBLMIN))
       end if
 
-      RHOAW3=RHOE*AW3
+      RHOAW3=RHOE*AW3  ! mass flux (positive)
 
       ! Second difference coefficients for scalars; RDZ is RHO/DZ, DMI is (G DT)/DP
       ! ---------------------------------------------------------------------------
@@ -4784,8 +4929,8 @@ end if
       KH(:,:,LM) = CT * Z(:,:,LM)*((MAPL_RGAS * TV(:,:,LM))/PLE(:,:,LM))
       TKH = KH
 
-      ! Water vapor can differ at the surface
-      !--------------------------------------
+      ! Water vapor exchange coefficient can differ at the surface
+      !-----------------------------------------------------------
 
       AKQ         = AKS
       CKQ         = CKS
@@ -4822,7 +4967,7 @@ end if
         
      AKSS(:,:,1)=0.0
      AKUU(:,:,1)=0.0
-
+     AKQQ(:,:,1)=0.0
 
      if (MFPARAMS%IMPLICIT == 1 .and. MFPARAMS%DISCRETE == 0) then
         AKSS(:,:,2:LM) = - KH(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,2:LM) &
@@ -4830,25 +4975,29 @@ end if
         AKUU(:,:,2:LM) = - KM(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,2:LM) &
                          - 0.5*DMI(:,:,2:LM)*RHOAW3(:,:,1:LM-1)
      else
+        AKQQ(:,:,2:LM) = - KH(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,2:LM)
         AKSS(:,:,2:LM) = - KH(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,2:LM)
         AKUU(:,:,2:LM) = - KM(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,2:LM)
      end if
-     AKQQ = AKSS
+!     AKQQ = AKSS
 
      CKSS(:,:,LM)=-CT*DMI(:,:,LM)
      CKQQ(:,:,LM)=-CQ*DMI(:,:,LM)
      CKUU(:,:,LM)=-CU*DMI(:,:,LM)
   
      if (MFPARAMS%IMPLICIT == 1 .and. MFPARAMS%DISCRETE == 0) then
+        CKQQ(:,:,1:LM-1) = - KH(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,1:LM-1) &
+                           + 0.5*DMI(:,:,1:LM-1)*RHOAW3(:,:,1:LM-1)
         CKSS(:,:,1:LM-1) = - KH(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,1:LM-1) &
                            + 0.5*DMI(:,:,1:LM-1)*RHOAW3(:,:,1:LM-1)
         CKUU(:,:,1:LM-1) = - KM(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,1:LM-1) &
                            + 0.5*DMI(:,:,1:LM-1)*RHOAW3(:,:,1:LM-1)
      else
+        CKQQ(:,:,1:LM-1) = - KH(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,1:LM-1)
         CKSS(:,:,1:LM-1) = - KH(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,1:LM-1)
         CKUU(:,:,1:LM-1) = - KM(:,:,1:LM-1)*RDZ(:,:,1:LM-1)*AE3(:,:,1:LM-1)*DMI(:,:,1:LM-1)
      end if
-     CKQQ(:,:,1:LM-1) = CKSS(:,:,1:LM-1)  
+!     CKQQ(:,:,1:LM-1) = CKSS(:,:,1:LM-1)  
  
      BKSS = 1.0 - (CKSS+AKSS)
      BKQQ = 1.0 - (CKQQ+AKQQ)
@@ -4870,9 +5019,9 @@ end if
         AKQQ(:,:,2:LM) = AKQQ(:,:,2:LM) - DMI(:,:,2:LM)*RHOAW3(:,:,1:LM-1)
         AKUU(:,:,2:LM) = AKUU(:,:,2:LM) - DMI(:,:,2:LM)*RHOAW3(:,:,1:LM-1)
 
-        BKSS(:,:,2:LM-1) = BKSS(:,:,2:LM-1) + DMI(:,:,2:LM-1)*RHOAW3(:,:,2:LM-1)
-        BKQQ(:,:,2:LM-1) = BKQQ(:,:,2:LM-1) + DMI(:,:,2:LM-1)*RHOAW3(:,:,2:LM-1)
-        BKUU(:,:,2:LM-1) = BKUU(:,:,2:LM-1) + DMI(:,:,2:LM-1)*RHOAW3(:,:,2:LM-1)
+        BKSS(:,:,1:LM-1) = BKSS(:,:,1:LM-1) + DMI(:,:,1:LM-1)*RHOAW3(:,:,1:LM-1)
+        BKQQ(:,:,1:LM-1) = BKQQ(:,:,1:LM-1) + DMI(:,:,1:LM-1)*RHOAW3(:,:,1:LM-1)
+        BKUU(:,:,1:LM-1) = BKUU(:,:,1:LM-1) + DMI(:,:,1:LM-1)*RHOAW3(:,:,1:LM-1)
      end if
   end if
 
@@ -4897,6 +5046,14 @@ end if
    YQI(:,:,1:LM-1) = DMI(:,:,1:LM-1)*( RHOE(:,:,1:LM-1)*AWQI3(:,:,1:LM-1) - RHOE(:,:,0:LM-2)*AWQI3(:,:,0:LM-2) )
    YU(:,:,1:LM-1)  = DMI(:,:,1:LM-1)*( RHOE(:,:,1:LM-1)*AWU3(:,:,1:LM-1)  - RHOE(:,:,0:LM-2)*AWU3(:,:,0:LM-2) )
    YV(:,:,1:LM-1)  = DMI(:,:,1:LM-1)*( RHOE(:,:,1:LM-1)*AWV3(:,:,1:LM-1)  - RHOE(:,:,0:LM-2)*AWV3(:,:,0:LM-2) )
+
+  if (associated(YQVX)) YQVX = YQV*DT/DMI   ! Multiply by layer mass (DMI = DT/MASS)  
+  if (associated(YQLX)) YQLX = YQL*DT/DMI
+  if (associated(YQIX)) YQIX = YQI*DT/DMI
+
+  if (associated(AKQQX)) AKQQX = AKQQ
+  if (associated(BKQQX)) BKQQX = BKQQ - 1.0
+  if (associated(CKQQX)) CKQQX = CKQQ
 
    ! Add prescribed surface fluxes
    if ( SCM_SL /= 0 .and. (SCM_SL_FLUX == 1 .or. SCM_SL_FLUX == 2) ) then
@@ -5079,6 +5236,7 @@ end if
     integer                             :: KM, K,L
     logical                             :: FRIENDLY
     logical                             :: WEIGHTED
+    logical                             :: OPT      ! selects algorithm in VTRISOLVE
 
     real,               dimension(IM,JM,LM) :: DP
     real(kind=MAPL_R8), dimension(IM,JM,LM) :: SX
@@ -5170,6 +5328,7 @@ end if
     call MAPL_GetPointer(EXPORT, SAFDIFFUSE ,  'SAFDIFFUSE' , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, QAFDIFFUSE ,  'QAFDIFFUSE' , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
 
+
 ! Count the firlds in TR...
 !--------------------------
 
@@ -5257,6 +5416,8 @@ end if
        
        if(associated(SRG)) then
           SG => SRG
+!       else if (trim(name)=='QLLS') then
+!          SG = S(:,:,LM)
        else
           allocate (SG(0,0), stat=STATUS)
           VERIFY_(STATUS)
@@ -5274,6 +5435,8 @@ end if
 
 ! Pick the right exchange coefficients
 !-------------------------------------
+
+OPT = .TRUE.
 
 if ( (trim(name) /= 'S'   ) .and. (trim(name) /= 'Q'   ) .and. &
      (trim(name) /= 'QLLS') .and. (trim(name) /= 'QILS') .and. &
@@ -5303,32 +5466,34 @@ if ( (trim(name) /= 'S'   ) .and. (trim(name) /= 'Q'   ) .and. &
 
  elseif (trim(name) =='S') then
           CX => CT
-          DX => DKSS
+          DX => DKS
           AK => AKSS; BK => BKSS; CK => CKSS
           SX=S+YS      
  elseif (trim(name)=='Q') then
           CX => CQ
-          DX => DKQQ
+          DX => DKQ
           AK => AKQQ; BK => BKQQ; CK => CKQQ
           SX=S+YQV
  elseif (trim(name)=='QLLS') then
           CX => CQ
-          DX => DKQQ
+          DX => DKQ
           AK => AKQQ; BK => BKQQ; CK => CKQQ
           SX=S+YQL
+          OPT = .FALSE.
  elseif (trim(name)=='QILS') then
           CX => CQ
-          DX => DKQQ
+          DX => DKQ
           AK => AKQQ; BK => BKQQ; CK => CKQQ
           SX=S+YQI
+          OPT = .FALSE.
  elseif (trim(name)=='U') then       
          CX => CU
-         DX => DKUU
+         DX => DKV
          AK => AKUU; BK => BKUU; CK => CKUU
          SX=S+YU
  elseif (trim(name)=='V') then       
          CX => CU
-         DX => DKUU
+         DX => DKV
          AK => AKUU; BK => BKUU; CK => CKUU
          SX=S+YV        
  end if
@@ -5337,7 +5502,7 @@ if ( (trim(name) /= 'S'   ) .and. (trim(name) /= 'Q'   ) .and. &
 ! Solve for semi-implicit changes. This modifies SX
 ! -------------------------------------------------
 
-       call VTRISOLVE(AK,BK,CK,SX,SG)
+       call VTRISOLVE(AK,BK,CK,SX,SG,OPT)
 
 ! Compute the surface fluxes
 !---------------------------
@@ -5416,7 +5581,7 @@ if ( (trim(name) /= 'S'   ) .and. (trim(name) /= 'Q'   ) .and. &
        if( TYPE=='S' ) then 
           if(associated(SAFDIFFUSE)) SAFDIFFUSE = SX
        endif
-       if( TYPE=='Q' ) then
+       if( TYPE=='Q' ) then  !!! should this be NAME=='Q' ?
           if(associated(QAFDIFFUSE)) QAFDIFFUSE = SX
        endif
 
@@ -5427,6 +5592,7 @@ if ( (trim(name) /= 'S'   ) .and. (trim(name) /= 'Q'   ) .and. &
           SDF = CX * (1.0-DX(:,:,LM))
        endif
 
+!       if(.not.associated(SRG) .and. trim(name)/='QLLS') then
        if(.not.associated(SRG)) then
           deallocate (SG)
        end if
@@ -5964,19 +6130,21 @@ end subroutine RUN1
             RETURN_(ESMF_FAILURE)
          end if
          if( trim(NAME)=='QV' ) then
-            DKX => DKQQ
+            DKX => DKQ
          end if
          if( trim(NAME)=='S') then
-            DKX => DKSS
+            DKX => DKS
          end if
          if( trim(NAME)=='U' .or. trim(NAME)=='V' ) then
-            DKX => DKUU
+            DKX => DKV
          end if
 
 ! Update diffused quantity
 !-------------------------
 
          SX = S
+
+!         if (associated(DSG) .and. trim(NAME)=='QLLS') print *,'DSG is associated for QLLS!!!'
 
          if( associated(DSG) .and. SCM_SL == 0 ) then
             do L=1,LM 
@@ -6725,13 +6893,14 @@ end subroutine RUN1
 
 ! !INTERFACE:
 
-  subroutine VTRISOLVE ( A,B,C,Y,YG )
+  subroutine VTRISOLVE ( A,B,C,Y,YG,OPT )
 
 ! !ARGUMENTS:
 
     real,               dimension(:,:,:),  intent(IN   ) ::  A, B, C
     real(kind=MAPL_R8), dimension(:,:,:),  intent(INOUT) ::  Y
     real,               dimension(:,:),    intent(IN)    ::  YG
+    logical,                               intent(IN)    :: OPT
 
 ! !DESCRIPTION: Solves tridiagonal system that has been LU decomposed
 !   $LU x = f$. This is done by first solving $L g = f$ for $g$, and 
@@ -6776,9 +6945,10 @@ end subroutine RUN1
 
     if(size(YG)>0) then
        Y(:,:,LM)   = (Y(:,:,LM) - C(:,:,LM) * YG        )*B(:,:,LM)
-    else
+    else if (OPT) then
        Y(:,:,LM)   =  Y(:,:,LM)*B(:,:,LM-1)/(B(:,:,LM-1) - A(:,:,LM)*(1.0+C(:,:,LM-1)*B(:,:,LM-1) ))
-    !  Y(:,:,LM)   =  Y(:,:,LM)*B(:,:,LM)/( 1.0+C(:,:,LM)*B(:,:,LM) )     ! Alternate formulation
+    else
+       Y(:,:,LM)   =  Y(:,:,LM)*B(:,:,LM)/( 1.0+C(:,:,LM)*B(:,:,LM) )     ! Alternate formulation
     endif
 
     do L = LM-1,1,-1

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/edmf.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/edmf.F90
@@ -362,7 +362,7 @@ SUBROUTINE RUN_EDMF(its,ite, jts,jte, kts,kte, dt, &   ! Inputs
               end if
            end do
            lts = lts - thv3(IH,JH,kte)
-           L0 = L0/( 1.0 + (mfparams%ent0lts/mfparams%ent0-1.)*(0.5+0.5*tanh(0.25*(lts-18.5))) )
+           L0 = L0/( 1.0 + (mfparams%ent0lts/mfparams%ent0-1.)*(0.5+0.5*tanh(0.3*(lts-18.5))) )
         end if
       else ! if mfparams%ET not 2
         L0 = mfparams%L0

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/edmf.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/edmf.F90
@@ -55,6 +55,7 @@ real, parameter ::     &
     real    :: MFLIMFAC
     real    :: ICE_RAMP
     real    :: PRCPCRIT
+    real    :: TREFF
  endtype EDMFPARAMS_TYPE
  type (EDMFPARAMS_TYPE) :: MFPARAMS
 
@@ -361,7 +362,7 @@ SUBROUTINE RUN_EDMF(its,ite, jts,jte, kts,kte, dt, &   ! Inputs
               end if
            end do
            lts = lts - thv3(IH,JH,kte)
-           L0 = L0/( 1.0 + (mfparams%ent0lts/mfparams%ent0-1.)*(0.5+0.5*tanh(0.3*(lts-19.))) )
+           L0 = L0/( 1.0 + (mfparams%ent0lts/mfparams%ent0-1.)*(0.5+0.5*tanh(0.35*(lts-18.5))) )
         end if
       else ! if mfparams%ET not 2
         L0 = mfparams%L0

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/edmf.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/edmf.F90
@@ -362,7 +362,7 @@ SUBROUTINE RUN_EDMF(its,ite, jts,jte, kts,kte, dt, &   ! Inputs
               end if
            end do
            lts = lts - thv3(IH,JH,kte)
-           L0 = L0/( 1.0 + (mfparams%ent0lts/mfparams%ent0-1.)*(0.5+0.5*tanh(0.35*(lts-18.5))) )
+           L0 = L0/( 1.0 + (mfparams%ent0lts/mfparams%ent0-1.)*(0.5+0.5*tanh(0.25*(lts-18.5))) )
         end if
       else ! if mfparams%ET not 2
         L0 = mfparams%L0

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/shoc.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/shoc.F90
@@ -375,7 +375,7 @@ contains
           if (shocparams%BUOYOPT==2) then
             a_prod_bu = (ggr / thv(i,j,k)) * wthv_sec(i,j,k)
           else
-            a_prod_bu = -1.*wrk*brunt(i,j,k) !+ (ggr / thv(i,j,k))*wthv_mf(i,j,k)
+            a_prod_bu = -1.*wrk*brunt(i,j,k) + (ggr / thv(i,j,k))*wthv_mf(i,j,k)
           end if
 
           buoy_sgs = brunt(i,j,k)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/shoc.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/shoc.F90
@@ -375,7 +375,7 @@ contains
           if (shocparams%BUOYOPT==2) then
             a_prod_bu = (ggr / thv(i,j,k)) * wthv_sec(i,j,k)
           else
-            a_prod_bu = -1.*wrk*brunt(i,j,k) + (ggr / thv(i,j,k))*wthv_mf(i,j,k)
+            a_prod_bu = -1.*wrk*brunt(i,j,k) !+ (ggr / thv(i,j,k))*wthv_mf(i,j,k)
           end if
 
           buoy_sgs = brunt(i,j,k)


### PR DESCRIPTION
Updates to SHOC-MF, including:
- Changed default BUOY_OPTION parameter from 2 to 1
- Adjusted LTS-dependence of EDMF lateral entrainment to extend StCu
- Added EDMF-based diffusion for generic tracers to represent updraft transport.