### PR TITLE
fix and update cice6 parameters

### DIFF
--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
@@ -44,7 +44,7 @@
     lonpnt(1)      =  0.
     latpnt(2)      = -65.
     lonpnt(2)      = -45.
-    histfreq       = 'm','d','x','x','x'
+    histfreq       = 'm','x','x','x','x'
     histfreq_n     =  1 , 1 , 1 , 1 , 1
     histfreq_base  = 'zero'
     hist_avg       = .true.
@@ -240,7 +240,7 @@
     iceruf_ocn      = 0.03
     emissivity      = 0.985
     fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
+    update_ocn_f    = .true.
     l_mpond_fresh   = .false.
     tfrz_option     = 'linear_salt'
     oceanmixed_ice  = .false.

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/540x458/ice_in
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/540x458/ice_in
@@ -44,7 +44,7 @@
     lonpnt(1)      =  0.
     latpnt(2)      = -65.
     lonpnt(2)      = -45.
-    histfreq       = 'm','d','x','x','x'
+    histfreq       = 'm','x','x','x','x'
     histfreq_n     =  1 , 1 , 1 , 1 , 1
     histfreq_base  = 'zero'
     hist_avg       = .true.
@@ -101,8 +101,8 @@
     restart_lvl  = .true.
     tr_pond_topo = .false.
     restart_pond_topo = .false.
-    tr_pond_lvl  = .false.
-    restart_pond_lvl  = .false.
+    tr_pond_lvl  = .true.
+    restart_pond_lvl  = .true.
     tr_snow      = .false.
     restart_snow = .false.
     tr_iso       = .false.
@@ -115,7 +115,7 @@
 
 &thermo_nml
     kitd              = 1
-    ktherm            = 1
+    ktherm            = 2
     conduct           = 'bubbly'
     ksno              = 0.3d0
     a_rapid_mode      =  0.5e-3
@@ -174,19 +174,19 @@
 /
 
 &shortwave_nml
-    shortwave       = 'ccsm3'
+    shortwave       = 'dEdd'
     albedo_type     = 'ccsm3'
     albicev         = 0.78
     albicei         = 0.36
     albsnowv        = 0.98
     albsnowi        = 0.70 
     ahmax           = 0.3
-    R_ice           = 0.
-    R_pnd           = 0.
-    R_snw           = 1.5
+    R_ice           = -1.
+    R_pnd           = -1.
+    R_snw           = -1.
     dT_mlt          = 1.5
     rsnw_mlt        = 1500.
-    kalg            = 0.6
+    kalg            = 0.0
     sw_redist         = .true.
     sw_frac           = 0.9d0
     sw_dtemp          = 0.02d0
@@ -240,7 +240,7 @@
     iceruf_ocn      = 0.03
     emissivity      = 0.985
     fbot_xfer_type  = 'constant'
-    update_ocn_f    = .false.
+    update_ocn_f    = .true.
     l_mpond_fresh   = .false.
     tfrz_option     = 'linear_salt'
     oceanmixed_ice  = .false.


### PR DESCRIPTION
This PR updated some run time CICE6 params based on recent test runs.

* 540x458
   -  fix update_ocn_f (should be true)
   -  set default shortwave to ```dEdd``` scheme
   -  change default dEdd params
   -  do not output dailies by default
* 1440x1080
   -  fix update_ocn_f (should be true)

This PR is zero diff for AMIP and coupled running with CICE4