### PR TITLE
CICE6 cmake and namelist updates for post release v6.5.0 merge

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SeaiceInterfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SeaiceInterfaceGridComp.F90
@@ -2704,9 +2704,13 @@ contains
           DQS     = GEOS_QSAT(TS(:,N), PS, RAMP=0.0, PASCALS=.TRUE.) - QS(:,N)
           QS(:,N) = QS(:,N) + DQS
 
-          LHF     = LHF + EVD * MAPL_ALHS * DTS
+          EVP     = EVP + EVD * DTS
           SHF     = SHF + SHD * DTS
+          LHF     = EVP * MAPL_ALHS
 
+
+          if(associated(SUBLIM )) SUBLIM  = SUBLIM  + EVP    *FR(:,N)
+          if(associated(EVAPOUT)) EVAPOUT = EVAPOUT + EVP    *FR(:,N)
           if(associated(DELTS  )) DELTS   = DELTS   + DTS*CFT*FR(:,N)
           if(associated(DELQS  )) DELQS   = DELQS   + DQS*CFQ*FR(:,N)
           if(associated(TST    )) TST     = TST     + TS(:,N)*FR(:,N)
@@ -2724,6 +2728,8 @@ contains
     if(associated(QST    )) call Normalize(QST,    FRCICE) 
     if(associated(HLATICE)) call Normalize(HLATICE,FRCICE)
     if(associated(SHICE  )) call Normalize(SHICE,  FRCICE)
+    if(associated(SUBLIM )) call Normalize(SUBLIM, FRCICE)
+    if(associated(EVAPOUT)) call Normalize(EVAPOUT, FRCICE)
 
     if(associated(LWNDICE)) call Normalize(LWNDICE,  FRCICE, set_undef=.True.)
           

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
@@ -293,8 +293,6 @@
     restart_hbrine  = .false.
     tr_zaero        = .false.
     modal_aero      = .false.
-    optics_file     = 'unknown'
-    optics_file_fieldname = 'modalBCabsorptionParameter5band'
     skl_bgc         = .false.
     z_tracers       = .false.
     dEdd_algae      = .false.

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/540x458/ice_in
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/540x458/ice_in
@@ -293,8 +293,6 @@
     restart_hbrine  = .false.
     tr_zaero        = .false.
     modal_aero      = .false.
-    optics_file     = 'unknown'
-    optics_file_fieldname = 'modalBCabsorptionParameter5band'
     skl_bgc         = .false.
     z_tracers       = .false.
     dEdd_algae      = .false.

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_cmake/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_cmake/CMakeLists.txt
@@ -29,6 +29,7 @@ list( APPEND CICE6_SRCS
    icepack/columnphysics/icepack_orbital.F90
    icepack/columnphysics/icepack_parameters.F90
    icepack/columnphysics/icepack_shortwave.F90
+   icepack/columnphysics/icepack_shortwave_data.F90
    icepack/columnphysics/icepack_snow.F90
    icepack/columnphysics/icepack_therm_bl99.F90
    icepack/columnphysics/icepack_therm_itd.F90
@@ -40,7 +41,6 @@ list( APPEND CICE6_SRCS
    icepack/columnphysics/icepack_wavefracspec.F90
    icepack/columnphysics/icepack_zbgc.F90
    icepack/columnphysics/icepack_zbgc_shared.F90
-   icepack/columnphysics/icepack_zsalinity.F90
    cicecore/shared/ice_arrays_column.F90
    cicecore/shared/ice_calendar.F90
    cicecore/shared/ice_constants.F90
@@ -52,53 +52,54 @@ list( APPEND CICE6_SRCS
    cicecore/shared/ice_restart_column.F90
    cicecore/shared/ice_restart_shared.F90
    cicecore/shared/ice_spacecurve.F90
-   cicecore/cicedynB/dynamics/ice_dyn_eap.F90
-   cicecore/cicedynB/dynamics/ice_dyn_shared.F90
-   cicecore/cicedynB/dynamics/ice_transport_driver.F90
-   cicecore/cicedynB/dynamics/ice_dyn_evp_1d.F90
-   cicecore/cicedynB/dynamics/ice_transport_remap.F90
-   cicecore/cicedynB/dynamics/ice_dyn_vp.F90
-   cicecore/cicedynB/dynamics/ice_dyn_evp.F90
-   cicecore/cicedynB/general/ice_init.F90
-   cicecore/cicedynB/general/ice_state.F90
-   cicecore/cicedynB/general/ice_flux_bgc.F90
-   cicecore/cicedynB/general/ice_step_mod.F90
-   cicecore/cicedynB/general/ice_forcing_bgc.F90
-   cicecore/cicedynB/general/ice_flux.F90
-   cicecore/cicedynB/general/ice_forcing.F90
-   cicecore/cicedynB/analysis/ice_diagnostics_bgc.F90
-   cicecore/cicedynB/analysis/ice_history_drag.F90
-   cicecore/cicedynB/analysis/ice_history_shared.F90
-   cicecore/cicedynB/analysis/ice_history_mechred.F90
-   cicecore/cicedynB/analysis/ice_history_bgc.F90
-   cicecore/cicedynB/analysis/ice_history.F90
-   cicecore/cicedynB/analysis/ice_history_fsd.F90
-   cicecore/cicedynB/analysis/ice_diagnostics.F90
-   cicecore/cicedynB/analysis/ice_history_snow.F90
-   cicecore/cicedynB/analysis/ice_history_pond.F90
-   cicecore/cicedynB/infrastructure/ice_domain.F90
-   cicecore/cicedynB/infrastructure/ice_grid.F90
-   cicecore/cicedynB/infrastructure/ice_memusage.F90
-   cicecore/cicedynB/infrastructure/ice_restoring.F90
-   cicecore/cicedynB/infrastructure/ice_restart_driver.F90
-   cicecore/cicedynB/infrastructure/comm/mpi/ice_global_reductions.F90
-   cicecore/cicedynB/infrastructure/comm/mpi/ice_reprosum.F90
-   cicecore/cicedynB/infrastructure/comm/mpi/ice_exit.F90
-   cicecore/cicedynB/infrastructure/comm/mpi/ice_timers.F90
-   cicecore/cicedynB/infrastructure/comm/mpi/ice_communicate.F90
-   cicecore/cicedynB/infrastructure/comm/mpi/ice_broadcast.F90
-   cicecore/cicedynB/infrastructure/comm/mpi/ice_gather_scatter.F90
-   cicecore/cicedynB/infrastructure/comm/mpi/ice_boundary.F90
-   cicecore/cicedynB/infrastructure/io/io_netcdf/ice_restart.F90
-   cicecore/cicedynB/infrastructure/io/io_netcdf/ice_history_write.F90
-   cicecore/cicedynB/infrastructure/ice_blocks.F90
-   cicecore/cicedynB/infrastructure/ice_read_write.F90
+   cicecore/cicedyn/dynamics/ice_dyn_core1d.F90
+   cicecore/cicedyn/dynamics/ice_dyn_eap.F90
+   cicecore/cicedyn/dynamics/ice_dyn_shared.F90
+   cicecore/cicedyn/dynamics/ice_transport_driver.F90
+   cicecore/cicedyn/dynamics/ice_dyn_evp1d.F90
+   cicecore/cicedyn/dynamics/ice_transport_remap.F90
+   cicecore/cicedyn/dynamics/ice_dyn_vp.F90
+   cicecore/cicedyn/dynamics/ice_dyn_evp.F90
+   cicecore/cicedyn/general/ice_init.F90
+   cicecore/cicedyn/general/ice_state.F90
+   cicecore/cicedyn/general/ice_flux_bgc.F90
+   cicecore/cicedyn/general/ice_step_mod.F90
+   cicecore/cicedyn/general/ice_forcing_bgc.F90
+   cicecore/cicedyn/general/ice_flux.F90
+   cicecore/cicedyn/general/ice_forcing.F90
+   cicecore/cicedyn/analysis/ice_diagnostics_bgc.F90
+   cicecore/cicedyn/analysis/ice_history_drag.F90
+   cicecore/cicedyn/analysis/ice_history_shared.F90
+   cicecore/cicedyn/analysis/ice_history_mechred.F90
+   cicecore/cicedyn/analysis/ice_history_bgc.F90
+   cicecore/cicedyn/analysis/ice_history.F90
+   cicecore/cicedyn/analysis/ice_history_fsd.F90
+   cicecore/cicedyn/analysis/ice_diagnostics.F90
+   cicecore/cicedyn/analysis/ice_history_snow.F90
+   cicecore/cicedyn/analysis/ice_history_pond.F90
+   cicecore/cicedyn/infrastructure/ice_domain.F90
+   cicecore/cicedyn/infrastructure/ice_grid.F90
+   cicecore/cicedyn/infrastructure/ice_memusage.F90
+   cicecore/cicedyn/infrastructure/ice_restoring.F90
+   cicecore/cicedyn/infrastructure/ice_restart_driver.F90
+   cicecore/cicedyn/infrastructure/comm/mpi/ice_global_reductions.F90
+   cicecore/cicedyn/infrastructure/comm/mpi/ice_reprosum.F90
+   cicecore/cicedyn/infrastructure/comm/mpi/ice_exit.F90
+   cicecore/cicedyn/infrastructure/comm/mpi/ice_timers.F90
+   cicecore/cicedyn/infrastructure/comm/mpi/ice_communicate.F90
+   cicecore/cicedyn/infrastructure/comm/mpi/ice_broadcast.F90
+   cicecore/cicedyn/infrastructure/comm/mpi/ice_gather_scatter.F90
+   cicecore/cicedyn/infrastructure/comm/mpi/ice_boundary.F90
+   cicecore/cicedyn/infrastructure/io/io_netcdf/ice_restart.F90
+   cicecore/cicedyn/infrastructure/io/io_netcdf/ice_history_write.F90
+   cicecore/cicedyn/infrastructure/ice_blocks.F90
+   cicecore/cicedyn/infrastructure/ice_read_write.F90
 )
 
 list( APPEND CICE6_SRCS
    # a single c source file
-   cicecore/cicedynB/infrastructure/ice_shr_reprosum86.c
-   cicecore/cicedynB/infrastructure/ice_memusage_gptl.c
+   cicecore/cicedyn/infrastructure/ice_shr_reprosum86.c
+   cicecore/cicedyn/infrastructure/ice_memusage_gptl.c
    # drivers for mapl: ls -1 cicecore/drivers/mapl/geos/*0
    cicecore/drivers/mapl/geos/CICE_FinalMod.F90
    cicecore/drivers/mapl/geos/CICE_InitMod.F90


### PR DESCRIPTION
This PR updated CMake and ```ice_in``` (CICE6 config file) to be consistent with upstream merge of CICE6.

Zero-diff for AMIP and coupled CICE4.

Depends on https://github.com/GEOS-ESM/CICE/pull/6 and https://github.com/GEOS-ESM/Icepack/pull/5, and https://github.com/GEOS-ESM/GEOSgcm/pull/779

  