### PR TITLE
Fixed uninitialized tep and qp when wstar <= 0.001

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/LockEntrain.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/LockEntrain.F90
@@ -1265,7 +1265,8 @@ contains
         qp   = q(i,j,nlev) + 2.*evap(i,j)/(zrho*wstar)
 !        print *,'tpert=',2.*sh(i,j)/(zrho*wstar*MAPL_CP)
       else
-
+         tep  = t(i,j,nlev) + 0.4
+         qp   = q(i,j,nlev)
       end if
     else   ! tpfac scales up bstar by inv. ratio of
            ! heat-bubble area to stagnant area


### PR DESCRIPTION
When wstar <= 0.001, tep and qp were left uninitialized inside mpbl_depth. These two variables are used later. When the code is build debug, this resulted in NaNs being sent to dqsat. @wmputman and @narnold1 , could you please check if my choice if initialization makes sense...

This PR fixes #930, and quite possibly the issue inside MAPL_LocStream as reported multiple times by @dbarahon 