### PR TITLE
bug fix: remove double-counting of heat corr (StieglitzSnow.F90)

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/StieglitzSnow.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/StieglitzSnow.F90
@@ -671,7 +671,7 @@ contains
           if(-dw > wesn(1) ) then
              dw = -wesn(1)
              evap = -dw/(dts*areasc)
-             hcorr=hcorr+(lhflux-evap*alhv)*areasc
+             !hcorr=hcorr+(lhflux-evap*alhv)*areasc  ! removed, was double-counting corr, see "Store excess heat in hcorr" below; koster+reichle, 31 May 2024
              lhflux=evap*alhv
           endif
           wesn(1)  = wesn(1) + dw


### PR DESCRIPTION
In the rare circumstance when more snow would need to be sublimated than is available in the top layer, the residual energy accounting term was added twice, once here and again ~30 lines further down.

This appears to be a bug.  It was discovered during the review of the land energy budget for M21C.  

Fixing this bug is (probably) a non-0-diff change for the restarts.  It should be non-0-diff for at least some model diagnostics. 

Further examination is on-going. 

cc: @rdkoster 