### PR TITLE
Update FMS CMake target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.17.0
-#bcs_version: &bcs_version v11.4.0
+#baselibs_version: &baselibs_version v8.0.2
+#bcs_version: &bcs_version v11.5.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@3
 
 workflows:
   build-test:
@@ -45,7 +45,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort]
+              compiler: [ifort]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -37,7 +37,7 @@ esma_add_library (${this}
   SRCS ${srcs}
   DEPENDENCIES GEOS_Shared GMAO_mpeu MAPL Chem_Shared Chem_Base esmf)
 
-get_target_property (extra_incs fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property (extra_incs FMS::fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(${this} PRIVATE
    $<BUILD_INTERFACE:${extra_incs}>
    )


### PR DESCRIPTION
As we move to FMS in Baselibs, we shouldn't use the old `fms_r4` and `fms_r8` targets anymore as they are non-standard. Instead we move to `FMS::fms_r4` and `FMS::fms_r8`.

This in combination with other PRs in GEOSgcm v12 testing.

NOTE: CI is failing since it isn't picking up the v12 testing branch.