### PR TITLE
M21C exports and LONG_NAMES for land water and energy balances

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -1553,7 +1553,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'max_water_content'         ,&
+    LONG_NAME          = 'max_soil_water_content_above_wilting_point'         ,&
     UNITS              = 'kg m-2'                    ,&
     SHORT_NAME         = 'CDCR2'                     ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1589,7 +1589,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'interception_loss_energy_flux',&
+    LONG_NAME          = 'interception_loss_latent_heat_flux',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPINT'                    ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1598,7 +1598,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'baresoil_evaporation_energy_flux' ,&
+    LONG_NAME          = 'baresoil_evaporation_latent_heat_flux' ,&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPSOI'                    ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1607,7 +1607,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'transpiration_energy_flux' ,&
+    LONG_NAME          = 'transpiration_latent_heat_flux' ,&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPVEG'                    ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1616,7 +1616,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snow_ice_evaporation_energy_flux_on_land',&
+    LONG_NAME          = 'snowpack_evaporation_latent_heat_flux_on_land',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPICE'                    ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1625,7 +1625,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snowpack_evaporation_energy_flux',&
+    LONG_NAME          = 'snowpack_evaporation_latent_heat_flux',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPSNO'                    ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1922,8 +1922,8 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    SHORT_NAME         = 'SPLAND',                    &
-    LONG_NAME          = 'rate_of_spurious_energy_source_land',&
+    SHORT_NAME         = 'SPLAND',                    &              ! a.k.a. SPSHLAND
+    LONG_NAME          = 'Spurious_sensible_heat_flux_land',&
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1931,8 +1931,17 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    SHORT_NAME         = 'SPWATR',                    &
-    LONG_NAME          = 'rate_of_spurious_water_source_land',&
+    SHORT_NAME         = 'SPLH',                      &
+    LONG_NAME          = 'Spurious_latent_heat_flux_land',&
+    UNITS              = 'W m-2',                     &
+    DIMS               = MAPL_DimsHorzOnly,           &
+    VLOCATION          = MAPL_VLocationNone,          &
+                                           RC=STATUS  )
+  VERIFY_(STATUS)
+
+  call MAPL_AddExportSpec(GC,                    &
+    SHORT_NAME         = 'SPWATR',                    &              ! a.k.a. SPEVLAND
+    LONG_NAME          = 'Spurious_evapotranspiration_flux_land',&
     UNITS              = 'kg m-2 s-1',                &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1941,7 +1950,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SPSNOW',                    &
-    LONG_NAME          = 'rate_of_spurious_snow_energy_source_land',&
+    LONG_NAME          = 'Spurious_snow_energy_flux_land',&
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1985,7 +1994,7 @@ module GEOS_SurfaceGridCompMod
     VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'total_latent_energy_flux'  ,&
+    LONG_NAME          = 'total_latent_heat_flux_consistent_with_evaporation_from_turbulence'  ,&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'LHFX'                      ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -5276,6 +5285,7 @@ module GEOS_SurfaceGridCompMod
     real, pointer, dimension(:,:) :: DWLAND       => NULL()
     real, pointer, dimension(:,:) :: DHLAND       => NULL()
     real, pointer, dimension(:,:) :: SPLAND       => NULL()
+    real, pointer, dimension(:,:) :: SPLH         => NULL()
     real, pointer, dimension(:,:) :: SPWATR       => NULL()
     real, pointer, dimension(:,:) :: SPSNOW       => NULL()
     real, pointer, dimension(:,:) :: RCU          => NULL()
@@ -5579,6 +5589,7 @@ module GEOS_SurfaceGridCompMod
     real, pointer, dimension(:) :: DWLANDTILE       => NULL()
     real, pointer, dimension(:) :: DHLANDTILE       => NULL()
     real, pointer, dimension(:) :: SPLANDTILE       => NULL()
+    real, pointer, dimension(:) :: SPLHTILE         => NULL()
     real, pointer, dimension(:) :: SPWATRTILE       => NULL()
     real, pointer, dimension(:) :: SPSNOWTILE       => NULL()
     real, pointer, dimension(:,:) :: RDU001TILE     => NULL()
@@ -6441,6 +6452,7 @@ module GEOS_SurfaceGridCompMod
     call MAPL_GetPointer(EXPORT  , DWLAND  , 'DWLAND' ,  RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT  , DHLAND  , 'DHLAND' ,  RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT  , SPLAND  , 'SPLAND' ,  RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(EXPORT  , SPLH    , 'SPLH'   ,  RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT  , SPWATR  , 'SPWATR' ,  RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT  , SPSNOW  , 'SPSNOW' ,  RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT  , RDU001  , 'RDU001' ,  RC=STATUS); VERIFY_(STATUS)
@@ -7051,6 +7063,7 @@ module GEOS_SurfaceGridCompMod
     call MKTILE(DWLAND  ,DWLANDTILE  ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(DHLAND  ,DHLANDTILE  ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(SPLAND  ,SPLANDTILE  ,NT,RC=STATUS); VERIFY_(STATUS)
+    call MKTILE(SPLH    ,SPLHTILE    ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(SPWATR  ,SPWATRTILE  ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(SPSNOW  ,SPSNOWTILE  ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(RDU001  ,RDU001TILE  ,NT,RC=STATUS); VERIFY_(STATUS)
@@ -7922,6 +7935,10 @@ module GEOS_SurfaceGridCompMod
        call MAPL_LocStreamTransform( LOCSTREAM,SPLAND,SPLANDTILE, RC=STATUS) 
        VERIFY_(STATUS)
     endif
+    if(associated(SPLH  )) then
+       call MAPL_LocStreamTransform( LOCSTREAM,SPLH  ,SPLHTILE  , RC=STATUS) 
+       VERIFY_(STATUS)
+    endif
     if(associated(SPWATR)) then
        call MAPL_LocStreamTransform( LOCSTREAM,SPWATR,SPWATRTILE, RC=STATUS) 
        VERIFY_(STATUS)
@@ -8564,6 +8581,7 @@ module GEOS_SurfaceGridCompMod
     if(associated(DWLANDTILE  )) deallocate(DWLANDTILE  )
     if(associated(DHLANDTILE  )) deallocate(DHLANDTILE  )
     if(associated(SPLANDTILE  )) deallocate(SPLANDTILE  )
+    if(associated(SPLHTILE    )) deallocate(SPLHTILE    )
     if(associated(SPWATRTILE  )) deallocate(SPWATRTILE  )
     if(associated(SPSNOWTILE  )) deallocate(SPSNOWTILE  )
     if(associated(RDU001TILE  )) deallocate(RDU001TILE  )
@@ -8879,6 +8897,8 @@ module GEOS_SurfaceGridCompMod
       call MAPL_GetPointer(GEX(type), dum, 'DHLAND'  , ALLOC=associated(DHLANDTILE  ), notFoundOK=.true., RC=STATUS)
       VERIFY_(STATUS)
       call MAPL_GetPointer(GEX(type), dum, 'SPLAND'  , ALLOC=associated(SPLANDTILE  ), notFoundOK=.true., RC=STATUS)
+      VERIFY_(STATUS)
+      call MAPL_GetPointer(GEX(type), dum, 'SPLH'    , ALLOC=associated(SPLHTILE    ), notFoundOK=.true., RC=STATUS)
       VERIFY_(STATUS)
       call MAPL_GetPointer(GEX(type), dum, 'SPWATR'  , ALLOC=associated(SPWATRTILE  ), notFoundOK=.true., RC=STATUS)
       VERIFY_(STATUS)
@@ -9525,6 +9545,10 @@ module GEOS_SurfaceGridCompMod
       end if
       if(associated(SPLANDTILE)) then
          call FILLOUT_TILE(GEX(type), 'SPLAND',   SPLANDTILE, XFORM, RC=STATUS)
+         VERIFY_(STATUS)
+      end if
+      if(associated(SPLHTILE  )) then
+         call FILLOUT_TILE(GEX(type), 'SPLH'  ,   SPLHTILE,   XFORM, RC=STATUS)
          VERIFY_(STATUS)
       end if
       if(associated(SPWATRTILE)) then

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -589,7 +589,7 @@ module GEOS_SurfaceGridCompMod
 
     call MAPL_AddImportSpec(GC,                              &
         SHORT_NAME         = 'LWDNSRF',                           &
-        LONG_NAME          = 'surface_downwelling_longwave_flux', &
+        LONG_NAME          = 'surface_absorbed_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -598,7 +598,7 @@ module GEOS_SurfaceGridCompMod
 
     call MAPL_AddImportSpec(GC,                              &
         SHORT_NAME         = 'ALW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -607,7 +607,7 @@ module GEOS_SurfaceGridCompMod
 
     call MAPL_AddImportSpec(GC,                              &
         SHORT_NAME         = 'BLW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2 K-1',                         &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -1770,7 +1770,7 @@ module GEOS_SurfaceGridCompMod
  
    call MAPL_AddExportSpec(GC,                    &
      SHORT_NAME         = 'LWUPSNOW',                    &
-     LONG_NAME          = 'surface_upwelling_longwave_flux_snow',         &
+     LONG_NAME          = 'surface_emitted_longwave_flux_snow',         &
      UNITS              = 'W m-2',                     &
      DIMS               = MAPL_DimsHorzOnly,           &
      VLOCATION          = MAPL_VLocationNone,          &
@@ -1779,7 +1779,7 @@ module GEOS_SurfaceGridCompMod
  
    call MAPL_AddExportSpec(GC,                    &
      SHORT_NAME         = 'LWDNSNOW',                    &
-     LONG_NAME          = 'surface_downwelling_longwave_flux_snow',         &
+     LONG_NAME          = 'surface_absorbed_longwave_flux_snow',         &
      UNITS              = 'W m-2',                     &
      DIMS               = MAPL_DimsHorzOnly,           &
      VLOCATION          = MAPL_VLocationNone,          &
@@ -1967,7 +1967,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_outgoing_longwave_flux',&
+    LONG_NAME          = 'surface_emitted_longwave_flux',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'HLWUP'                     ,&
     DIMS               = MAPL_DimsHorzOnly           ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlake_GridComp/GEOS_LakeGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlake_GridComp/GEOS_LakeGridComp.F90
@@ -192,7 +192,7 @@ module GEOS_LakeGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
-        LONG_NAME          = 'surface_outgoing_longwave_flux',&
+        LONG_NAME          = 'surface_emitted_longwave_flux',&
         UNITS              = 'W m-2'                     ,&
         SHORT_NAME         = 'HLWUP'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
@@ -600,7 +600,7 @@ module GEOS_LakeGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'ALW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -609,7 +609,7 @@ module GEOS_LakeGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'BLW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2 K-1',                         &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -672,7 +672,7 @@ module GEOS_LakeGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'LWDNSRF',                           &
-        LONG_NAME          = 'surface_downwelling_longwave_flux', &
+        LONG_NAME          = 'surface_absorbed_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOS_LandGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOS_LandGridComp.F90
@@ -656,6 +656,11 @@ contains
             RC=STATUS  )
        VERIFY_(STATUS)
        call MAPL_AddExportSpec ( GC, &
+            SHORT_NAME = 'SPLH', &
+            CHILD_ID = CATCH(1), &
+            RC=STATUS  )
+       VERIFY_(STATUS)
+       call MAPL_AddExportSpec ( GC, &
             SHORT_NAME = 'SPWATR', &
             CHILD_ID = CATCH(1), &
             RC=STATUS  )
@@ -1114,9 +1119,12 @@ contains
        VERIFY_(STATUS)
        call MAPL_AddExportSpec ( GC, SHORT_NAME = 'DHLAND' ,  CHILD_ID = CATCHCN(1), RC=STATUS  )
        VERIFY_(STATUS)
-       call MAPL_AddExportSpec ( GC, SHORT_NAME = 'SPLAND' ,  CHILD_ID = CATCHCN(1), RC=STATUS  )
+       call MAPL_AddExportSpec ( GC, SHORT_NAME = 'SPLAND' ,  CHILD_ID = CATCHCN(1), RC=STATUS  )              ! a.k.a. SPSHLAND
        VERIFY_(STATUS)
-       call MAPL_AddExportSpec ( GC, SHORT_NAME = 'SPWATR' ,  CHILD_ID = CATCHCN(1), RC=STATUS  )
+! will need later for CatchCN:
+!       call MAPL_AddExportSpec ( GC, SHORT_NAME = 'SPLH'   ,  CHILD_ID = CATCHCN(1), RC=STATUS  )
+!       VERIFY_(STATUS)
+       call MAPL_AddExportSpec ( GC, SHORT_NAME = 'SPWATR' ,  CHILD_ID = CATCHCN(1), RC=STATUS  )              ! a.k.a. SPEVLAND
        VERIFY_(STATUS)
        call MAPL_AddExportSpec ( GC, SHORT_NAME = 'SPSNOW' ,  CHILD_ID = CATCHCN(1), RC=STATUS  )
        VERIFY_(STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
@@ -421,7 +421,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'surface_downwelling_longwave_flux',&
+         LONG_NAME          = 'surface_absorbed_longwave_flux',&
          UNITS              = 'W m-2'                       ,&
          SHORT_NAME         = 'LWDNSRF'                     ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -430,7 +430,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux',&
+         LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux',&
          UNITS              = 'W m-2'                       ,&
          SHORT_NAME         = 'ALW'                         ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -439,7 +439,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux',&
+         LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux',&
          UNITS              = 'W_m-2 K-1'                   ,&
          SHORT_NAME         = 'BLW'                         ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -1718,7 +1718,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_outgoing_longwave_flux',&
+    LONG_NAME          = 'surface_emitted_longwave_flux',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'HLWUP'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2408,7 +2408,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'LWUPSNOW',                    &
-    LONG_NAME          = 'surface_upwelling_longwave_flux_snow',         &
+    LONG_NAME          = 'surface_emitted_longwave_flux_snow',         &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2417,7 +2417,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'LWDNSNOW',                    &
-    LONG_NAME          = 'surface_downwelling_longwave_flux_snow',         &
+    LONG_NAME          = 'surface_absorbed_longwave_flux_snow',         &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
@@ -860,7 +860,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddInternalSpec(GC                  ,&
-    LONG_NAME          = 'max_water_content'         ,&
+    LONG_NAME          = 'max_soil_water_content_above_wilting_point'         ,&
     UNITS              = 'kg m-2'                    ,&
     SHORT_NAME         = 'CDCR2'                     ,&
     FRIENDLYTO         = trim(COMP_NAME)             ,&
@@ -1619,7 +1619,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'interception_loss_energy_flux',&
+    LONG_NAME          = 'interception_loss_latent_heat_flux',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPINT'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1628,7 +1628,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'baresoil_evap_energy_flux' ,&
+    LONG_NAME          = 'baresoil_evaporation_latent_heat_flux' ,&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPSOI'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1637,7 +1637,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'transpiration_energy_flux' ,&
+    LONG_NAME          = 'transpiration_latent_heat_flux' ,&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPVEG'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1646,7 +1646,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snow_ice_evaporation_energy_flux_on_land',&
+    LONG_NAME          = 'snowpack_evaporation_latent_heat_flux',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPICE'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1683,7 +1683,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snowpack_evaporation_energy_flux',&
+    LONG_NAME          = 'snowpack_evaporation_latent_heat_flux',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPSNO'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1746,7 +1746,7 @@ subroutine SetServices ( GC, RC )
 
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'total_latent_energy_flux'  ,&
+    LONG_NAME          = 'total_latent_heat_flux_consistent_with_evaporation_from_turbulence'  ,&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'HLATN'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2097,7 +2097,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'change_upward_sensible_energy_flux',&
+    LONG_NAME          = 'change_upward_sensible_heat_flux',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'DELSH'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2584,8 +2584,8 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    SHORT_NAME         = 'SPLAND',                    &
-    LONG_NAME          = 'rate_of_spurious_energy_source_land',&
+    SHORT_NAME         = 'SPLAND',                    &              ! a.k.a. SPSHLAND
+    LONG_NAME          = 'Spurious_sensible_heat_flux_land',&
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2593,8 +2593,17 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    SHORT_NAME         = 'SPWATR',                    &
-    LONG_NAME          = 'rate_of_spurious_water_source_land',&
+    SHORT_NAME         = 'SPLH',                      &
+    LONG_NAME          = 'Spurious_latent_heat_flux_land',&
+    UNITS              = 'W m-2',                     &
+    DIMS               = MAPL_DimsTileOnly,           &
+    VLOCATION          = MAPL_VLocationNone,          &
+                                           RC=STATUS  )
+  VERIFY_(STATUS)
+
+  call MAPL_AddExportSpec(GC,                    &
+    SHORT_NAME         = 'SPWATR',                    &              ! a.k.a. SPEVLAND
+    LONG_NAME          = 'Spurious_evapotranspiration_flux_land',&
     UNITS              = 'kg m-2 s-1',                &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2603,7 +2612,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SPSNOW',                    &
-    LONG_NAME          = 'rate_of_spurious_snow_energy_source_land',&
+    LONG_NAME          = 'Spurious_snow_energy_flux_land',&
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3933,7 +3942,8 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         real, dimension(:),   pointer :: DWLAND
         real, dimension(:),   pointer :: DHLAND
         real, dimension(:),   pointer :: SPLAND
-        real, dimension(:),   pointer :: SPWATR
+        real, dimension(:),   pointer :: SPLH
+        real, dimension(:),   pointer :: SPWATR  
         real, dimension(:),   pointer :: SPSNOW
 
         real, dimension(:),   pointer :: WAT10CM
@@ -3981,11 +3991,10 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         real,pointer,dimension(:) :: SHSNOW1, AVETSNOW1, WAT10CM1, WATSOI1, ICESOI1
         real,pointer,dimension(:) :: LHSNOW1, LWUPSNOW1, LWDNSNOW1, NETSWSNOW
         real,pointer,dimension(:) :: TCSORIG1, TPSN1IN1, TPSN1OUT1, FSW_CHANGE
-	real,pointer,dimension(:) :: WCHANGE, ECHANGE, HSNACC, EVACC, SHACC
+	real,pointer,dimension(:) :: WCHANGE, ECHANGE, HSNACC, LHOUT, EVACC, LHACC, SHACC
 	real,pointer,dimension(:) :: SNOVR, SNOVF, SNONR, SNONF
 	real,pointer,dimension(:) :: VSUVR, VSUVF
 	real,pointer,dimension(:) :: ALWX, BLWX
-        real,pointer,dimension(:) :: LHACC, SUMEV
         real,pointer,dimension(:) :: FICE1
         real,pointer,dimension(:) :: SLDTOT
  
@@ -4086,7 +4095,7 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         type(OFFLINE_WRAP)          :: wrap
         integer                     :: OFFLINE_MODE
         real,dimension(:,:),allocatable :: ALWN, BLWN
-        ! un-adelterated TC's and QC's
+        ! un-adulterated TC's and QC's
         real, pointer               :: TC1_0(:), TC2_0(:),  TC4_0(:)
         real, pointer               :: QA1_0(:), QA2_0(:),  QA4_0(:)
 
@@ -4216,8 +4225,8 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         call MAPL_Get ( MAPL                 ,&
              RUNALARM  = ALARM                            ,&
              ORBIT     = ORBIT                            ,&
-             TILELATS  = LATS                             ,&
-             TILELONS  = LONS                             ,&
+             TILELATS  = LATS                             ,&      ! [radians]
+             TILELONS  = LONS                             ,&      ! [radians]
              INTERNAL_ESMF_STATE = INTERNAL               ,&
              RC=STATUS )
         VERIFY_(STATUS)
@@ -4477,6 +4486,7 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         call MAPL_GetPointer(EXPORT,DWLAND, 'DWLAND' ,             RC=STATUS); VERIFY_(STATUS)
         call MAPL_GetPointer(EXPORT,DHLAND, 'DHLAND' ,             RC=STATUS); VERIFY_(STATUS)
         call MAPL_GetPointer(EXPORT,SPLAND, 'SPLAND' ,             RC=STATUS); VERIFY_(STATUS)
+        call MAPL_GetPointer(EXPORT,SPLH,   'SPLH'   ,             RC=STATUS); VERIFY_(STATUS)
         call MAPL_GetPointer(EXPORT,SPWATR, 'SPWATR' ,             RC=STATUS); VERIFY_(STATUS)
         call MAPL_GetPointer(EXPORT,SPSNOW, 'SPSNOW' ,             RC=STATUS); VERIFY_(STATUS)
         call MAPL_GetPointer(EXPORT,RMELTDU001,'RMELTDU001',  RC=STATUS); VERIFY_(STATUS)
@@ -4514,34 +4524,36 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         allocate(RDC      (NTILES))  
         if (.not. associated(VISDF)) allocate(VISDF(NTILES))
         if (.not. associated(NIRDF)) allocate(NIRDF(NTILES))
-	allocate(UUU      (NTILES))
-	allocate(RHO      (NTILES))
-	allocate(ZVG      (NTILES))
-	allocate(LAI0     (NTILES))
-	allocate(GRN0     (NTILES))
-	allocate(Z0       (NTILES))
-	allocate(D0       (NTILES))
-	allocate(SFMC     (NTILES))
-	allocate(RZMC     (NTILES))
-	allocate(PRMC     (NTILES))
-	allocate(ENTOT    (NTILES))
-	allocate(ghflxsno (NTILES))
-	allocate(ghflxtskin(NTILES))
-	allocate(WTOT     (NTILES))
-	allocate(WCHANGE  (NTILES))
-	allocate(ECHANGE  (NTILES))
-	allocate(HSNACC   (NTILES))
-	allocate(EVACC    (NTILES))
-	allocate(SHACC    (NTILES))
-	allocate(VSUVR    (NTILES))
-	allocate(VSUVF    (NTILES))
-	allocate(SNOVR    (NTILES))
-	allocate(SNOVF    (NTILES))
-	allocate(SNONR    (NTILES))
-	allocate(SNONF    (NTILES))
-	allocate(CAT_ID   (NTILES))
-	allocate(ALWX     (NTILES))
-	allocate(BLWX     (NTILES))
+        allocate(UUU      (NTILES))
+        allocate(RHO      (NTILES))
+        allocate(ZVG      (NTILES))
+        allocate(LAI0     (NTILES))
+        allocate(GRN0     (NTILES))
+        allocate(Z0       (NTILES))
+        allocate(D0       (NTILES))
+        allocate(SFMC     (NTILES))
+        allocate(RZMC     (NTILES))
+        allocate(PRMC     (NTILES))
+        allocate(ENTOT    (NTILES))
+        allocate(ghflxsno (NTILES))
+        allocate(ghflxtskin(NTILES))
+        allocate(WTOT     (NTILES))
+        allocate(WCHANGE  (NTILES))
+        allocate(ECHANGE  (NTILES))
+        allocate(HSNACC   (NTILES))
+        allocate(LHOUT    (NTILES))
+        allocate(EVACC    (NTILES))
+        allocate(LHACC    (NTILES))
+        allocate(SHACC    (NTILES))
+        allocate(VSUVR    (NTILES))
+        allocate(VSUVF    (NTILES))
+        allocate(SNOVR    (NTILES))
+        allocate(SNOVF    (NTILES))
+        allocate(SNONR    (NTILES))
+        allocate(SNONF    (NTILES))
+        allocate(CAT_ID   (NTILES))
+        allocate(ALWX     (NTILES))
+        allocate(BLWX     (NTILES))
         allocate(SHSNOW1   (NTILES))
         allocate(AVETSNOW1 (NTILES))
         allocate(WAT10CM1  (NTILES))
@@ -4554,8 +4566,6 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         allocate(TCSORIG1  (NTILES))
         allocate(TPSN1IN1  (NTILES))
         allocate(TPSN1OUT1 (NTILES))
-        allocate(LHACC     (NTILES))
-        allocate(SUMEV     (NTILES))
         allocate(FICE1     (NTILES)) 
         allocate(SLDTOT    (NTILES))             ! total solid precip
         allocate(FSW_CHANGE(NTILES))
@@ -5452,7 +5462,7 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
 
              RA(:,FSAT), RA(:,FTRN), RA(:,FWLT), RA(:,FSNW)       ,&
 
-             ZTH, DRPAR, DFPAR, SWNETFREE, SWNETSNOW, LWDNSRF     ,&
+             ZTH, DRPAR, DFPAR, SWNETFREE, SWNETSNOW, LWDNSRF     ,&  ! LWDNSRF = *absorbed* longwave only (excl reflected)
 
              PS*.01                                               ,&
 
@@ -5474,14 +5484,14 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
              CAPAC, CATDEF, RZEXC, SRFEXC, GHTCNT, TSURF          ,&
              WESNN, HTSNNN, SNDZN                                 ,&
 
-             EVAPOUT, SHOUT, RUNOFF, EVPINT, EVPSOI, EVPVEG       ,&
-             EVPICE                                               ,&
+             EVAPOUT, SHOUT, RUNOFF, EVPINT, EVPSOI, EVPVEG       ,&  ! EVAPOUT:                        kg/m2/s
+             EVPICE                                               ,&  ! EVPINT, EVPSOI, EVPVEG, EVPICE: W/m2
              BFLOW                                                ,&
              RUNSURF                                              ,&
              SMELT                                                ,&
-             HLWUP                                                ,&
+             HLWUP                                                ,&  ! *emitted* longwave only (excl reflected)
              SWNDSRF                                              ,&
-             HLATN                                                ,&
+             LHOUT                                                ,&  ! renamed from HLATN to avoid confusion w/ HLATN=LHFX in SurfaceGC
              QINFIL                                               ,&
              AR1                                                  ,&
              AR2                                                  ,&
@@ -5492,14 +5502,16 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
              TC(:,FSNW)                                           ,&
              ASNOW                                                ,&
              TP1, TP2, TP3, TP4, TP5, TP6,  SFMC, RZMC, PRMC      ,&
-             ENTOT,WTOT, WCHANGE, ECHANGE, HSNACC, EVACC, SHACC   ,&
+             ENTOT,WTOT, WCHANGE, ECHANGE, HSNACC                 ,&      
+             EVACC                                                ,&  ! kg/m2/s 
+             LHACC, SHACC                                         ,&  ! W/m2
              SHSNOW1, AVETSNOW1, WAT10CM1, WATSOI1, ICESOI1       ,&
              LHSNOW1, LWUPSNOW1, LWDNSNOW1, NETSWSNOW             ,&
              TCSORIG1, TPSN1IN1, TPSN1OUT1,FSW_CHANGE             ,&
              lonbeg,lonend,latbeg,latend                          ,&
              TC1_0=TC1_0, TC2_0=TC2_0, TC4_0=TC4_0                ,&
              QA1_0=QA1_0, QA2_0=QA2_0, QA4_0=QA4_0                ,&
-             RCONSTIT=RCONSTIT, RMELT=RMELT, TOTDEPOS=TOTDEPOS, LHACC=LHACC)
+             RCONSTIT=RCONSTIT, RMELT=RMELT, TOTDEPOS=TOTDEPOS)
 
         end if
         
@@ -5519,14 +5531,21 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         call MAPL_TimerOff ( MAPL, "-CATCH" )
 
         if (OFFLINE_MODE /=0) then
+
+           ! in offline mode, disregard the GCM-specific TC/QC modifications and the 
+           ! accounting terms for turbulent fluxes (but not snow heat accounting term)
+
            TC(:,FSAT) = TC1_0
            TC(:,FTRN) = TC2_0
            TC(:,FWLT) = TC4_0
            QC(:,FSAT) = QA1_0
            QC(:,FTRN) = QA2_0
            QC(:,FWLT) = QA4_0
-           EVACC = 0.0
-           SHACC = 0.0
+           
+           EVACC      = 0.0
+           LHACC      = 0.0
+           SHACC      = 0.0
+
         endif
 
         QC(:,FSNW) =  GEOS_QSAT ( TC(:,FSNW), PS, PASCALS=.true., RAMP=0.0 )
@@ -5616,21 +5635,7 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
            TST     = TST   +           TC(:,N)          *FR(:,N)
            QST     = QST   +           QC(:,N)          *FR(:,N)
         end do
-
-        if (OFFLINE_MODE == 0) then
-!amm add correction term to latent heat diagnostics (HLATN is always allocated)
-!    this will impact the export LHLAND
-        HLATN = HLATN - LHACC
-! also add some portion of the correction term to evap from soil, int, veg and snow
-        SUMEV = EVPICE+EVPSOI+EVPVEG+EVPINT
-        where(SUMEV>0.)
-        EVPICE = EVPICE - EVACC*EVPICE/SUMEV
-        EVPSOI = EVPSOI - EVACC*EVPSOI/SUMEV
-        EVPINT = EVPINT - EVACC*EVPINT/SUMEV
-        EVPVEG = EVPVEG - EVACC*EVPVEG/SUMEV
-        endwhere
-        endif
-
+        
         if(associated( LST  )) LST    = TST
         if(associated( TPSURF))TPSURF = TSURF
         if(associated( WET1 )) WET1   = max(min(SFMC / POROS,1.0),0.0)
@@ -5644,13 +5649,80 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
 
         if(associated(EVPSNO)) EVPSNO = EVPICE
         if(associated(SUBLIM)) SUBLIM = EVPICE*(1./MAPL_ALHS)*FR(:,FSNW)
-        if(associated(EVLAND)) EVLAND = EVAPOUT-EVACC
         if(associated(PRLAND)) PRLAND = PCU+PLS+SLDTOT
         if(associated(SNOLAND)) SNOLAND = SLDTOT     ! note, not just SNO
         if(associated(DRPARLAND)) DRPARLAND = DRPAR
         if(associated(DFPARLAND)) DFPARLAND = DFPAR
-        if(associated(LHLAND)) LHLAND = HLATN
-        if(associated(SHLAND)) SHLAND = SHOUT-SHACC
+       
+        ! -----------------------------------------------------------------------------------------
+        !
+        ! IMPORTANT: Surface turbulent fluxes in [*]LAND exports are returned as calculated by Catchment! 
+        !
+        ! For completeness, also return the "accounting" terms that represent the difference between
+        ! the flux calculated by Catchment and the flux calculated by the atmosphere (Turbulence GC).
+        !
+        !   EVAP__calculated_by_atmosphere = EVLAND - EVACC     kg/m2/s
+        !   EFLUX_calculated_by_atmosphere = LHLAND - LHACC     W/m2      
+        !   HFLUX_calculated_by_atmosphere = SHLAND - SHACC     W/m2
+        !
+        ! Note: LHACC added for completeness and consistency with the mass flux term (EVACC);
+        !       strictly speaking, the atmosphere only receives the evap mass flux and the sensible 
+        !       heat flux, but not the latent heat flux.
+        !
+        ! In previous model versions, the [*]ACC accouting terms were subtracted from the
+        ! Catchment-calculated fluxes, thus returning the turbulent fluxes as calculated by 
+        ! the atmosphere.
+        !
+        ! Note: In offline mode, the [*]ACC accounting terms are zeroed out above. 
+        !
+        ! - reichle, 17 July 2024
+         
+        if(associated(EVLAND)) EVLAND = EVAPOUT   ! EVLAND is what Catchment thinks it should be 
+        if(associated(LHLAND)) LHLAND = LHOUT     ! LHLAND is what Catchment thinks it should be
+        if(associated(SHLAND)) SHLAND = SHOUT     ! SHLAND is what Catchment thinks it should be
+        
+        if(associated(SPWATR)) SPWATR = EVACC
+        if(associated(SPLH  )) SPLH   = LHACC
+        if(associated(SPLAND)) SPLAND = SHACC
+        
+        ! Compute latent heat flux that is consistent with the evap mass flux as calculated 
+        ! by the atmosphere (Turbulence GC).  In the "flx" HISTORY collection, EFLUX is 
+        ! the all-surface latent heat flux, with HLATN (as below) being the land contribution.
+
+        HLATN   = LHOUT   - LHACC
+
+        ! In previous model versions, the evap mass flux EVAPOUT and the sensible heat flux SHOUT
+        ! were returned as calculated by Catchment.  These diagnostic are not written in MERRA-2.
+        ! In FP and GEOSIT, they are only included in ocean ("ocn") Collections.  They appear to 
+        ! be used also in the "gmichem" and "S2S" collections. 
+        ! For consistency with previous model versions, keep returning EVAPOUT and SHOUT as 
+        ! calculated by Catchment.
+
+        ! Overview of surface turbulent flux variables in subroutine catchment(), the Catch, Land, and Surface Gridded Components, and the M21 "lnd" HISTORY collection
+        !
+        !-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+        ! Description        | Units   | catchment() | CatchGC                     | LandGC  | SurfaceGC              | HISTORY    | Notes                                                        |
+        !                    |         | ArgName     | VarName | export            | export  | export  | averaged     | M21C       |                                                              |
+        !                    |         |             |         | (tile)            | (tile)  | (grid)  | over         | "lnd"      |                                                              |
+        !=========================================================================================================================================================================================|
+        ! evap mass flux     | kg/m2/s | EVAP        | EVAPOUT | EVLAND            | EVLAND  | EVLAND  | land         | EVLAND     |                                                              |
+        ! evap mass flux     | kg/m2/s | -           | -       | EVAPOUT           | EVAPOUT | EVAPOUT | all surfaces | n/a        |                                                              |
+        ! EV accounting term | kg/m2/s | EVACC       | EVACC   | SPWATR            | SPWATR  | SPWATR  | land         | SPEVLAND   | EVLAND-SPEVLAND = EVAP_from_TurbGC [100% land]               |
+        !-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+        ! latent heat flux   | W/m2    | LHFLUX      | LHOUT   | LHLAND            | LHLAND  | LHLAND  | land         | LHLAND     |                                                              |
+        ! latent heat flux   | W/m2    | -           | -       | HLATN=LHOUT-LHACC | HLATN   | LHFX    | all surfaces | n/a        | consistent w/ EVAP_from_TurbGC [100% land]                   |
+        ! LH accounting term | W/m2    | LHACC       | LHACC   | SPLH              | SPLH    | SPLH    | land         | SPLHLAND   | (LHLAND-SPLHLAND) consistent w/ EVAP_from_TurbGC [100% land] |
+        ! LH component       | W/m2    | EINT        | EVPINT  | EVPINT            | EVPINT  | EVPINT  | land         | LHLANDINTR |                                                              |
+        ! LH component       | W/m2    | ESOI        | EVPSOI  | EVPSOI            | EVPSOI  | EVPSOI  | land         | LHLANDSOIL |                                                              | 
+        ! LH component       | W/m2    | EVEG        | EVPVEG  | EVPVEG            | EVPVEG  | EVPVEG  | land         | LHLANDTRNS |                                                              |
+        ! LH component       | W/m2    | ESNO        | EVPICE  | EVPICE            | EVPICE  | EVPICE  | land         | LHLANDSBLN |                                                              |
+        !-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+        ! sensible heat flux | W/m2    | SHFLUX      | SHOUT   | SHLAND            | SHLAND  | SHLAND  | land         | SHLAND     |                                                              |
+        ! sensible heat flux | W/m2    | -           | -       | SHOUT             | SHOUT   | SHOUT   | all surfaces | n/a        |                                                              |
+        ! SH accounting term | W/m2    | SHACC       | SHACC   | SPLAND            | SPLAND  | SPLAND  | land         | SPSHLAND   | SHLAND-SPSHLAND = SH_from_TurbGC [for 100% land]             |
+        !-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+                                                                                                         
+        
         if(associated(SWLAND)) SWLAND = SWNDSRF
         if(associated(LWLAND)) LWLAND = LWNDSRF
         if(associated(GHLAND)) GHLAND = GHFLX
@@ -5674,8 +5746,6 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         if(associated(TSLAND)) TSLAND = WESNN (1,:) + WESNN (2,:) + WESNN (3,:)
         if(associated(DWLAND)) DWLAND = WCHANGE
         if(associated(DHLAND)) DHLAND = ECHANGE
-        if(associated(SPLAND)) SPLAND = SHACC
-        if(associated(SPWATR)) SPWATR = EVACC
         if(associated(SPSNOW)) SPSNOW = HSNACC
 
         if(associated(FRSAT )) FRSAT  = max( min( FR(:,FSAT),1.0 ), 0.0 )
@@ -5821,15 +5891,15 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
         deallocate(LWDNSNOW1)
         deallocate(NETSWSNOW)
         deallocate(TCSORIG1 )
-        deallocate(LHACC )
-        deallocate(SUMEV )
         deallocate(TPSN1IN1 )
         deallocate(TPSN1OUT1)
         deallocate(GHFLXTSKIN)
         deallocate(WCHANGE  )
         deallocate(ECHANGE  )
         deallocate(HSNACC   )
+        deallocate(LHOUT    )
         deallocate(EVACC    )
+        deallocate(LHACC    )
         deallocate(SHACC    )
         !deallocate(VISDF    )
         !deallocate(NIRDF    )
@@ -5978,7 +6048,7 @@ subroutine RUN0(gc, import, export, clock, rc)
   call MAPL_GetPointer(import, ps, 'PS', rc=status)
   VERIFY_(status)
 
-  ! Pointers to EXPOERTs
+  ! Pointers to EXPORTs
   call MAPL_GetPointer(export, asnow, 'ASNOW', rc=status)
   VERIFY_(status)
   call MAPL_GetPointer(export, emis, 'EMIS', rc=status)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
@@ -132,14 +132,14 @@
       CONTAINS
 
       SUBROUTINE CATCHMENT (                                                   &
-                     NCH, LONS, LATS, DTSTEP, UFW4RO, FWETC, FWETL,            &
-                     cat_id,ITYP,DZSF,TRAINC,TRAINL, TSNOW, TICE, TFRZR, UM,   &
+                     NCH, LONS, LATS, DTSTEP, UFW4RO, FWETC, FWETL,            &  ! LONS, LATS are in [radians] !!!
+                     cat_id,ITYP,DZSF,TRAINC,TRAINL, TSNOW, TICE, TFRZR, UM,   &  ! cat_id is set to no-data in GEOS_CatchGridcomp !!!
                      ETURB1, DEDQA1, DEDTC1, HSTURB1,DHSDQA1, DHSDTC1,         &
                      ETURB2, DEDQA2, DEDTC2, HSTURB2,DHSDQA2, DHSDTC2,         &
                      ETURB4, DEDQA4, DEDTC4, HSTURB4,DHSDQA4, DHSDTC4,         &
                      ETURBS, DEDQAS, DEDTCS, HSTURBS,DHSDQAS, DHSDTCS,         &
                      TM, QM, ra1, ra2, ra4, raS, SUNANG, PARDIR, PARDIF,       &
-                     SWNETF,SWNETS,  HLWDWN, PSUR,  ZLAI,   GREEN,  Z2,        &
+                     SWNETF,SWNETS,  HLWDWN, PSUR,  ZLAI,   GREEN,  Z2,        &  ! HLWDWN = *absorbed* longwave only (excl reflected)
                      SQSCAT, RSOIL1, RSOIL2,   RDC,                            &
                      QSAT1, DQS1, ALW1, BLW1,  QSAT2, DQS2, ALW2, BLW2,        &
                      QSAT4, DQS4, ALW4, BLW4,  QSATS, DQSS, ALWS, BLWS,        &
@@ -150,19 +150,20 @@
                      TC1, TC2, TC4, QA1, QA2, QA4, CAPAC,                      &
                      CATDEF, RZEXC, srfexc, GHTCNT, TSURF,                     &
                      WESNN, HTSNNN, SNDZN,                                     &
-                     EVAP, SHFLUX, RUNOFF,                                     &
-                     EINT, ESOI, EVEG, ESNO,  BFLOW,RUNSRF,SMELT,              &
-                     HLWUP,SWLAND,HLATN,QINFIL,AR1, AR2, RZEQ,                 &
+                     EVAP, SHFLUX, RUNOFF,                                     &  ! EVAP:                   kg/m2/s
+                     EINT, ESOI, EVEG, ESNO,  BFLOW,RUNSRF,SMELT,              &  ! EINT, ESOI, EVEG, ESNO: W/m2
+                     HLWUP,SWLAND,LHFLUX,QINFIL,AR1, AR2, RZEQ,                &  ! HLWUP = *emitted* longwave only (excl reflected)
                      GHFLUX, GHFLUXSNO, GHTSKIN, TPSN1, ASNOW0,                &
                      TP1, TP2, TP3, TP4, TP5, TP6,                             &
                      sfmc, rzmc, prmc, entot, wtot, WCHANGE, ECHANGE, HSNACC,  &
-                     EVACC, SHACC,                                             &
+                     EVACC,                                                    &  ! kg/m2/s
+                     LHACC, SHACC,                                             &  ! W/m2
                      SH_SNOW, AVET_SNOW, WAT_10CM, TOTWAT_SOIL, TOTICE_SOIL,   &
                      LH_SNOW, LWUP_SNOW, LWDOWN_SNOW, NETSW_SNOW,              &
                      TCSORIG, TPSN1IN, TPSN1OUT,FSW_CHANGE ,                   &
                      lonbeg,lonend,latbeg,latend,                              &
-                     TC1_0, TC2_0, TC4_0, QA1_0, QA2_0, QA4_0, EACC_0,         &
-                     RCONSTIT, RMELT, TOTDEPOS,  LHACC)
+                     TC1_0, TC2_0, TC4_0, QA1_0, QA2_0, QA4_0, EACC_0,         &  ! OPTIONAL
+                     RCONSTIT, RMELT, TOTDEPOS )
 
       IMPLICIT NONE
 
@@ -215,10 +216,10 @@
 
       REAL, INTENT(OUT), DIMENSION(NCH) ::      EVAP, SHFLUX, RUNOFF,          &
                      EINT, ESOI, EVEG, ESNO, BFLOW,RUNSRF,SMELT,               &
-                     HLWUP,SWLAND,HLATN,QINFIL,AR1, AR2, RZEQ,                 &
+                     HLWUP,SWLAND,LHFLUX,QINFIL,AR1, AR2, RZEQ,                &
                      GHFLUX, TPSN1, ASNOW0, TP1, TP2, TP3, TP4, TP5, TP6,      &
                      sfmc, rzmc, prmc, entot, wtot, tsurf, WCHANGE, ECHANGE,   &
-                     HSNACC, EVACC, SHACC
+                     HSNACC, EVACC, LHACC, SHACC
       REAL, INTENT(OUT), DIMENSION(NCH) :: GHFLUXSNO, GHTSKIN
 
       REAL, INTENT(OUT), DIMENSION(NCH) :: SH_SNOW, AVET_SNOW,         &
@@ -229,8 +230,6 @@
                      FSW_CHANGE
 
       
-      REAL, INTENT(OUT), DIMENSION(NCH), OPTIONAL :: LHACC
-
       REAL, INTENT(OUT), DIMENSION(NCH), OPTIONAL :: TC1_0,TC2_0,TC4_0
       REAL, INTENT(OUT), DIMENSION(NCH), OPTIONAL :: QA1_0,QA2_0,QA4_0 	
       REAL, INTENT(OUT), DIMENSION(NCH), OPTIONAL :: EACC_0 
@@ -281,7 +280,8 @@
               SCLAI, tsn1, tsn2, tsn3, hold, hnew, emaxrz, dedtc0,             &
               dhsdtc0, alhfsn, ADJ, raddn, zc1, tsnowsrf, dum, tsoil,          &
               QA1X, QA2X, QA4X, TC1X, TC2X, TC4X, TCSX,                        &
-              EVAPX1,EVAPX2,EVAPX4,SHFLUXX1,SHFLUXX2,SHFLUXX4,EVEGFRC,         &
+              EVAPX1,EVAPX2,EVAPX4,EVAPX124,                                   &
+              SHFLUXX1,SHFLUXX2,SHFLUXX4,EVEGFRC,                              &
               EVAPXS,SHFLUXXS,phi,rho_fs,WSS,sumdepth,                         &   
               sndzsc, wesnprec, sndzprec,  sndz1perc,                          &   
               mltwtr, wesnbot, dtss
@@ -461,7 +461,7 @@
          write (*,*)  RUNSRF(n_out)    
          write (*,*)  SMELT(n_out)  
          write (*,*)  HLWUP(n_out)    
-         write (*,*)  HLATN(n_out)    
+         write (*,*)  LHFLUX(n_out)    
          write (*,*)  QINFIL(n_out)    
          write (*,*)  AR1(n_out)    
          write (*,*)  AR2(n_out)    
@@ -563,8 +563,6 @@
 !     in the heat content of deposited snow.
  
         HSNACC(N)=0.
-        EVACC(N)=0.
-        SHACC(N)=0.
         RUNSRF(N)=0.
 
 
@@ -1024,7 +1022,7 @@
         ENDIF 
  
       DO N=1,NCH 
-        HLATN(N)=(1.-ASNOW(N))*                                                &
+        LHFLUX(N)=(1.-ASNOW(N))*                                               &
               (EVAP1(N)*AR1(N)+EVAP2(N)*AR2(N)+EVAP4(N)*AR4(N))*ALHE           &
               +ASNOW(N)*EVSNOW(N)*ALHS 
         EVAP(N)=(1.-ASNOW(N))*                                                 &
@@ -1110,13 +1108,10 @@
         EINTX=EIRFRC(N)*EVAPFR(N)*DTSTEP
         IF(EINTX .GT. CAPAC(N)) THEN
           EDIF=(EINTX-CAPAC(N))/DTSTEP
-!          EVACC(N)=EVACC(N)-EDIF
           EVAPFR(N)=EVAPFR(N)-EDIF
           EVAP(N)=EVAP(N)-EDIF
-          HLATN(N)=HLATN(N)-EDIF*ALHE
+          LHFLUX(N)=LHFLUX(N)-EDIF*ALHE
           SHFLUX(N)=SHFLUX(N)+EDIF*ALHE
-!          SHACC(N)=SHACC(N)+EDIF*ALHE
-!          HSNACC(N)=HSNACC(N)+EDIF*ALHE
           EIRFRC(N)=CAPAC(N)/((EVAPFR(N)+1.E-20)*DTSTEP)
           ENDIF
         ENDDO
@@ -1237,13 +1232,11 @@
          if(werror(n) .gt. 0.) then
            edif=werror(n)/dtstep
            EVAP(N)=EVAP(N)-EDIF
-           HLATN(N)=HLATN(N)-EDIF*ALHE
+           LHFLUX(N)=LHFLUX(N)-EDIF*ALHE
            EVEGFRC=EVEG(N)/(EVEG(N)+ESOI(N)+1.E-20)
            EVEG(N)=EVEG(N)-EDIF*EVEGFRC*DTSTEP
            ESOI(N)=ESOI(N)-EDIF*(1.-EVEGFRC)*DTSTEP
            SHFLUX(N)=SHFLUX(N)+EDIF*ALHE
-!           EVACC(N)=EVACC(n)-EDIF
-!           SHACC(N)=SHACC(N)+EDIF*ALHE
            endif
          enddo
 
@@ -1264,7 +1257,6 @@
         hold=csoil(n)*(ar1old(n)*tc1(n)+ar2old(n)*tc2(n)+ar4old(n)*tc4(n))
         hnew=csoil(n)*(ar1(n)*tc1(n)+ar2(n)*tc2(n)+ar4(n)*tc4(n))
         shflux(n)=shflux(n)-(hnew-hold)/dtstep
-!        SHACC(N)=SHACC(N)-(hnew-hold)/dtstep
         enddo
 
 !**** ---------------------------------------------------
@@ -1454,28 +1446,26 @@
 ! fluxes, since the land model has to update those areas (based on the fluxes)
 ! as a matter of course.
 
+        ! evap (mass) flux (kg/m2/s)
+
         EVAPX1=ETURB1(N)+DEDQA1(N)*(QA1(N)-QA1_ORIG(N))
         EVAPX2=ETURB2(N)+DEDQA2(N)*(QA2(N)-QA2_ORIG(N))
         EVAPX4=ETURB4(N)+DEDQA4(N)*(QA4(N)-QA4_ORIG(N))
         EVAPXS=ETURBS(N)+DEDQAS(N)*DQSS(N)*(TPSN1(N)-TCS_ORIG(N))
-        EVACC(N)=        (1.-ASNOW0(N))*                                       &
-                        ( AR1(N)*EVAPX1+                                       &
-                          AR2(N)*EVAPX2+                                       &
-                          AR4(N)*EVAPX4 )                                      &
-                      +  ASNOW0(N)*EVAPXS
-        EVACC(N)=EVAP(N)-EVACC(N)
 
+        EVAPX124 = AR1(N)*EVAPX1 + AR2(N)*EVAPX2 + AR4(N)*EVAPX4 
+        
+        EVACC(N)=EVAP(N)-(1.-ASNOW0(N))*EVAPX124-ASNOW0(N)*EVAPXS
 
-        ! added term for latent heat flux correction, reichle+qliu, 9 Oct 2008
+        ! latent heat (energy) flux (W/m2)
+        !
+        ! Note: Strictly speaking, the atmosphere does not receive the latent heat flux,
+        !       only the evap mass flux and the sensible heat flux.  For completeness, 
+        !       however, we also calculate a corresponding "accounting" (or "error") term.
+        
+        LHACC(N) = LHFLUX(N) - (1.-ASNOW0(N))*ALHE*EVAPX124 - ASNOW0(N)*ALHS*EVAPXS 
 
-        if(present(lhacc)) then
-           LHACC(N)=  ALHE*(1.-ASNOW0(N))*                           &
-                ( AR1(N)*EVAPX1+                                     &
-                  AR2(N)*EVAPX2+                                     &
-                  AR4(N)*EVAPX4 )                                    &
-                + ALHS*ASNOW0(N)*EVAPXS
-           LHACC(N)=HLATN(N)-LHACC(N)
-           end if
+        ! sensible heat (energy) flux (W/m2)
 
         SHFLUXX1=HSTURB1(N)+DHSDTC1(N)*(TC1(N)-TC1_ORIG(N))
         SHFLUXX2=HSTURB2(N)+DHSDTC2(N)*(TC2(N)-TC2_ORIG(N))
@@ -1510,7 +1500,7 @@
         TOTICE_SOIL(N)=TOTWAT_SOIL(N)*FRICE(N)
 
 
-        ENDDO     
+        ENDDO  ! N=1,NCH (PROCESS DATA AS NECESSARY PRIOR TO RETURN)   
 
       if(numout.ne.0) then
        do i = 1,numout
@@ -1654,7 +1644,7 @@
          write (*,*)  RUNSRF(n_out)    
          write (*,*)  SMELT(n_out)  
          write (*,*)  HLWUP(n_out)    
-         write (*,*)  HLATN(n_out)    
+         write (*,*)  LHFLUX(n_out)    
          write (*,*)  QINFIL(n_out)    
          write (*,*)  AR1(n_out)    
          write (*,*)  AR2(n_out)    

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
@@ -163,7 +163,7 @@
                      TCSORIG, TPSN1IN, TPSN1OUT,FSW_CHANGE ,                   &
                      lonbeg,lonend,latbeg,latend,                              &
                      TC1_0, TC2_0, TC4_0, QA1_0, QA2_0, QA4_0, EACC_0,         &  ! OPTIONAL
-                     RCONSTIT, RMELT, TOTDEPOS )
+                     RCONSTIT, RMELT, TOTDEPOS )                                  ! OPTIONAL
 
       IMPLICIT NONE
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -788,7 +788,7 @@ module GEOS_LandiceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
-        LONG_NAME          = 'surface_outgoing_longwave_flux',&
+        LONG_NAME          = 'surface_emitted_longwave_flux',&
         UNITS              = 'W m-2'                     ,&
         SHORT_NAME         = 'HLWUP'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
@@ -1166,7 +1166,7 @@ module GEOS_LandiceGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'ALW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -1175,7 +1175,7 @@ module GEOS_LandiceGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'BLW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2 K-1',                         &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -1238,7 +1238,7 @@ module GEOS_LandiceGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'LWDNSRF',                           &
-        LONG_NAME          = 'surface_downwelling_longwave_flux', &
+        LONG_NAME          = 'surface_absorbed_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_CICE4ColumnPhysGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_CICE4ColumnPhysGridComp.F90
@@ -247,7 +247,7 @@ module GEOS_CICE4ColumnPhysGridComp
                                                _RC  ) 
 
      call MAPL_AddExportSpec(GC,                     &
-        LONG_NAME          = 'surface_outgoing_longwave_flux',&
+        LONG_NAME          = 'surface_emitted_longwave_flux',&
         UNITS              = 'W m-2'                     ,&
         SHORT_NAME         = 'HLWUP'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
@@ -255,7 +255,7 @@ module GEOS_CICE4ColumnPhysGridComp
                                                _RC  ) 
 
      call MAPL_AddExportSpec(GC,                     &
-        LONG_NAME          = 'sea_ice_outgoing_longwave_flux',&
+        LONG_NAME          = 'sea_ice_emitted_longwave_flux',&
         UNITS              = 'W m-2'                     ,&
         SHORT_NAME         = 'HLWUPICE'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
@@ -623,7 +623,7 @@ module GEOS_CICE4ColumnPhysGridComp
         _RC  )
 
      call MAPL_AddExportSpec(GC                     ,&
-        LONG_NAME          = 'surface_downward_longwave_flux',&
+        LONG_NAME          = 'surface_absorbed_longwave_flux',&
         UNITS              = 'W m-2'                     ,&
         SHORT_NAME         = 'LWDNSRF'                   ,&
         DIMS               = MAPL_DimsTileOnly           ,&
@@ -735,7 +735,7 @@ module GEOS_CICE4ColumnPhysGridComp
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'ALW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -743,7 +743,7 @@ module GEOS_CICE4ColumnPhysGridComp
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'BLW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2 K-1',                         &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -751,7 +751,7 @@ module GEOS_CICE4ColumnPhysGridComp
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'LWDNSRF',                           &
-        LONG_NAME          = 'surface_downwelling_longwave_flux', &
+        LONG_NAME          = 'surface_absorbed_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -1491,7 +1491,7 @@ module GEOS_CICE4ColumnPhysGridComp
 
    call MAPL_AddExportSpec(GC,                     &
         SHORT_NAME         = 'HLWUPN'                     ,&
-        LONG_NAME          = 'outgoing_longwave_flux_at_ice_snow_surface_over_ice_categories',&
+        LONG_NAME          = 'emitted_longwave_flux_at_ice_snow_surface_over_ice_categories',&
         UNITS              = 'W m-2'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         UNGRIDDED_DIMS     = (/NUM_ICE_CATEGORIES/)      ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -259,7 +259,7 @@ module GEOS_OpenwaterGridCompMod
                                                _RC  ) 
 
      call MAPL_AddExportSpec(GC,                     &
-        LONG_NAME          = 'surface_outgoing_longwave_flux',&
+        LONG_NAME          = 'surface_emitted_longwave_flux',&
         UNITS              = 'W m-2'                     ,&
         SHORT_NAME         = 'HLWUP'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
@@ -942,7 +942,7 @@ module GEOS_OpenwaterGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'ALW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -950,7 +950,7 @@ module GEOS_OpenwaterGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'BLW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2 K-1',                         &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -958,7 +958,7 @@ module GEOS_OpenwaterGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'LWDNSRF',                           &
-        LONG_NAME          = 'surface_downwelling_longwave_flux', &
+        LONG_NAME          = 'surface_absorbed_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SaltWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SaltWaterGridComp.F90
@@ -218,7 +218,7 @@ module GEOS_SaltwaterGridCompMod
                                                _RC  ) 
 
      call MAPL_AddExportSpec(GC,                     &
-        LONG_NAME          = 'surface_outgoing_longwave_flux',&
+        LONG_NAME          = 'surface_emitted_longwave_flux',&
         UNITS              = 'W m-2'                     ,&
         SHORT_NAME         = 'HLWUP'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
@@ -202,7 +202,7 @@ module GEOS_SimpleSeaiceGridCompMod
 
      call MAPL_AddExportSpec(GC,                     &
         SHORT_NAME         = 'HLWUP'                     ,&
-        LONG_NAME          = 'surface_outgoing_longwave_flux',&
+        LONG_NAME          = 'surface_emitted_longwave_flux',&
         UNITS              = 'W m-2'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
@@ -699,7 +699,7 @@ module GEOS_SimpleSeaiceGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'ALW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -707,7 +707,7 @@ module GEOS_SimpleSeaiceGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'BLW',                               &
-        LONG_NAME          = 'linearization_of_surface_upwelling_longwave_flux', &
+        LONG_NAME          = 'linearization_of_surface_emitted_longwave_flux', &
         UNITS              = 'W m-2 K-1',                         &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -715,7 +715,7 @@ module GEOS_SimpleSeaiceGridCompMod
 
      call MAPL_AddImportSpec(GC,                             &
         SHORT_NAME         = 'LWDNSRF',                           &
-        LONG_NAME          = 'surface_downwelling_longwave_flux', &
+        LONG_NAME          = 'surface_absorbed_longwave_flux', &
         UNITS              = 'W m-2',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &


### PR DESCRIPTION
As in #957 but for R21C branch. 

Also corrects long names for longwave fluxes (cf. GEOSgcm_GridComp PR #764) except for CatchmentCN, which is not relevant for M21C.