### PR TITLE
Fixes for Ninja builds

### DIFF
--- a/GEOSwgcm_GridComp/GEOSwavewatch_GridComp/ww3_multi_esmf/CMakeLists.txt
+++ b/GEOSwgcm_GridComp/GEOSwavewatch_GridComp/ww3_multi_esmf/CMakeLists.txt
@@ -73,8 +73,8 @@ set (WW3_path ${CMAKE_CURRENT_SOURCE_DIR}/${WW3_rel_path})
 get_filename_component(aux_dir ${WW3_path}/model/aux ABSOLUTE)
 get_filename_component(ftn_dir ${WW3_path}/model/ftn ABSOLUTE)
 
-message(STATUS "WW3 aux_dir ${aux_dir}")
-message(STATUS "WW3 ftn_dir ${ftn_dir}")
+message(DEBUG "WW3 aux_dir ${aux_dir}")
+message(DEBUG "WW3 ftn_dir ${ftn_dir}")
 
 add_executable(w3adc "${aux_dir}/w3adc.f")
 
@@ -82,9 +82,16 @@ set (WW3ESMF_F90)
 foreach(src_file ${WW3ESMF_FTN})
     STRING(REGEX REPLACE ".ftn" ".F90" gen_src_file ${src_file})
     STRING(REGEX REPLACE "/" "_" gen_log_file ${gen_src_file})
+    # Testing shows that we only want BYPRODUCTS here if our CMAKE_GENERATOR is Unix Makefiles
+    # If we use Ninja, we don't want BYPRODUCTS
+    if (CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+      set(BYPRODUCTS ${gen_src_file})
+    else()
+      set(BYPRODUCTS "")
+    endif()
     add_custom_command(
         OUTPUT  ${gen_src_file}
-        BYPRODUCTS  ${gen_src_file}
+        BYPRODUCTS  ${BYPRODUCTS}
         DEPENDS w3adc ${ftn_dir}/${src_file}
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/run_w3adc.sh ${ftn_dir} ${src_file} > ${gen_log_file}.w3adc.log 2>&1
         COMMENT "Running w3adc ${src_file}")


### PR DESCRIPTION
Spurred on by @FlorianDeconinck, I thought about a ninja build of GEOS and when I tried it, I hit an error, namely that described in https://github.com/GEOS-ESM/GEOSgcm/issues/745

So, I was spurred on. Testing showed that apparently the `BYPRODUCTS` line here was the cause.

Now, soon @adarmenov and @atrayano will hopefully move GEOS to the new WW3 which blessedly has moved from the crazy `.ftn` files and now is proper CMake. Woo!

But until this, this ugly CMake seems to allow Ninja to build GEOS again.

I also mark some messages as debug.