### PR TITLE
[NDSL] Use QuantityFactory for AerActivation memory wrap

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/__init__.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/__init__.py
@@ -1,2 +1,2 @@
-from .translate_radiation_coupling import TranslateRadCouple
 from .translate_aer_activation import TranslateAerActivation
+from .translate_radiation_coupling import TranslateRadCouple

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/translate_aer_activation.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/translate_aer_activation.py
@@ -66,7 +66,7 @@ class TranslateAerActivation(TranslateFortranData2Py):
             [X_DIM, Y_DIM, Z_DIM],
             "n/a",
         )
-        qty.view[:, :, :] = data[:, :, :]
+        qty.view[:, :, :] = qty.np.asarray(data[:, :, :])
         return qty
 
     def make_ij_field(self, data) -> Quantity:
@@ -74,7 +74,7 @@ class TranslateAerActivation(TranslateFortranData2Py):
             [X_DIM, Y_DIM],
             "n/a",
         )
-        qty.view[:, :] = data[:, :]
+        qty.view[:, :] = qty.np.asarray(data[:, :])
         return qty
 
     def make_nmodes_ijk_field(self, data) -> Quantity:
@@ -82,7 +82,7 @@ class TranslateAerActivation(TranslateFortranData2Py):
             [X_DIM, Y_DIM, Z_DIM, "n_modes"],
             "n/a",
         )
-        qty.view[:, :, :, :] = data[:, :, :, :]
+        qty.view[:, :, :, :] = qty.np.asarray(data[:, :, :, :])
         return qty
 
     def compute(self, inputs):


### PR DESCRIPTION
Quantities are now expected throughout the Aer Activation port (inputs & temporary). This solves the performance portability issue.

Required for re-integration back to Fortan.