### PR TITLE
remove filling of WET1 (a.k.a. GWETTOP) with 1s over non-land

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
@@ -1262,6 +1262,10 @@ contains
                                                        RC=STATUS  )
      VERIFY_(STATUS)
 
+     ! NOTE: GOCART's dust code expects WET1 to have all the cells with MAPL_UNDEF
+     !       (aka not land) to be replaced with 1.0. We want WET1 to have
+     !       MAPL_UNDEF over non-land points, so we need a separate export to pass
+     !       to GOCART which is WET1 with all non-land points set to 1.0.
      call MAPL_AddConnectivity ( GC,                              &
         SRC_NAME  = [ 'WET1_FOR_CHEM' ],                          &
         SRC_ID      = SURF,                                       &
@@ -1269,6 +1273,7 @@ contains
         DST_ID      = CHEM,                                       &
                                                        RC=STATUS  )
      VERIFY_(STATUS)
+
      if (DO_CO2CNNEE == 1) then
         call MAPL_AddConnectivity ( GC,                           &
              SHORT_NAME  = (/'CNNEE'/),                           &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -8462,14 +8462,6 @@ module GEOS_SurfaceGridCompMod
       endif
 
 
-! Fill WET1 over non-land points
-!-------------------------------
-
-      if( associated(WET1) ) then
-          where(WET1 == MAPL_UNDEF) WET1 = 1.0
-      endif
-
-
 ! Fill imports/exports for OBIO
 !-------------------------------
       if((DO_OBIO/=0) .OR. (ATM_CO2 == ATM_CO2_FOUR)) then


### PR DESCRIPTION
Filling WET1 (a.k.a. GWETTOP) seems to be a bug.  This PR removes the filling. 

PR should be 0-diff except for GWETTOP diagnostic.  Leaving decision about need for testing to GCM gatekeepers.

@biljanaorescanin @sdrabenh @elakkraoui @mathomp4 @atrayano @bena-nasa @rdkoster 


PS: History of this chunk of code courtesy of @mathomp4:

From the blame, it's been there since the initial commit in Git:

[https://github.com/GEOS-ESM/GEOSgcm_GridComp/blame/95b31b7dc478be622d1593daba8aaf2f971416de/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90#L8465-L8470](https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FGEOS-ESM%2FGEOSgcm_GridComp%2Fblame%2F95b31b7dc478be622d1593daba8aaf2f971416de%2FGEOSagcm_GridComp%2FGEOSphysics_GridComp%2FGEOSsurface_GridComp%2FGEOS_SurfaceGridComp.F90%23L8465-L8470&data=05%7C02%7Crolf.h.reichle%40nasa.gov%7C4eba46ea711b4b9d2ddd08dcb6d9e565%7C7005d45845be48ae8140d43da96dd17b%7C0%7C0%7C638586294201308041%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=DpOf43C%2BWDi12UONK8oKLWkMyVyQP1kpOfZxuFKEgP4%3D&reserved=0)

and looking in CVS, it's been like that since rev 1.130 from 2007:

```
revision 1.130

date: 2007/09/24 02:21:08;  author: trayanov;  state: Exp;  lines: +883 -884

Conversion of GEOS-5 tag GEOSagcm-Eros-beta7p13 to MAPL
```


I went back further in time and found the code used to be:

 ```
      if( associated(WET1) ) then

          call GET_POINTER( EXPORT, FRLAND,  'FRLAND' , RC=STATUS )

          VERIFY_(STATUS)

          WET1 = FRLAND*WET1 + 1-FRLAND

      endif
```

but then Max changed it to something like present day in rev 1.109:

 
```
revision 1.109

date: 2006/05/25 18:37:50;  author: f4mjs;  state: Exp;  lines: +222 -38

mjs: correction to u10m, etc, added u50m, etc, added land diagnostics, modified meaning of snow depths.
```

So not much help with the CVS message for the why.