### PR TITLE
Update ESMF CMake target to ESMF::ESMF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_GcmGridComp.F90)
   esma_add_library(${this}
     SRCS GEOS_GcmGridComp.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL esmf)
+    DEPENDENCIES MAPL ESMF::ESMF)
 
   ecbuild_install_project( NAME GEOSgcm_GridComp)
 

--- a/GEOSagcm_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/CMakeLists.txt
@@ -11,14 +11,14 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_AgcmSimpleGridComp.F90)
   esma_add_library (${this}
     SRCS GEOS_AgcmSimpleGridComp.F90
     SUBCOMPONENTS GEOSsuperdyn_GridComp GEOShs_GridComp
-    DEPENDENCIES MAPL esmf)
+    DEPENDENCIES MAPL ESMF::ESMF)
 
 elseif (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_AgcmGridComp.F90)
 
   esma_add_library (${this}
     SRCS GEOS_AgcmGridComp.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GEOS_Shared Chem_Shared esmf)
+    DEPENDENCIES MAPL GEOS_Shared Chem_Shared ESMF::ESMF)
 
 else ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
@@ -15,7 +15,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_PhysicsGridComp.F90)
   esma_add_library (${this}
     SRCS GEOS_PhysicsGridComp.F90 MBundle_IncrementMod.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GMAO_mpeu GMAO_stoch esmf)
+    DEPENDENCIES MAPL GMAO_mpeu GMAO_stoch ESMF::ESMF)
 
 else ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
@@ -28,7 +28,7 @@ install( FILES ${resource_files}
    DESTINATION etc
    )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GEOS_Shared MAPL esmf NetCDF::NetCDF_Fortran)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GEOS_Shared MAPL ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -34,7 +34,7 @@ endif ()
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES GEOS_Shared GMAO_mpeu MAPL Chem_Shared Chem_Base esmf)
+  DEPENDENCIES GEOS_Shared GMAO_mpeu MAPL Chem_Shared Chem_Base ESMF::ESMF)
 
 get_target_property (extra_incs fms_r4 INCLUDE_DIRECTORIES)
 target_include_directories(${this} PRIVATE

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/CMakeLists.txt
@@ -13,7 +13,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_SurfaceGridComp.F90)
     SRCS GEOS_SurfaceGridComp.F90
     SUBCOMPONENTS ${alldirs}
     SUBDIRS Shared
-    DEPENDENCIES GEOS_SurfaceShared MAPL GMAO_mpeu esmf)
+    DEPENDENCIES GEOS_SurfaceShared MAPL GMAO_mpeu ESMF::ESMF)
 
 else ()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlake_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlake_GridComp/CMakeLists.txt
@@ -2,5 +2,5 @@ esma_set_this()
 
 esma_add_library (${this}
   SRCS GEOS_LakeGridComp.F90
-  DEPENDENCIES GEOS_Shared MAPL esmf)
+  DEPENDENCIES GEOS_Shared MAPL ESMF::ESMF)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/CMakeLists.txt
@@ -13,5 +13,5 @@ esma_add_library (${this}
   SRCS GEOS_LandGridComp.F90
   SUBCOMPONENTS ${alldirs}
   SUBDIRS Shared
-  DEPENDENCIES GEOS_SurfaceShared GEOS_LandShared MAPL esmf)
+  DEPENDENCIES GEOS_SurfaceShared GEOS_LandShared MAPL ESMF::ESMF)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory (GEOScatchCNCLM45_GridComp)
 esma_add_library (${this}
   SRCS GEOS_CatchCNGridComp.F90
   SUBDIRS Shared
-  DEPENDENCIES GEOS_SurfaceShared GEOS_LandShared GEOS_CatchCNShared MAPL esmf)
+  DEPENDENCIES GEOS_SurfaceShared GEOS_LandShared GEOS_CatchCNShared MAPL ESMF::ESMF)
 
 # Special case for GEOScatch and GEOScatchCN components - build with / without openmp
 if (USE_OPENMP)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CLM40/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CLM40/CMakeLists.txt
@@ -39,7 +39,7 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared GEOS_CatchCNShared esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared GEOS_CatchCNShared ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 if (is_openmp)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/CMakeLists.txt
@@ -10,7 +10,7 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared CLM40 GEOS_CatchCNShared esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared CLM40 GEOS_CatchCNShared ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 if (is_openmp)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CMakeLists.txt
@@ -46,7 +46,7 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_LandShared GEOS_CatchCNShared esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES MAPL GEOS_LandShared GEOS_CatchCNShared ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 if (is_openmp)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CMakeLists.txt
@@ -10,7 +10,7 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared CLM45 GEOS_CatchCNShared esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES MAPL GEOS_Shared GEOS_LandShared CLM45 GEOS_CatchCNShared ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE SHARED)
 
 if (is_openmp)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/CMakeLists.txt
@@ -8,5 +8,5 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_LandShared esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES MAPL GEOS_LandShared ESMF::ESMF NetCDF::NetCDF_Fortran)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSigni_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSigni_GridComp/CMakeLists.txt
@@ -3,9 +3,9 @@ esma_set_this ()
 
 set (resource_files
     GEOS_IgniGridComp.rc
-   ) 
+   )
 
-install( FILES ${resource_files} 
+install( FILES ${resource_files}
    DESTINATION etc
    )
 
@@ -17,6 +17,6 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_Shared esmf
+  DEPENDENCIES MAPL GEOS_Shared ESMF::ESMF
   )
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/CMakeLists.txt
@@ -5,6 +5,6 @@ set (srcs
    routing_model.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 install(PROGRAMS build_rivernetwork.py DESTINATION bin)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSvegdyn_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSvegdyn_GridComp/CMakeLists.txt
@@ -1,4 +1,4 @@
 esma_set_this ()
 
-esma_add_library (${this} SRCS GEOS_VegdynGridComp.F90 DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
+esma_add_library (${this} SRCS GEOS_VegdynGridComp.F90 DEPENDENCIES MAPL ESMF::ESMF NetCDF::NetCDF_Fortran)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/CMakeLists.txt
@@ -8,5 +8,5 @@ set_source_files_properties (catch_constants.f90 PROPERTIES COMPILE_FLAGS ${PP})
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES GEOS_SurfaceShared GEOS_Shared MAPL esmf
+  DEPENDENCIES GEOS_SurfaceShared GEOS_Shared MAPL ESMF::ESMF
   TYPE SHARED)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/CMakeLists.txt
@@ -2,5 +2,5 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS GEOS_LandIceGridComp.F90
-  DEPENDENCIES MAPL GEOS_Shared GEOS_SurfaceShared esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES MAPL GEOS_Shared GEOS_SurfaceShared ESMF::ESMF NetCDF::NetCDF_Fortran
   )

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/CMakeLists.txt
@@ -8,5 +8,5 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES GEOS_Shared MAPL CICE4 esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES GEOS_Shared MAPL CICE4 ESMF::ESMF NetCDF::NetCDF_Fortran)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CMakeLists.txt
@@ -18,7 +18,7 @@ endif ()
 
 set_source_files_properties(mkMITAquaRaster.F90 PROPERTIES COMPILE_FLAGS "${BYTERECLEN}")
 
-esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL GEOS_SurfaceShared GEOS_LandShared esmf NetCDF::NetCDF_Fortran OpenMP::OpenMP_Fortran)
+esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL GEOS_SurfaceShared GEOS_LandShared ESMF::ESMF NetCDF::NetCDF_Fortran OpenMP::OpenMP_Fortran)
 
 if(NOT FORTRAN_COMPILER_SUPPORTS_FINDLOC)
    target_compile_definitions(${this} PRIVATE USE_EXTERNAL_FINDLOC)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CMakeLists.txt
@@ -23,7 +23,7 @@ set (exe_srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GEOS_SurfaceShared GEOS_LandShared esmf NetCDF::NetCDF_Fortran GEOS_CatchCNShared)
+  DEPENDENCIES MAPL GEOS_SurfaceShared GEOS_LandShared ESMF::ESMF NetCDF::NetCDF_Fortran GEOS_CatchCNShared)
 
 foreach (src ${exe_srcs})
   string (REGEX REPLACE ".F90" ".x" exe ${src})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSturbulence_GridComp/CMakeLists.txt
@@ -10,4 +10,4 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES GEOS_Shared MAPL esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES GEOS_Shared MAPL ESMF::ESMF NetCDF::NetCDF_Fortran)

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/CMakeLists.txt
@@ -18,7 +18,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_SuperdynGridComp.F90)
   esma_add_library (${this}
     SRCS GEOS_SuperdynGridComp.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GEOS_Shared esmf)
+    DEPENDENCIES MAPL GEOS_Shared ESMF::ESMF)
 
 else ()
 

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOSdatmodyn_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOSdatmodyn_GridComp/CMakeLists.txt
@@ -5,5 +5,5 @@ set (srcs
   stratus_ic.F90 cfmip_ic.F90 NeuralNet.F90 GEOS_DatmoDynGridComp.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GEOS_Shared MAPL esmf NetCDF::NetCDF_Fortran)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GEOS_Shared MAPL ESMF::ESMF NetCDF::NetCDF_Fortran)
 

--- a/GEOSdataatm_GridComp/CMakeLists.txt
+++ b/GEOSdataatm_GridComp/CMakeLists.txt
@@ -6,7 +6,7 @@ set (srcs
 
 esma_add_library (${this}
    SRCS ${srcs}
-   DEPENDENCIES MAPL GEOSsurface_GridComp GEOS_Shared esmf)
+   DEPENDENCIES MAPL GEOSsurface_GridComp GEOS_Shared ESMF::ESMF)
 
 target_compile_definitions (${this} PRIVATE USE_CICE USE_R8)
 

--- a/GEOSmkiau_GridComp/CMakeLists.txt
+++ b/GEOSmkiau_GridComp/CMakeLists.txt
@@ -8,6 +8,6 @@ set (srcs
   DynVec_GridComp.F90
   )
 
-set(dependencies MAPL_cfio_r4 NCEP_sp_r4i4 GEOS_Shared GMAO_mpeu MAPL FVdycoreCubed_GridComp esmf NetCDF::NetCDF_Fortran)
+set(dependencies MAPL_cfio_r4 NCEP_sp_r4i4 GEOS_Shared GMAO_mpeu MAPL FVdycoreCubed_GridComp ESMF::ESMF NetCDF::NetCDF_Fortran)
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies})
 

--- a/GEOSogcm_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ set (alldirs
   GEOS_OceanGridComp
   )
 
-set (dependencies GEOS_Seaice_GridComp MAPL CICE4 esmf)
+set (dependencies GEOS_Seaice_GridComp MAPL CICE4 ESMF::ESMF)
 
 if ( BUILD_MIT_OCEAN )
   add_compile_definitions(BUILD_MIT_OCEAN)

--- a/GEOSogcm_GridComp/GEOS_OceanBioGeoChemGridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOS_OceanBioGeoChemGridComp/CMakeLists.txt
@@ -16,7 +16,7 @@ set (SRCS
 
 esma_add_library(${this}
   SRCS ${SRCS}
-  DEPENDENCIES MAPL esmf)
+  DEPENDENCIES MAPL ESMF::ESMF)
 
 
 

--- a/GEOSogcm_GridComp/GEOS_OradBioGridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOS_OradBioGridComp/CMakeLists.txt
@@ -15,5 +15,5 @@ set (SRCS
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES MAPL esmf)
+  DEPENDENCIES MAPL ESMF::ESMF)
 

--- a/GEOSogcm_GridComp/GEOS_OradGridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOS_OradGridComp/CMakeLists.txt
@@ -1,4 +1,4 @@
 esma_set_this ()
 
-esma_add_library (${this} SRCS GEOS_OradGridComp.F90 DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
+esma_add_library (${this} SRCS GEOS_OradGridComp.F90 DEPENDENCIES MAPL ESMF::ESMF NetCDF::NetCDF_Fortran)
 

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_cmake/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_cmake/CMakeLists.txt
@@ -121,7 +121,7 @@ endforeach ()
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES ESMF NetCDF::NetCDF_Fortran
+  DEPENDENCIES ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE SHARED
 )
 

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CMakeLists.txt
@@ -6,7 +6,7 @@ if ( NOT BUILD_MIT_OCEAN )
  esma_add_library (${this}
    SRCS GEOS_SeaIceGridComp.F90
    SUBCOMPONENTS GEOSdataseaice_GridComp GEOSCICEDyna_GridComp CICE_GEOSPlug
-   DEPENDENCIES MAPL CICE4 esmf)
+   DEPENDENCIES MAPL CICE4 ESMF::ESMF)
 else()
 
   add_compile_definitions(BUILD_MIT_OCEAN)
@@ -14,5 +14,5 @@ else()
   esma_add_library (${this}
     SRCS GEOS_SeaIceGridComp.F90
     SUBCOMPONENTS GEOSdataseaice_GridComp GEOSMITDyna_GridComp
-    DEPENDENCIES MAPL esmf)
+    DEPENDENCIES MAPL ESMF::ESMF)
 endif()

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSCICEDyna_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSCICEDyna_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 esma_add_library (${this}
    SRCS GEOS_CICEDynaGridComp.F90
-   DEPENDENCIES MAPL CICE4 esmf)
+   DEPENDENCIES MAPL CICE4 ESMF::ESMF)
 
 target_compile_definitions(${this} PRIVATE DIAGOUT MODIFY_TOPOGRAPHY USE_R8)
 

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSMITDyna_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSMITDyna_GridComp/CMakeLists.txt
@@ -1,11 +1,9 @@
 esma_set_this ()
 
-esma_add_library (${this} 
-   SRCS GEOS_MITDynaGridComp.F90 
-   DEPENDENCIES MAPL CICE4
+esma_add_library (${this}
+   SRCS GEOS_MITDynaGridComp.F90
+   DEPENDENCIES MAPL CICE4 ESMF::ESMF NetCDF::NetCDF_Fortran
 )
-
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 
 

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSdataseaice_GridComp/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this ()
 
 # This is for selecting the sea ice data handle.
 ## We default to VERSION_1 and look if something is passed in.
-### VERSION_1 is what was used in MERRAA, MERRA-2 reanalyses, 
+### VERSION_1 is what was used in MERRAA, MERRA-2 reanalyses,
 ### VERSION_2 is a "test" with ice thickness from ExtData.
 
 set (DEFAULT_DATA_SEAICE "VERSION_1")
@@ -19,9 +19,9 @@ endif ()
 message(STATUS "DATA_SEAICE set to: ${DATA_SEAICE}")
 
 if (DATA_SEAICE STREQUAL "VERSION_1")
-  esma_add_library (${this} SRCS GEOS_DataSeaIceGridComp.F90         DEPENDENCIES MAPL CICE4 esmf NetCDF::NetCDF_Fortran)
+  esma_add_library (${this} SRCS GEOS_DataSeaIceGridComp.F90         DEPENDENCIES MAPL CICE4 ESMF::ESMF NetCDF::NetCDF_Fortran)
 elseif (DATA_SEAICE STREQUAL "VERSION_2")
-  esma_add_library (${this} SRCS GEOS_DataSeaIceGridComp_ExtData.F90 DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
+  esma_add_library (${this} SRCS GEOS_DataSeaIceGridComp_ExtData.F90 DEPENDENCIES MAPL ESMF::ESMF NetCDF::NetCDF_Fortran)
 else ()
   message (FATAL_ERROR "The only allowed values for DATA_SEAICE are ${ALLOWED_DATA_SEAICE}")
 endif ()

--- a/GEOSwgcm_GridComp/CMakeLists.txt
+++ b/GEOSwgcm_GridComp/CMakeLists.txt
@@ -19,7 +19,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_WgcmGridComp.F90)
   esma_add_library (${this}
     SRCS bl_seaspray.F90 GEOS_WgcmGridComp.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL esmf
+    DEPENDENCIES MAPL ESMF::ESMF
     )
 
 else ()

--- a/GEOSwgcm_GridComp/GEOSumwm_GridComp/CMakeLists.txt
+++ b/GEOSwgcm_GridComp/GEOSumwm_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ esma_add_subdirectories(
 
 esma_add_library (${this}
   SRCS GEOS_UMWMGridComp.F90
-  DEPENDENCIES MAPL umwm esmf
+  DEPENDENCIES MAPL umwm ESMF::ESMF
   )
 
 

--- a/GEOSwgcm_GridComp/GEOSumwm_GridComp/umwm_cmake/CMakeLists.txt
+++ b/GEOSwgcm_GridComp/GEOSumwm_GridComp/umwm_cmake/CMakeLists.txt
@@ -25,7 +25,7 @@ endforeach ()
 
 esma_add_library (${this}
    SRCS ${SRCS}
-   DEPENDENCIES esmf NetCDF::NetCDF_Fortran
+   DEPENDENCIES ESMF::ESMF NetCDF::NetCDF_Fortran
 )
 
 target_compile_definitions(${this} PRIVATE MPI ESMF GEOS)

--- a/GEOSwgcm_GridComp/GEOSwavewatch_GridComp/CMakeLists.txt
+++ b/GEOSwgcm_GridComp/GEOSwavewatch_GridComp/CMakeLists.txt
@@ -9,7 +9,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_WaveWatchGridComp.F90)
   esma_add_library (${this}
     SRCS GEOS_WaveWatchGridComp.F90
     SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL esmf
+    DEPENDENCIES MAPL ESMF::ESMF
     )
 
 else ()

--- a/GEOSwgcm_GridComp/GEOSwavewatch_GridComp/ww3_multi_esmf/CMakeLists.txt
+++ b/GEOSwgcm_GridComp/GEOSwavewatch_GridComp/ww3_multi_esmf/CMakeLists.txt
@@ -101,7 +101,7 @@ endforeach()
 
 esma_add_library (${this}
    SRCS ${WW3ESMF_F90}
-   DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran
+   DEPENDENCIES MAPL ESMF::ESMF NetCDF::NetCDF_Fortran
   )
 
 target_include_directories (${this} PRIVATE


### PR DESCRIPTION
This PR updates the ESMF CMake target to `ESMF::ESMF` which is the correct canonical target name for ESMF. This is necessary for Spack compatibility. NOTE: This requires ESMF 8.6.1 or later.