### PR TITLE
gcc14: Compile icepack data file at -O0

### DIFF
--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_cmake/CMakeLists.txt
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_cmake/CMakeLists.txt
@@ -127,3 +127,9 @@ esma_add_library (${this}
 
 target_compile_definitions (${this} PRIVATE USE_NETCDF GEOSCOUPLED FORTRANUNDERSCORE)
 
+# GCC 14 is taking *forever* to compile icepack_shortwave_data.F90
+# so we're going to use -O0 for this file only
+if (CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
+  set_source_files_properties(icepack/columnphysics/icepack_shortwave_data.F90 PROPERTIES COMPILE_OPTIONS ${FOPT0})
+endif ()
+


### PR DESCRIPTION
Testing with gcc 14 found that the compilation of `icepack/columnphysics/icepack_shortwave_data.F90` was taking...forever. This file is 9600 lines of just setting arrays with `reshape`:

https://github.com/CICE-Consortium/Icepack/blob/4c87095256c1c599c3ccaa857a95744158751a60/columnphysics/icepack_shortwave_data.F90

There is no reason I can think of you'd need to optimize this at `-O3` (though maybe @tclune has some thoughts), so for now we just say "if GNU, build at -O0". Now maybe this changes answers but even so, no one is running icepack → cice with GNU anyway, so it's essentially 0-diff.