### PR TITLE
Fixes #984, bug in which ZLCL was unfilled with BACM or MGB2

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_BACM_1M_InterfaceMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_BACM_1M_InterfaceMod.F90
@@ -481,6 +481,16 @@ subroutine BACM_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
        end do
     end do
 
+    call MAPL_GetPointer(EXPORT, PTR2D, 'ZLCL', RC=STATUS); VERIFY_(STATUS)
+    if (associated(PTR2D)) then
+      tmp2d = FIND_KLCL( T, Q, PLmb, IM, JM, LM )
+      do J=1,JM
+         do I=1,IM
+           PTR2D(I,J) = ZL0(I,J,tmp2d(I,J))
+         end do
+      end do
+    endif
+
     ! Export Tendencies
     call MAPL_GetPointer(EXPORT, DQVDT_macro, 'DQVDT_macro' , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(EXPORT, DQIDT_macro, 'DQIDT_macro' , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MGB2_2M_InterfaceMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MGB2_2M_InterfaceMod.F90
@@ -1396,6 +1396,15 @@ subroutine MGB2_2M_Run  (GC, IMPORT, EXPORT, CLOCK, RC)
     call MAPL_GetPointer(EXPORT, PTR2D,  'AN_SNR'    , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS); PTR2D=0.0
     call MAPL_GetPointer(EXPORT, PTR2D,  'SC_SNR'    , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS); PTR2D=0.0
     
+    call MAPL_GetPointer(EXPORT, PTR2D, 'ZLCL', RC=STATUS); VERIFY_(STATUS)
+    if (associated(PTR2D)) then
+      tmp2d = FIND_KLCL( T, Q, PLmb, IM, JM, LM )
+      do J=1,JM
+         do I=1,IM
+           PTR2D(I,J) = ZL0(I,J,tmp2d(I,J))
+         end do
+      end do
+    endif
 
     call MAPL_TimerOn(MAPL,"---CLDMACRO")
     call MAPL_GetPointer(EXPORT, DQVDT_macro, 'DQVDT_macro' , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)


### PR DESCRIPTION
Fixes #984, filling ZLCL for all microphysics options.  However, many other Moist exports remain unfilled.