### PR TITLE
Fixed conversion of minimal CAPAC to RUNOFF (catchment.F90)

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
@@ -1248,11 +1248,11 @@ CONTAINS
 
       DO N=1,NCH
 
-        RUNOFF(N) = RUNSRF(N)+BFLOW(N)
         IF(CAPAC(N).LT.1.E-10) THEN
-           RUNOFF(N) = RUNOFF(N)+CAPAC(N)/DTSTEP
+           RUNSRF(N) = RUNSRF(N)+CAPAC(N)/DTSTEP
            CAPAC(N) = 0.0
            endif
+        RUNOFF(N) = RUNSRF(N)+BFLOW(N)
 
         EINT(N) = EINT(N) * ALHE
         ESOI(N) = ESOI(N) * ALHE

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
@@ -1268,11 +1268,11 @@
 
       DO N=1,NCH
 
-        RUNOFF(N) = RUNSRF(N)+BFLOW(N)
         IF(CAPAC(N).LT.1.E-10) THEN
-           RUNOFF(N) = RUNOFF(N)+CAPAC(N)/DTSTEP
+           RUNSRF(N) = RUNSRF(N)+CAPAC(N)/DTSTEP
            CAPAC(N) = 0.0
            endif
+        RUNOFF(N) = RUNSRF(N)+BFLOW(N)
 
         EINT(N) = EINT(N) * ALHE / DTSTEP
         ESOI(N) = ESOI(N) * ALHE / DTSTEP


### PR DESCRIPTION
Addresses https://github.com/GEOS-ESM/GEOSgcm_GridComp/issues/990

Bug fix: Previously, minimal CAPAC values were converted into runoff by adding them directly into total RUNOFF, but not into one of its components (RUNSRF or BFLOW), which violated the definition of total RUNOFF (=RUNSRF + BFLOW).  This fix adds the minimal CAPAC into RUNSRF and thus preserves the equation of total RUNOFF.

Changes should be 0-diff for restarts in AGCM and LDAS, and differences should only be seen in the RUNSRF and possibly RUNOFF diagnostics.  The current implementation of the bug fix prioritizes efficiency and logic but may result in (minimal) changes in the total RUNOFF diagnostic, which may in turn result in non-0-diff changes in the coupled model (AOGCM).  If needed, we could change the implementation of the bug fix to also make it 0-diff for coupled model restarts.

@biljanaorescanin: When you get a chance, please test this PR for the GCM (incl. the coupled model) and the LDAS. 

cc: @rdkoster 