### PR TITLE
v12: Fix issue with gfdl qs_table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,10 @@ workflows:
           #baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
-          mepodevelop: true
+          # V12 code uses a special branch for now.
+          fixture_branch: feature/sdrabenh/gcm_v12
+          # We comment out this as it will "undo" the fixture_branch
+          #mepodevelop: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
 
       # Run AMIP GCM (1 hour, no ExtData)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,5 +55,4 @@ workflows:
           #baselibs_version: *baselibs_version
           #bcs_version: *bcs_version
           gcm_ocean_type: MOM6
-          landbcs_type: NL3
           change_layout: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 #bcs_version: &bcs_version v12.0.0
 
 orbs:
-  ci: geos-esm/circleci-tools@dev:f0c2c8ef70b5b840bbd8e08f6fabaa9f7bb4d5d4
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v8.0.2
-#bcs_version: &bcs_version v11.5.0
+#baselibs_version: &baselibs_version v8.5.0
+#bcs_version: &bcs_version v12.0.0
 
 orbs:
-  ci: geos-esm/circleci-tools@3
+  ci: geos-esm/circleci-tools@dev:f0c2c8ef70b5b840bbd8e08f6fabaa9f7bb4d5d4
 
 workflows:
   build-test:
@@ -52,4 +52,5 @@ workflows:
           #baselibs_version: *baselibs_version
           #bcs_version: *bcs_version
           gcm_ocean_type: MOM6
+          landbcs_type: NL3
           change_layout: false

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
@@ -4065,7 +4065,7 @@ subroutine qs_table (n)
     real :: tc
 
     ! -----------------------------------------------------------------------
-    ! compute es over ice between - 160 deg c and -40 deg c.
+    ! compute es over ice between - 160 deg c and 0 deg c.
     ! -----------------------------------------------------------------------
 
     do i = 1, 1600

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_cloud_microphys.F90
@@ -4068,7 +4068,7 @@ subroutine qs_table (n)
     ! compute es over ice between - 160 deg c and -40 deg c.
     ! -----------------------------------------------------------------------
 
-    do i = 1, 1200
+    do i = 1, 1600
         tem = es_table_tmin + delt * real (i - 1)
         fac0 = (tem - t_ice) / (tem * t_ice)
         fac1 = fac0 * li2


### PR DESCRIPTION
## NOTE:

I'm keeping draft right now just to make sure the CI works with this. If it does, I will undraft.

---

Today, I was trying to fix the v12 CI in GEOSgcm and once I patched up some Docker image issues, it crashed with:

```
forrtl: error (182): floating invalid - possible uninitialized real/complex variable.
Image              PC                Routine            Line        Source
libpthread-2.31.s  0000153E0848A910  Unknown               Unknown  Unknown
GEOSgcm.x          00000000072F3DA1  gfdl2_cloud_micro        4105  gfdl_cloud_microphys.F90
GEOSgcm.x          00000000072E1B01  gfdl2_cloud_micro        3473  gfdl_cloud_microphys.F90
```

Prints show that `table` is filled with `NaN` which then dies during:
```fortran
        table (i + 1200) = wice * table (i + 1200) + wh2o * esupc (i)
```
when it tries to use it on the right-hand side.

This is true with even the latest v12 updates from @wmputman and @atrayano. So, I took a look, and yep a bug. To wit in gfdl_cloud_microphysics we have in `qs_table` (truncated to look at `table`):
```fortran
    ! -----------------------------------------------------------------------
    ! compute es over ice between - 160 deg c and -40 deg c.
    ! -----------------------------------------------------------------------

    do i = 1, 1200
        table (i) = e00 * exp (fac2)
    enddo

    ! -----------------------------------------------------------------------
    ! compute es over water between - 40 deg c and 102 deg c.
    ! -----------------------------------------------------------------------

    do i = 1, es_table_length-1200
        if (i <= 400) then
            esupc (i) = esh40
        else
            table (i + 1200) = esh40
        endif
    enddo

    ! -----------------------------------------------------------------------
    ! derive blended es over ice and supercooled water between - 40 deg c and 0 deg c
    ! -----------------------------------------------------------------------

    do i = 1, 400
        table (i + 1200) = wice * table (i + 1200) + wh2o * esupc (i)
    enddo
```
The comments make it seem like we want to do:

1. -160 → -40
2. 0 → 102
3. -40 → 0

This seems to be slightly altered from the ["canonical" GFDL code](https://github.com/NCAR/ccpp-physics/blob/main/physics/MP/GFDL/module_gfdl_cloud_microphys.F90) which does:

1. -160 → 0
2. -20 → 102
3. -20 → 0

But notice the issue. The first loop in our code fills `table(1)` to `table(1200)`. The second one fills `table(1601)` to `table(2621)`. The third tries to fill `table(1201)` to `table(1600)` by blending. 

We *NEVER* set `table(1201)` to `table(1600)` in the first loop to then blend with in the third.

My proposed solution is to extend the first loop to 1600 so that `table` is filled from 1200 to 1600 with something for the blend.
