### PR TITLE
v12: Fix for SNOMAS and SRF_TYPE

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
@@ -1818,7 +1818,7 @@ contains
          VLOCATION = MAPL_VLocationCenter,              RC=STATUS  )
     VERIFY_(STATUS)
 
-    call MAPL_AddExportSpec(GC,                               &    
+    call MAPL_AddExportSpec(GC,                               &
          SHORT_NAME = 'VFALL_ICE',                                          &
          LONG_NAME  = 'terminal_velocity_of_falling_ice',       &
          UNITS      = 'm s-1',                                           &
@@ -2005,26 +2005,26 @@ contains
     call MAPL_AddExportSpec(GC,                               &
          SHORT_NAME = 'DBZ_MAX_S',                                          &
          LONG_NAME = 'Maximum_composite_radar_reflectivity_snow',                  &
-         UNITS     = 'dBZ',                                     & 
+         UNITS     = 'dBZ',                                     &
          DIMS      = MAPL_DimsHorzOnly,                            &
-         VLOCATION = MAPL_VLocationNone,              RC=STATUS  ) 
-    VERIFY_(STATUS) 
+         VLOCATION = MAPL_VLocationNone,              RC=STATUS  )
+    VERIFY_(STATUS)
 
     call MAPL_AddExportSpec(GC,                               &
          SHORT_NAME = 'DBZ_MAX_R',                                          &
          LONG_NAME = 'Maximum_composite_radar_reflectivity_rain',                  &
-         UNITS     = 'dBZ',                                     & 
+         UNITS     = 'dBZ',                                     &
          DIMS      = MAPL_DimsHorzOnly,                            &
-         VLOCATION = MAPL_VLocationNone,              RC=STATUS  ) 
-    VERIFY_(STATUS) 
+         VLOCATION = MAPL_VLocationNone,              RC=STATUS  )
+    VERIFY_(STATUS)
 
     call MAPL_AddExportSpec(GC,                               &
          SHORT_NAME = 'DBZ_MAX_G',                                          &
          LONG_NAME = 'Maximum_composite_radar_reflectivity_graupel',                  &
-         UNITS     = 'dBZ',                                     & 
+         UNITS     = 'dBZ',                                     &
          DIMS      = MAPL_DimsHorzOnly,                            &
-         VLOCATION = MAPL_VLocationNone,              RC=STATUS  ) 
-    VERIFY_(STATUS) 
+         VLOCATION = MAPL_VLocationNone,              RC=STATUS  )
+    VERIFY_(STATUS)
 
     call MAPL_AddExportSpec(GC,                               &
          SHORT_NAME = 'DBZ_MAX',                                          &
@@ -5336,12 +5336,17 @@ contains
        call MAPL_GetPointer(IMPORT, FRACI,     'FRACI'     , RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(IMPORT, SNOMAS,    'SNOMAS'    , RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(EXPORT, SRF_TYPE,  'SRF_TYPE'  , ALLOC=.TRUE., RC=STATUS); VERIFY_(STATUS)
-       SRF_TYPE = 0.0 ! Ocean
-       where (FRLAND > 0.1)
-         SRF_TYPE = 1.0 ! Land
-       end where
-       where ( (SNOMAS > 0.1) .OR. (FRLANDICE > 0.5) .OR. (FRACI > 0.5) )
-         SRF_TYPE = 2.0 ! Ice/Snow
+
+       where ( (FRLANDICE > 0.5) .OR. (FRACI > 0.5) )
+          SRF_TYPE = 3.0 ! Ice
+       elsewhere ( SNOMAS > 0.1 .AND. SNOMAS /= MAPL_UNDEF )
+          ! NOTE: SNOMAS has UNDEFs so we need to make sure we don't
+          !       allow that to infect this comparison
+          SRF_TYPE = 2.0 ! Snow
+       elsewhere (FRLAND > 0.1)
+          SRF_TYPE = 1.0 ! Land
+       elsewhere
+          SRF_TYPE = 0.0 ! Ocean
        end where
 
        ! Allocatables

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
@@ -36,7 +36,7 @@ module GEOSmoist_Process_Library
    real, parameter :: aT_ICE_ALL = 252.16
    real, parameter :: aT_ICE_MAX = 268.16
    real, parameter :: aICEFRPWR  = 2.0
-   ! Over snow/ice SRF_TYPE = 2
+   ! Over snow SRF_TYPE = 2 and over ice SRF_TYPE = 3
    real, parameter :: iT_ICE_ALL = 236.16
    real, parameter :: iT_ICE_MAX = 261.16
    real, parameter :: iICEFRPWR  = 6.0
@@ -395,7 +395,7 @@ module GEOSmoist_Process_Library
       real             :: ICEFRCT_C, ICEFRCT_M
 
 #ifdef USE_MODIS_ICE_POLY
-     ! Use MODIS polynomial from Hu et al, DOI: (10.1029/2009JD012384) 
+     ! Use MODIS polynomial from Hu et al, DOI: (10.1029/2009JD012384)
       tc = MAX(-46.0,MIN(TEMP-MAPL_TICE,46.0)) ! convert to celcius and limit range from -46:46 C
       ptc = 7.6725 + 1.0118*tc + 0.1422*tc**2 + 0.0106*tc**3 + 0.000339*tc**4 + 0.00000395*tc**5
       ICEFRCT = 1.0 - (1.0/(1.0 + exp(-1*ptc)))
@@ -424,8 +424,8 @@ module GEOSmoist_Process_Library
       ICEFRCT_C = MAX(ICEFRCT_C,0.00)
       ICEFRCT_C = ICEFRCT_C**aICEFRPWR
      ! Sigmoidal functions like figure 6b/6c of Hu et al 2010, doi:10.1029/2009JD012384
-      if (SRF_TYPE == 2.0) then
-        ! Over snow/ice
+      if (SRF_TYPE >= 2.0) then
+        ! Over snow (SRF_TYPE == 2.0) and ice (SRF_TYPE == 3.0)
         if (ICE_RADII_PARAM == 1) then
           ! Jason formula
           ICEFRCT_M  = 0.00
@@ -1701,7 +1701,7 @@ module GEOSmoist_Process_Library
 
 !            corrtest2 = max(-1.0,min(1.0,wqtntrgs/(sqrtw2*sqrtqt)))
             corrtest2 = max(-1.0,min(1.0,0.5*wqwsec/(sqrtw2*sqrtqt)))
-          
+
             qw1_1 = - corrtest2 / w1_2            ! A.7
             qw1_2 = - corrtest2 / w1_1            ! A.8
 


### PR DESCRIPTION
As found by @wmputman, the output of `SRF_TYPE` from Moist[^1] was odd in that the ocean was being shown as snow/ice:

![SRF_TYPE_in_badsnomas](https://github.com/user-attachments/assets/c77bebfb-d507-49fb-8b2c-bc1c5243936d)

In this image and the next, `SRF_TYPE => 0` is ocean, `SRF_TYPE => 1` is land, and `SRF_TYPE => 2` is snow/ice.

Obviously this is wrong. The culprit was that `SNOMAS` has some `MAPL_UNDEF` values and the code for `SRF_TYPE` wasn't taking that into account. With the fix, things look better:

![SRF_TYPE_in_goodsnomas](https://github.com/user-attachments/assets/441c95e4-2ab7-460a-8236-7a994cb01129)

Finally, @wmputman asked if we could separate out the snow and ice. So, this PR introduces a change where `SRF_TYPE => 2` is snow and `SRF_TYPE => 3` is ice. To accommodate this, `Process_Library` needs a small change. The new `SRF_TYPE` map is:

![SRF_TYPE_in_srf3](https://github.com/user-attachments/assets/5778c9c8-b3db-480f-8b7f-971e62a501a6)

This is of course a non-zero-diff bugfix for the code.

I will discuss with @sdrabenh and @wmputman if we should make a similar non-zero-diff fix in GEOSgcm v11, but for now we get it into v12.


[^1]: We note that `SRF_TYPE` should probably be an export of Surface. That can be a future change from @gmao-rreichle and his group. Not crucial now since only Moist uses this variable.