### PR TITLE
send clear message to log when mk_lakelandicesaltwater failed

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_LakeLandiceSaltRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_LakeLandiceSaltRestarts.F90
@@ -88,6 +88,9 @@ program mk_LakeLandiceSaltRestarts
 
      call InFmt%open(InRestart,pFIO_READ,rc=rc)
      InCfg = InFmt%read(rc=rc)
+     i = Incfg%get_dimension('tile', _RC)
+     _ASSERT( i == itiles, "The tile number in restart is inconsistent with the tile file: mk_LakeLandiceSaltRestarts")
+
      call MAPL_IOChangeRes(InCfg,OutCfg,(/'tile'/),(/otiles/),rc=rc)
 
      i = index(InRestart,'/',back=.true.)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_LakeLandiceSaltRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_LakeLandiceSaltRestarts.F90
@@ -89,7 +89,7 @@ program mk_LakeLandiceSaltRestarts
      call InFmt%open(InRestart,pFIO_READ,rc=rc)
      InCfg = InFmt%read(rc=rc)
      i = Incfg%get_dimension('tile', _RC)
-     _ASSERT( i == itiles, "The tile number in restart is inconsistent with the tile file: mk_LakeLandiceSaltRestarts")
+     _ASSERT( i == itiles, "mk_LakeLandiceSaltRestarts: Number of tiles in restart file is inconsistent with that in tile file.")
 
      call MAPL_IOChangeRes(InCfg,OutCfg,(/'tile'/),(/otiles/),rc=rc)
 


### PR DESCRIPTION
When restart file does not match the tile file, the program crashes. But without clear message, it is hard to figure out why it crashes. This PR would send the message to the log file.