### PR TITLE
Fixes #1009, incorrect units in GF precip fluxes

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF_GEOS5.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF_GEOS5.F90
@@ -3472,7 +3472,8 @@ ENDIF ! vertical discretization formulation
 	      dp=100.*(po_cup(i,k)-po_cup(i,k+1))
 	      !--- add congestus and deep plumes, and convert to kg/kg/s
               revsu_gf(i,k) = revsu_gf(i,k) + evap_flx(i,k)*g/dp
-              prfil_gf(i,k) = prfil_gf(i,k) + prec_flx(i,k)*g/dp
+              !--- leave precip flux in kg/m2/s
+              prfil_gf(i,k) = prfil_gf(i,k) + prec_flx(i,k) 
            enddo
        enddo
 


### PR DESCRIPTION
Fixes #1009: Diagnostic precip fluxes PFL_CN and PFI_CN from classic GF have incorrect units of kg/kg/m2/s, instead of kg/m2/s.