### PR TITLE
Fixes incorrect units in GF precip fluxes in R21C

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF_GEOS5.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/ConvPar_GF_GEOS5.F90
@@ -3745,7 +3745,7 @@ ENDIF ! vertical discretization formulation
 	      dp=100.*(po_cup(i,k)-po_cup(i,k+1))
 	      !--- add congestus and deep plumes, and convert to kg/kg/s
               revsu_gf(i,k) = revsu_gf(i,k) + evap_flx(i,k)*g/dp
-              prfil_gf(i,k) = prfil_gf(i,k) + prec_flx(i,k)*g/dp
+              prfil_gf(i,k) = prfil_gf(i,k) + prec_flx(i,k)  ! prfil_gf should have units of kg/m2/s
            enddo
        enddo
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
@@ -8748,10 +8748,6 @@ contains
          trdlx    =  1.0   
          KEX      =  1.E-04
 
-         ! adjust units to be [kg kg-1 s-1]
-         REV_CN_GF = REV_CN_GF*iMASS
-         RSU_CN_GF = RSU_CN_GF*iMASS
-
          call MAPL_TimerOff(STATE,"-GF")
       ENDIF
 !-srf-gf-scheme 


### PR DESCRIPTION
This fixes a bug in which GF precip fluxes are incorrectly divided by layer mass, yielding units of kg/kg/m2/s, instead of kg/m2/s.