### PR TITLE
[NDSL] Fix get data base url

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/get_data.sh
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/get_data.sh
@@ -5,4 +5,4 @@ set -e -x
 TEST_DATA_PATH="../../test_data/" #11.5.2/Moist/
 mkdir -p $TEST_DATA_PATH
 cd $TEST_DATA_PATH
-wget -r -nH --cut-dir=5 -np -R "index.html*" https://portal.nccs.nasa.gov/datashare/astg/smt/geos-fp/translate/11.5.2/Moist/TBC_C24_L72_Debug/
+wget -r -nH --cut-dir=5 -np -R "index.html*" https://portal.nccs.nasa.gov/datashare/astg/smt/geos-fp/translate/11.5.2/x86_GNU/Moist/TBC_C24_L72_Debug/


### PR DESCRIPTION
We need to further narrow our numerical regression test to a platform+compiler combo. Eg.
- x86_GNU
- arm_GNUclang

Default to `x86_GNU` which is Discover target (for now)