### PR TITLE
updated refresh method registration using newly introduced MAPL flag

### DIFF
--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/CICE_GEOSPlug.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/CICE_GEOSPlug.F90
@@ -933,6 +933,8 @@ contains
     type(MAPL_MetaComp),     pointer :: MAPL
 
 ! ErrLog Variables
+    character(len=ESMF_MAXSTR)       :: IAm
+    integer                          :: STATUS
 
     character(len=ESMF_MAXSTR)       :: COMP_NAME
 
@@ -940,16 +942,13 @@ contains
     character(len=14)                :: timeStamp
     logical                          :: doRecord
 
-    __Iam__('Record')
+    Iam = "Record"
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
 
     call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC)
-
-    ! for some reason, this causes Iam growing with CICE6 prefix
-    ! disable it for now
-    ! Iam = trim(COMP_NAME)//'::'//Iam
+    Iam = trim(COMP_NAME)//'::'//Iam
 
 ! Get my internal MAPL_Generic state
 !-----------------------------------
@@ -1006,26 +1005,24 @@ contains
   integer, optional,   intent(  OUT) :: RC     ! Error code
 
 !EOP
-
     type(MAPL_MetaComp),     pointer :: MAPL
 
 ! ErrLog Variables
-
+    character(len=ESMF_MAXSTR)       :: IAm
+    integer                          :: STATUS
     character(len=ESMF_MAXSTR)       :: COMP_NAME
 
 ! Locals
     character(len=14)                :: timeStamp
     logical                          :: doRecord
 
-    __Iam__('Restore')
+    IAm = "Restore"
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
 
     call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC)
-    ! for some reason, this causes Iam growing with CICE6 prefix
-    ! disable it for now
-    !Iam = trim(COMP_NAME)//'::'//Iam
+    Iam = trim(COMP_NAME)//'::'//Iam
 
 ! Get my internal MAPL_Generic state
 !-----------------------------------

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/CICE_GEOSPlug.F90
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/CICE_GEOSPlug.F90
@@ -94,7 +94,7 @@ contains
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,          Run,        _RC)
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_FINALIZE,     Finalize,   _RC)
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_WRITERESTART, Record,     _RC)
-    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_READRESTART,  Refresh,    _RC)
+    call MAPL_GridCompSetEntryPoint ( GC, MAPL_METHOD_REFRESH,      Refresh,    _RC)
 
 ! Set the state variable specs.
 ! -----------------------------
@@ -946,7 +946,10 @@ contains
 ! -----------------------------------------------------------
 
     call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC)
-    Iam = trim(COMP_NAME)//'::'//Iam
+
+    ! for some reason, this causes Iam growing with CICE6 prefix
+    ! disable it for now
+    ! Iam = trim(COMP_NAME)//'::'//Iam
 
 ! Get my internal MAPL_Generic state
 !-----------------------------------
@@ -1020,7 +1023,9 @@ contains
 ! -----------------------------------------------------------
 
     call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC)
-    Iam = trim(COMP_NAME)//'::'//Iam
+    ! for some reason, this causes Iam growing with CICE6 prefix
+    ! disable it for now
+    !Iam = trim(COMP_NAME)//'::'//Iam
 
 ! Get my internal MAPL_Generic state
 !-----------------------------------


### PR DESCRIPTION
This PR changed CICE_plug refresh method registration to using MAPL flag such that CICE6 rewind can utilize official MAPL support. It also fixed a string buffer overflow bug.

This is zero diff.
This PR depends on https://github.com/GEOS-ESM/MAPL/issues/2959, and CI will fail without it.