### PR TITLE
Bug fix for optional input arg "conserve_ice10_tzero" (StieglitzSnow.F90)

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/StieglitzSnow.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/StieglitzSnow.F90
@@ -1294,7 +1294,7 @@ contains
 
     if (present(rc_calc_tpsn)) rc_calc_tpsn = rc_tmp
 
-    if (conserve_ice10_tzero) then
+    if (conserve_ice10_tzero_tmp) then
        
        !**** Check that (ice10,tzero) conditions are conserved through
        !**** relayering process (or at least that (fices,tpsn) conditions don't 


### PR DESCRIPTION
An optional input argument ("conserve_ice10_tzero") was used in an if statement inside subroutine StieglitzSnow_relayer(), but the optional input argument may not be provided by the calling routine. 
In the GCM, the optional argument is provided in both calls to StieglitzSnow_relayer().   In the LDAS (incl. catch_incr.F90), however, the optional argument is not always provided, which makes the "if" statement fail with a seg fault error. 
The fix is to use the local variable ("conserve_ice10_tzero_tmp"), which always exists, in the offending if statement.

Could be considered _trivially_ 0-diff based on inspection of code change. 