### PR TITLE
do not terminate SURFSTAT when running with CICE6

### DIFF
--- a/GEOSdataatm_GridComp/GEOS_DataAtmGridComp.F90
+++ b/GEOSdataatm_GridComp/GEOS_DataAtmGridComp.F90
@@ -1075,7 +1075,7 @@ end subroutine RUN
     call MAPL_TimerOn(MAPL,"TOTAL"   )
     call MAPL_TimerOn(MAPL,"FINALIZE")
 
-    if (DO_CICE_THERMO /= 0) call dealloc_column_physics( MAPL_AM_I_Root(), Iam )
+    if (DO_CICE_THERMO == 1) call dealloc_column_physics( MAPL_AM_I_Root(), Iam )
 
     call MAPL_TimerOff(MAPL,"FINALIZE")
     call MAPL_TimerOff(MAPL,"TOTAL"   )

--- a/GEOSdataatm_GridComp/GEOS_DataAtmGridComp.F90
+++ b/GEOSdataatm_GridComp/GEOS_DataAtmGridComp.F90
@@ -270,7 +270,12 @@ module GEOS_DataAtmGridCompMod
 
     ! This call is needed only when we use ReadForcing.
     ! If we switch to use ExtData, next line has be commented out
-    call MAPL_TerminateImport    ( GC, ALL=.true., __RC__ )
+    if (DO_CICE_THERMO == 2) then
+       call MAPL_TerminateImport    ( GC, SHORT_NAMES=['SURFSTATE'],    &
+                                      CHILD_IDS=[SURF],  __RC__  )
+    else
+       call MAPL_TerminateImport    ( GC, ALL=.true., __RC__ )
+    endif
 
     call MAPL_GenericSetServices    ( GC, __RC__)
 


### PR DESCRIPTION
This PR prevents ```SURFSTATE``` from being terminated when CICE6 is running. Fixed https://github.com/GEOS-ESM/GEOSgcm_GridComp/issues/1029.

It is zero-diff.

