### PR TITLE
update LONG_NAME attributes to match M21C file specs; conservative regridding of (obs) PRECIP_FILE inputs

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -6052,6 +6052,7 @@ module GEOS_SurfaceGridCompMod
     real, allocatable :: PRECSUM(:,:)
     character(len=ESMF_MAXPATHLEN) :: SolCycFileName
     logical :: PersistSolar
+    logical :: allocateRunoff
 
 !=============================================================================
 
@@ -7366,12 +7367,19 @@ module GEOS_SurfaceGridCompMod
     call MKTILE(LWNDSRF ,LWNDSRFTILE ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(SWNDSRF ,SWNDSRFTILE ,NT,RC=STATUS); VERIFY_(STATUS)
 
+    allocateRunoff = .false.
+    if (associated(RUNOFF)) allocateRunoff = .true.
+
     if (associated(SURF_INTERNAL_STATE%RoutingType) .or. DO_DATA_ATM4OCN) then ! routing file exists or we run DataAtm
        allocate(DISCHARGETILE(NT),stat=STATUS); VERIFY_(STATUS)
        DISCHARGETILE=MAPL_Undef
-       allocate(RUNOFFTILE(NT),stat=STATUS); VERIFY_(STATUS)
-       RUNOFFTILE=MAPL_Undef
+       allocateRunoff = .true.
     end if
+    if (allocateRunoff) then
+       allocate(RUNOFFTILE(NT),stat=STATUS); VERIFY_(STATUS)
+       RUNOFFTILE = 0.0
+    end if
+
     call MKTILE(RUNSURF ,RUNSURFTILE ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(BASEFLOW,BASEFLOWTILE,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(ACCUM   ,ACCUMTILE   ,NT,RC=STATUS); VERIFY_(STATUS)
@@ -7513,8 +7521,6 @@ module GEOS_SurfaceGridCompMod
 
 !  Cycle through all continental children (skip ocean),
 !   collecting RUNOFFTILE exports.
-
-    if (associated(RUNOFFTILE)) RUNOFFTILE       = 0.0
 
     do I = 1, NUM_CHILDREN
        if (I == OCEAN) cycle

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -552,7 +552,7 @@ module GEOS_SurfaceGridCompMod
 
     call MAPL_AddImportSpec(GC,                              &
         SHORT_NAME         = 'DRPARN',                            &
-        LONG_NAME          = 'normalized_surface_downwelling_par_beam_flux', &
+        LONG_NAME          = 'normalized_surface_downwelling_PAR_beam_flux', &
         UNITS              = '1',                                 &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -561,7 +561,7 @@ module GEOS_SurfaceGridCompMod
 
     call MAPL_AddImportSpec(GC,                              &
         SHORT_NAME         = 'DFPARN',                            &
-        LONG_NAME          = 'normalized_surface_downwelling_par_diffuse_flux', &
+        LONG_NAME          = 'normalized_surface_downwelling_PAR_diffuse_flux', &
         UNITS              = '1',                                 &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -683,7 +683,7 @@ module GEOS_SurfaceGridCompMod
 !  !EXPORT STATE:
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_beam',   &
+        LONG_NAME          = 'surface_reflectivity_for_visible_beam',   &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVR',                             &
         DIMS               = MAPL_DimsHorzOnly,                   &
@@ -692,7 +692,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_diffuse',&
+        LONG_NAME          = 'surface_reflectivity_for_visible_diffuse',&
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVF',                             &
         DIMS               = MAPL_DimsHorzOnly,                   &
@@ -701,7 +701,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_nearinfrared_beam', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_beam', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNR',                             &
         DIMS               = MAPL_DimsHorzOnly,                   &
@@ -710,7 +710,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_nearinfraed_diffuse', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_diffuse', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNF',                             &
         DIMS               = MAPL_DimsHorzOnly,                   &
@@ -766,7 +766,16 @@ module GEOS_SurfaceGridCompMod
 
      call MAPL_AddExportSpec(GC,                             &
         SHORT_NAME         = 'FRACI',                             &
-        LONG_NAME          = 'ice_covered_fraction_of_tile',      &
+        LONG_NAME          = 'ice_covered_fraction_of_grid_cell',      &
+        UNITS              = '1',                                 &
+        DIMS               = MAPL_DimsHorzOnly,                   &
+        VLOCATION          = MAPL_VLocationNone,                  &
+                                                       RC=STATUS  )
+     VERIFY_(STATUS)
+
+     call MAPL_AddExportSpec(GC,                             &
+        SHORT_NAME         = 'OFRACI',                            &
+        LONG_NAME          = 'ice_covered_fraction_of_ocean_area',&
         UNITS              = '1',                                 &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -938,7 +947,7 @@ module GEOS_SurfaceGridCompMod
 
      call MAPL_AddExportSpec(GC,                             &
         SHORT_NAME         = 'TSOIL1',                            &
-        LONG_NAME          = 'soil_temperatures_layer_1'         ,&
+        LONG_NAME          = 'soil_temperature_layer_1'          ,&
         UNITS              = 'K',                                 &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -947,7 +956,7 @@ module GEOS_SurfaceGridCompMod
 
      call MAPL_AddExportSpec(GC,                             &
         SHORT_NAME         = 'TSOIL2',                            &
-        LONG_NAME          = 'soil_temperatures_layer_2'         ,&
+        LONG_NAME          = 'soil_temperature_layer_2'          ,&
         UNITS              = 'K',                                 &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -956,7 +965,7 @@ module GEOS_SurfaceGridCompMod
 
      call MAPL_AddExportSpec(GC,                             &
         SHORT_NAME         = 'TSOIL3',                            &
-        LONG_NAME          = 'soil_temperatures_layer_3'         ,&
+        LONG_NAME          = 'soil_temperature_layer_3'          ,&
         UNITS              = 'K',                                 &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -965,7 +974,7 @@ module GEOS_SurfaceGridCompMod
 
      call MAPL_AddExportSpec(GC,                             &
         SHORT_NAME         = 'TSOIL4',                            &
-        LONG_NAME          = 'soil_temperatures_layer_4'         ,&
+        LONG_NAME          = 'soil_temperature_layer_4'          ,&
         UNITS              = 'K',                                 &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -974,7 +983,7 @@ module GEOS_SurfaceGridCompMod
 
      call MAPL_AddExportSpec(GC,                             &
         SHORT_NAME         = 'TSOIL5',                            &
-        LONG_NAME          = 'soil_temperatures_layer_5'         ,&
+        LONG_NAME          = 'soil_temperature_layer_5'          ,&
         UNITS              = 'K',                                 &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -983,7 +992,7 @@ module GEOS_SurfaceGridCompMod
 
      call MAPL_AddExportSpec(GC,                             &
         SHORT_NAME         = 'TSOIL6',                            &
-        LONG_NAME          = 'soil_temperatures_layer_6'         ,&
+        LONG_NAME          = 'soil_temperature_layer_6'          ,&
         UNITS              = 'K',                                 &
         DIMS               = MAPL_DimsHorzOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -992,7 +1001,7 @@ module GEOS_SurfaceGridCompMod
 
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'fractional_area_of_land_snowcover',&
+    LONG_NAME          = 'fractional_area_of_snow_on_land',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ASNOW'                     ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1019,7 +1028,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_temperature_of_snow',&
+    LONG_NAME          = 'surface_temperature_of_snow_on_land',&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPSNOW'                    ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1046,7 +1055,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_temperature_of_wilted_zone',&
+    LONG_NAME          = 'surface_temperature_of_wilting_zone',&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPWLT'                     ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1100,7 +1109,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'surface_soil_wetness'              ,&
+        LONG_NAME          = 'soil_wetness_surface'              ,&
         UNITS              = '1'                                 ,&
         SHORT_NAME         = 'WET1'                              ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&
@@ -1109,7 +1118,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'surface_soil_wetness_for_chem'     ,&
+        LONG_NAME          = 'soil_wetness_surface_for_chem'     ,&
         UNITS              = '1'                                 ,&
         SHORT_NAME         = 'WET1_FOR_CHEM'                     ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&
@@ -1118,7 +1127,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'root_zone_soil_wetness'            ,&
+        LONG_NAME          = 'soil_wetness_rootzone'             ,&
         UNITS              = '1'                                 ,&
         SHORT_NAME         = 'WET2'                              ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&
@@ -1127,7 +1136,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'ave_prof_soil_moisture'            ,&
+        LONG_NAME          = 'soil_wetness_profile'              ,&
         UNITS              = '1'                                 ,&
         SHORT_NAME         = 'WET3'                              ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&
@@ -1136,7 +1145,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'water_surface_layer'               ,&
+        LONG_NAME          = 'soil_moisture_surface'             ,&
         UNITS              = 'm3 m-3'                            ,&
         SHORT_NAME         = 'WCSF'                              ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&
@@ -1145,7 +1154,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'water_root_zone'                   ,&
+        LONG_NAME          = 'soil_moisture_rootzone'            ,&
         UNITS              = 'm3 m-3'                            ,&
         SHORT_NAME         = 'WCRZ'                              ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&
@@ -1154,7 +1163,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'water_profile'                     ,&
+        LONG_NAME          = 'soil_moisture_profile'             ,&
         UNITS              = 'm3 m-3'                            ,&
         SHORT_NAME         = 'WCPR'                              ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&
@@ -1172,7 +1181,7 @@ module GEOS_SurfaceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'greenness_fraction'                ,&
+        LONG_NAME          = 'vegetation_greenness_fraction'     ,&
         UNITS              = '1'                                 ,&
         SHORT_NAME         = 'GRN'                               ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&
@@ -1418,7 +1427,7 @@ module GEOS_SurfaceGridCompMod
     VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                             ,&
-        LONG_NAME          = 'snow_depth_within_snow_covered_area_fraction'   ,&
+        LONG_NAME          = 'snow_depth_within_snow_covered_area_fraction_on_land'   ,&
         UNITS              = 'm'                                 ,&
         SHORT_NAME         = 'SNOWDP'                            ,&
         DIMS               = MAPL_DimsHorzOnly                   ,&
@@ -1603,7 +1612,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'runoff_flux',&
+    LONG_NAME          = 'runoff_total_flux'         ,&
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'RUNOFF'                    ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1693,7 +1702,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'baseflow_flux'             ,&
+    LONG_NAME          = 'baseflow_flux_land'        ,&
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'BASEFLOW'                  ,&
     DIMS               = MAPL_DimsHorzOnly           ,&
@@ -1712,7 +1721,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'EVLAND',                    &
-    LONG_NAME          = 'Total_evapotranspiration_land',          &
+    LONG_NAME          = 'total_evapotranspiration_land',          &
     UNITS              = 'kg m-2 s-1',                &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1739,7 +1748,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'DRPARLAND',                 &
-    LONG_NAME          = 'surface_downwelling_par_beam_flux', &
+    LONG_NAME          = 'surface_downwelling_PAR_beam_flux', &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1748,7 +1757,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'DFPARLAND',                 &
-    LONG_NAME          = 'surface_downwelling_par_diffuse_flux', &
+    LONG_NAME          = 'surface_downwelling_PAR_diffuse_flux', &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1793,7 +1802,7 @@ module GEOS_SurfaceGridCompMod
 
    call MAPL_AddExportSpec(GC,                    &
      SHORT_NAME         = 'SWNETSNOW',                    &
-     LONG_NAME          = 'Net_shortwave_snow',        &
+     LONG_NAME          = 'Net_shortwave_flux_snow',        &
      UNITS              = 'W m-2',                     &
      DIMS               = MAPL_DimsHorzOnly,           &
      VLOCATION          = MAPL_VLocationNone,          &
@@ -1820,7 +1829,7 @@ module GEOS_SurfaceGridCompMod
 
    call MAPL_AddExportSpec(GC,                    &
      SHORT_NAME         = 'GHSNOW',                    &
-     LONG_NAME          = 'Ground_heating_snow',       &
+     LONG_NAME          = 'Ground_heating_flux_snow',       &
      UNITS              = 'W m-2',                     &
      DIMS               = MAPL_DimsHorzOnly,           &
      VLOCATION          = MAPL_VLocationNone,          &
@@ -1847,7 +1856,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SWLAND',                    &
-    LONG_NAME          = 'Net_shortwave_land',        &
+    LONG_NAME          = 'Net_shortwave_flux_land',   &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1856,7 +1865,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SWDOWNLAND',                &
-    LONG_NAME          = 'Incident_shortwave_land',   &
+    LONG_NAME          = 'Incident_shortwave_flux_land',   &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1865,7 +1874,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'LWLAND',                    &
-    LONG_NAME          = 'Net_longwave_land',         &
+    LONG_NAME          = 'Net_longwave_flux_land',         &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1874,7 +1883,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'GHLAND',                    &
-    LONG_NAME          = 'Ground_heating_land',       &
+    LONG_NAME          = 'Ground_heating_flux_land',       &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1883,7 +1892,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'GHTSKIN',                   &
-    LONG_NAME          = 'Ground_heating_for_skin_temp',&
+    LONG_NAME          = 'Ground_heating_flux_for_skin_temp',&
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -1910,7 +1919,7 @@ module GEOS_SurfaceGridCompMod
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'TWLAND',                    &
-    LONG_NAME          = 'Avail_water_storage_land',  &
+    LONG_NAME          = 'total_water_storage_land',  &
     UNITS              = 'kg m-2',                    &
     DIMS               = MAPL_DimsHorzOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2395,7 +2404,7 @@ module GEOS_SurfaceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                             &
-       LONG_NAME          = 'interception_reservoir_capac',      &
+       LONG_NAME          = 'vegetation_interception_water_storage',      &
        UNITS              = 'kg m-2',                            &
        SHORT_NAME         = 'CAPAC',                             &
        DIMS               = MAPL_DimsHorzOnly,                   &
@@ -3343,7 +3352,7 @@ module GEOS_SurfaceGridCompMod
 
      call MAPL_AddInternalSpec(GC,                           &
         SHORT_NAME         = 'TS',                                &
-        LONG_NAME          = 'surface_skin_temperature',          &
+        LONG_NAME          = 'surface_temperature',          &
         UNITS              = 'K',                                 &
         FriendlyTO         = trim(COMP_NAME),                     &
         DIMS               = MAPL_DimsHorzOnly,                   &
@@ -5384,6 +5393,7 @@ module GEOS_SurfaceGridCompMod
 
     real, pointer, dimension(:,:) :: LST       => NULL()
     real, pointer, dimension(:,:) :: FRI       => NULL()
+    real, pointer, dimension(:,:) :: OFRI      => NULL()
     real, pointer, dimension(:,:) :: EMISS     => NULL()
     real, pointer, dimension(:,:) :: ALBVR     => NULL()
     real, pointer, dimension(:,:) :: ALBVF     => NULL()
@@ -5738,6 +5748,7 @@ module GEOS_SurfaceGridCompMod
 
     real, pointer, dimension(:) :: LSTTILE      => NULL()
     real, pointer, dimension(:) :: FRTILE       => NULL()
+    real, pointer, dimension(:) :: OFRTILE      => NULL()
     real, pointer, dimension(:) :: EMISSTILE    => NULL()
     real, pointer, dimension(:) :: ALBVRTILE    => NULL()
     real, pointer, dimension(:) :: ALBVFTILE    => NULL()
@@ -6425,7 +6436,7 @@ module GEOS_SurfaceGridCompMod
 
      ! call MAPL_CFIORead( PRECIP_FILE, CurrentTime, Bundle, RC=STATUS)
      ! VERIFY_(STATUS)
-       call MAPL_read_bundle( Bundle,PRECIP_FILE, CurrentTime, RC=status)
+       call MAPL_read_bundle( Bundle, PRECIP_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
        VERIFY_(STATUS)
        call ESMFL_BundleGetPointerToData(Bundle,'PRECTOT',PTTe, RC=STATUS)
        VERIFY_(STATUS)
@@ -6879,6 +6890,10 @@ module GEOS_SurfaceGridCompMod
     call MAPL_GetPointer(EXPORT  , FRI     , 'FRACI'  ,  alloc=associated(LWI) , rC=STATUS)
     VERIFY_(STATUS)
 
+! Not sure about why alloc of FRI depends on LWI, but copy the logic anyway 
+    call MAPL_GetPointer(EXPORT  , OFRI    , 'OFRACI' ,  alloc=associated(LWI) , rC=STATUS)
+    VERIFY_(STATUS)
+
 !    FRI =  max(min(FRI,1.0),0.0)
 
 ! RiverRouting: force allocations of RUNOFF from continental components,
@@ -7249,6 +7264,7 @@ module GEOS_SurfaceGridCompMod
     call MKTILE(ALBNF   ,ALBNFTILE   ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(EMISS   ,EMISSTILE   ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(FRI     ,FRTILE      ,NT,RC=STATUS); VERIFY_(STATUS)
+    call MKTILE(OFRI    ,OFRTILE     ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(TSOIL1  ,TSOIL1TILE  ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(TSOIL2  ,TSOIL2TILE  ,NT,RC=STATUS); VERIFY_(STATUS)
     call MKTILE(TSOIL3  ,TSOIL3TILE  ,NT,RC=STATUS); VERIFY_(STATUS)
@@ -7492,7 +7508,8 @@ module GEOS_SurfaceGridCompMod
     end if
 
 
-    FRTILE = 0.0
+    FRTILE  = 0.0
+    OFRTILE = MAPL_UNDEF
 
 !  Cycle through all continental children (skip ocean),
 !   collecting RUNOFFTILE exports.
@@ -7677,7 +7694,11 @@ module GEOS_SurfaceGridCompMod
        VERIFY_(STATUS)
     endif
     if(associated( FRI  )) then
-       call MAPL_LocStreamTransform( LOCSTREAM,  FRI  ,     FRTILE, RC=STATUS)
+       call MAPL_LocStreamTransform( LOCSTREAM,  FRI  ,     FRTILE, RC=STATUS) 
+       VERIFY_(STATUS)
+    endif
+    if(associated( OFRI )) then
+       call MAPL_LocStreamTransform( LOCSTREAM,  OFRI ,    OFRTILE, RC=STATUS) 
        VERIFY_(STATUS)
     endif
     if(associated(TSOIL1)) then
@@ -9030,6 +9051,7 @@ module GEOS_SurfaceGridCompMod
     if(associated(ALBVRTILE ))  deallocate(ALBVRTILE)
     if(associated(EMISSTILE ))  deallocate(EMISSTILE)
     if(associated(FRTILE    ))  deallocate(FRTILE   )
+    if(associated(OFRTILE   ))  deallocate(OFRTILE  )
 
     if(associated(DUDP)) deallocate( DUDP )
     if(associated(DUWT)) deallocate( DUWT )
@@ -9299,6 +9321,9 @@ module GEOS_SurfaceGridCompMod
       call MAPL_GetPointer(GEX(type), dum, 'SPSNOW'  , ALLOC=associated(SPSNOWTILE  ), notFoundOK=.true., RC=STATUS)
       VERIFY_(STATUS)
       call MAPL_GetPointer(GEX(type), dum, 'FRACI'   , ALLOC=associated(   FRTILE   ), notFoundOK=.true., RC=STATUS)
+      VERIFY_(STATUS)
+! in case FRACI removed in future
+      call MAPL_GetPointer(GEX(type), dum, 'FRACI'   , ALLOC=associated(  OFRTILE   ), notFoundOK=.true., RC=STATUS)
       VERIFY_(STATUS)
       call MAPL_GetPointer(GEX(type), dum, 'RDU001'  , ALLOC=associated(RDU001TILE  ), notFoundOK=.true., RC=STATUS)
       VERIFY_(STATUS)
@@ -9678,6 +9703,10 @@ module GEOS_SurfaceGridCompMod
       end if
       if(associated(   FRTILE)) then
          call FILLOUT_TILE(GEX(type), 'FRACI',      FRTILE, XFORM, RC=STATUS)
+         VERIFY_(STATUS)
+      end if
+      if(associated(  OFRTILE)) then
+         call FILLOUT_TILE(GEX(type), 'FRACI',     OFRTILE, XFORM, RC=STATUS)
          VERIFY_(STATUS)
       end if
       if(associated(TSOIL1TILE)) then

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlake_GridComp/GEOS_LakeGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlake_GridComp/GEOS_LakeGridComp.F90
@@ -137,7 +137,7 @@ module GEOS_LakeGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_beam',   &
+        LONG_NAME          = 'surface_reflectivity_for_visible_beam',   &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -146,7 +146,7 @@ module GEOS_LakeGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_diffuse',&
+        LONG_NAME          = 'surface_reflectivity_for_visible_diffuse',&
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -155,7 +155,7 @@ module GEOS_LakeGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_beam', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_beam', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -164,7 +164,7 @@ module GEOS_LakeGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_diffuse', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_diffuse', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -192,7 +192,7 @@ module GEOS_LakeGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
-          LONG_NAME          = 'runoff_flux',&
+          LONG_NAME          = 'runoff_total_flux'         ,&
           UNITS              = 'kg m-2 s-1'                ,&
           SHORT_NAME         = 'RUNOFF'                    ,&
           DIMS               = MAPL_DimsTileOnly           ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOS_CatchCNGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOS_CatchCNGridComp.F90
@@ -245,7 +245,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'surface_downwelling_par_beam_flux',&
+         LONG_NAME          = 'surface_downwelling_PAR_beam_flux',&
          UNITS              = 'W m-2'                       ,&
          SHORT_NAME         = 'DRPAR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -254,7 +254,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'surface_downwelling_par_diffuse_flux',&
+         LONG_NAME          = 'surface_downwelling_PAR_diffuse_flux',&
          UNITS              = 'W m-2'                       ,&
          SHORT_NAME         = 'DFPAR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -346,7 +346,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'greeness_fraction'           ,&
+         LONG_NAME          = 'vegetation_greenness_fraction',&
          UNITS              = '1'                           ,&
          SHORT_NAME         = 'GRN'                         ,&
          DIMS               = MAPL_DimsTileOnly             ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/GEOS_CatchCNCLM40GridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/GEOS_CatchCNCLM40GridComp.F90
@@ -344,7 +344,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'surface_downwelling_par_beam_flux',&
+         LONG_NAME          = 'surface_downwelling_PAR_beam_flux',&
          UNITS              = 'W m-2'                       ,&
          SHORT_NAME         = 'DRPAR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -353,7 +353,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
     
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'surface_downwelling_par_diffuse_flux',&
+         LONG_NAME          = 'surface_downwelling_PAR_diffuse_flux',&
          UNITS              = 'W m-2'                       ,&
          SHORT_NAME         = 'DFPAR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -445,7 +445,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'greeness_fraction'           ,&
+         LONG_NAME          = 'vegetation_greenness_fraction'           ,&
          UNITS              = '1'                           ,&
          SHORT_NAME         = 'GRN'                         ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -1161,7 +1161,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddInternalSpec(GC                  ,&
-    LONG_NAME          = 'interception_reservoir_capac',&
+    LONG_NAME          = 'vegetation_interception_water_storage',&
     UNITS              = 'kg m-2'                    ,&
     SHORT_NAME         = 'CAPAC'                     ,&
     FRIENDLYTO         = trim(COMP_NAME)             ,&
@@ -2172,7 +2172,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'runoff_flux'               ,&
+    LONG_NAME          = 'runoff_total_flux'         ,&
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'RUNOFF'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2208,7 +2208,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snow_ice_evaporation_energy_flux',&
+    LONG_NAME          = 'snow_ice_evaporation_energy_flux_on_land',&
     UNITS              = 'W m-2'                     ,&
     SHORT_NAME         = 'EVPICE'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2227,7 +2227,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'totoal soil moisture'      ,&
+    LONG_NAME          = 'total_soil_moisture'      ,&
     UNITS              = 'kg m-2'                    ,&
     SHORT_NAME         = 'WATSOI'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2253,7 +2253,7 @@ subroutine SetServices ( GC, RC )
                                            RC=STATUS  )
   VERIFY_(STATUS)
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'baseflow_flux'             ,&
+    LONG_NAME          = 'baseflow_flux_land'             ,&
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'BASEFLOW'                  ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2389,7 +2389,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'ave_catchment_temp_incl_snw',& 
+    LONG_NAME          = 'surface_temperature_of_land_incl_snow',& 
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPSURF'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2398,7 +2398,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'temperature_top_snow_layer',&
+    LONG_NAME          = 'surface_temperature_of_snow_on_land',&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPSNOW'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2407,7 +2407,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'temperature_unsaturated_zone',&
+    LONG_NAME          = 'surface_temperature_of_unsaturated_zone',&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPUNST'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2416,7 +2416,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'temperature_saturated_zone',&
+    LONG_NAME          = 'surface_temperature_of_saturated_zone',&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPSAT'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2425,7 +2425,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'temperature_wilted_zone'   ,&
+    LONG_NAME          = 'surface_temperature_of_wilting_zone'   ,&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPWLT'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2434,7 +2434,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'fractional_area_of_land_snowcover',&
+    LONG_NAME          = 'fractional_area_of_snow_on_land',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ASNOW'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2497,7 +2497,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snow_depth_within_snow_covered_area_fraction' ,&
+    LONG_NAME          = 'snow_depth_within_snow_covered_area_fraction_on_land' ,&
     UNITS              = 'm'                         ,&
     SHORT_NAME         = 'SNOWDP'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2506,7 +2506,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_soil_wetness'      ,&
+    LONG_NAME          = 'soil_wetness_surface'      ,&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'WET1'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2515,7 +2515,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'root_zone_soil_wetness'    ,&
+    LONG_NAME          = 'soil_wetness_rootzone'    ,&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'WET2'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2524,7 +2524,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'ave_prof_soil__moisture'   ,&
+    LONG_NAME          = 'soil_wetness_profile'   ,&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'WET3'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2533,7 +2533,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'water_surface_layer'       ,&
+    LONG_NAME          = 'soil_moisture_surface'       ,&
     UNITS              = 'm3 m-3'                    ,&
     SHORT_NAME         = 'WCSF'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2542,7 +2542,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'water_root_zone'           ,&
+    LONG_NAME          = 'soil_moisture_rootzone'           ,&
     UNITS              = 'm3 m-3'                    ,&
     SHORT_NAME         = 'WCRZ'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2551,7 +2551,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'water_ave_prof'            ,&
+    LONG_NAME          = 'soil_moisture_profile'            ,&
     UNITS              = 'm3 m-3'                   ,&
     SHORT_NAME         = 'WCPR'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2560,7 +2560,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_1' ,&
+    LONG_NAME          = 'soil_temperature_layer_1' ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP1'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2569,7 +2569,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_2' ,&
+    LONG_NAME          = 'soil_temperature_layer_2' ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP2'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2578,7 +2578,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_3' ,&
+    LONG_NAME          = 'soil_temperature_layer_3' ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP3'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2587,7 +2587,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_4' ,&
+    LONG_NAME          = 'soil_temperature_layer_4' ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP4'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2596,7 +2596,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_5' ,&
+    LONG_NAME          = 'soil_temperature_layer_5' ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP5'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2605,7 +2605,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_6' ,&
+    LONG_NAME          = 'soil_temperature_layer_6' ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP6'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2623,7 +2623,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_albedo_visible_beam',&
+    LONG_NAME          = 'surface_reflectivity_visible_beam',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ALBVR'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2632,7 +2632,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_albedo_visible_diffuse',&
+    LONG_NAME          = 'surface_reflectivity_visible_diffuse',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ALBVF'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2641,7 +2641,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_albedo_near_infrared_beam',&
+    LONG_NAME          = 'surface_reflectivity_near_infrared_beam',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ALBNR'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2650,7 +2650,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_albedo_near_infrared_diffuse',&
+    LONG_NAME          = 'surface_reflectivity_near_infrared_diffuse',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ALBNF'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2932,7 +2932,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'EVLAND',                    &
-    LONG_NAME          = 'Evaporation_land',          &
+    LONG_NAME          = 'total_evapotranspiration_land',          &
     UNITS              = 'kg m-2 s-1',                &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2959,7 +2959,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'DRPARLAND',                 &
-    LONG_NAME          = 'surface_downwelling_par_beam_flux', &
+    LONG_NAME          = 'surface_downwelling_PAR_beam_flux', &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2968,7 +2968,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'DFPARLAND',                 &
-    LONG_NAME          = 'surface_downwelling_par_diffuse_flux', &
+    LONG_NAME          = 'surface_downwelling_PAR_diffuse_flux', &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2987,7 +2987,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SWNETSNOW',                    &
-    LONG_NAME          = 'Net_shortwave_snow',        &
+    LONG_NAME          = 'Net_shortwave_flux_snow',        &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3071,7 +3071,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SWLAND',                    &
-    LONG_NAME          = 'Net_shortwave_land',        &
+    LONG_NAME          = 'Net_shortwave_flux_land',        &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3080,7 +3080,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SWDOWNLAND',                &
-    LONG_NAME          = 'Incident_shortwave_land',   &
+    LONG_NAME          = 'Incident_shortwave_flux_land',   &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3090,7 +3090,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'LWLAND',                    &
-    LONG_NAME          = 'Net_longwave_land',         &
+    LONG_NAME          = 'Net_longwave_flux_land',         &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3100,7 +3100,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'GHLAND',                    &
-    LONG_NAME          = 'Ground_heating_land',       &
+    LONG_NAME          = 'Ground_heating_flux_land',       &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3109,7 +3109,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'GHTSKIN',                   &
-    LONG_NAME          = 'Ground_heating_skin_temp',  &
+    LONG_NAME          = 'Ground_heating_flux_for_skin_temp_land',  &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3128,7 +3128,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'TWLAND',                    &
-    LONG_NAME          = 'Avail_water_storage_land',  &
+    LONG_NAME          = 'total_water_storage_land',  &
     UNITS              = 'kg m-2',                    &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3174,7 +3174,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SPLAND',                    &
-    LONG_NAME          = 'rate_of_spurious_land_energy_source',&
+    LONG_NAME          = 'rate_of_spurious_energy_source_land',&
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3183,7 +3183,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SPWATR',                    &
-    LONG_NAME          = 'rate_of_spurious_land_water_source',&
+    LONG_NAME          = 'rate_of_spurious_water_source_land',&
     UNITS              = 'kg m-2 s-1',                &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -3192,7 +3192,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SPSNOW',                    &
-    LONG_NAME          = 'rate_of_spurious_snow_energy',&
+    LONG_NAME          = 'rate_of_spurious_snow_energy_source_land',&
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/GEOS_CatchCNCLM40GridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM40_GridComp/GEOS_CatchCNCLM40GridComp.F90
@@ -1381,7 +1381,7 @@ subroutine SetServices ( GC, RC )
 
   if (SNOW_ALBEDO_INFO == 1) then
     call MAPL_AddInternalSpec(GC                  ,&
-       LONG_NAME          = 'effective_snow_albedo'               ,&
+       LONG_NAME          = 'effective_snow_reflectivity',&
        UNITS              = '1'                         ,&
        SHORT_NAME         = 'SNOWALB'                   ,&
        FRIENDLYTO         = trim(COMP_NAME)             ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
@@ -321,7 +321,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
     
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'surface_downwelling_par_beam_flux',&
+         LONG_NAME          = 'surface_downwelling_PAR_beam_flux',&
          UNITS              = 'W m-2'                       ,&
          SHORT_NAME         = 'DRPAR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -330,7 +330,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'surface_downwelling_par_diffuse_flux',&
+         LONG_NAME          = 'surface_downwelling_PAR_diffuse_flux',&
          UNITS              = 'W m-2'                       ,&
          SHORT_NAME         = 'DFPAR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -411,7 +411,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     call MAPL_AddImportSpec(GC                         ,&
-         LONG_NAME          = 'greeness_fraction'           ,&
+         LONG_NAME          = 'vegetation_greenness_fraction',&
          UNITS              = '1'                           ,&
          SHORT_NAME         = 'GRN'                         ,&
          DIMS               = MAPL_DimsTileOnly             ,&
@@ -1112,7 +1112,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddInternalSpec(GC                  ,&
-    LONG_NAME          = 'interception_reservoir_capac',&
+    LONG_NAME          = 'vegetation_interception_water_storage',&
     UNITS              = 'kg m-2'                    ,&
     SHORT_NAME         = 'CAPAC'                     ,&
     FRIENDLYTO         = trim(COMP_NAME)             ,&
@@ -1564,7 +1564,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'runoff_flux'               ,&
+    LONG_NAME          = 'runoff_total_flux'         ,&
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'RUNOFF'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1619,7 +1619,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'totoal soil moisture'      ,&
+    LONG_NAME          = 'total_soil_moisture'       ,&
     UNITS              = 'kg m-2'                    ,&
     SHORT_NAME         = 'WATSOI'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1645,7 +1645,7 @@ subroutine SetServices ( GC, RC )
                                            RC=STATUS  )
   VERIFY_(STATUS)
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'baseflow_flux'             ,&
+    LONG_NAME          = 'baseflow_flux_land'        ,&
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'BASEFLOW'                  ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1780,7 +1780,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'ave_catchment_temp_incl_snw',& 
+    LONG_NAME          = 'surface_temperature_of_land_incl_snow',& 
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPSURF'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1789,7 +1789,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'temperature_top_snow_layer',&
+    LONG_NAME          = 'surface_temperature_of_snow_on_land',&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPSNOW'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1798,7 +1798,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'temperature_unsaturated_zone',&
+    LONG_NAME          = 'surface_temperature_of_unsaturated_zone',&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPUNST'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1807,7 +1807,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'temperature_saturated_zone',&
+    LONG_NAME          = 'surface_temperature_of_saturated_zone',&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPSAT'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1816,7 +1816,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'temperature_wilted_zone'   ,&
+    LONG_NAME          = 'surface_temperature_of_wilting_zone'   ,&
     UNITS              = 'K'                         ,&
     SHORT_NAME         = 'TPWLT'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1825,7 +1825,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'fractional_area_of_land_snowcover',&
+    LONG_NAME          = 'fractional_area_of_snow_on_land',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ASNOW'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1888,7 +1888,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snow_depth_within_snow_covered_area_fraction'   ,&
+    LONG_NAME          = 'snow_depth_within_snow_covered_area_fraction_on_land'   ,&
     UNITS              = 'm'                         ,&
     SHORT_NAME         = 'SNOWDP'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1897,7 +1897,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_soil_wetness'      ,&
+    LONG_NAME          = 'soil_wetness_surface'      ,&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'WET1'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1906,7 +1906,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'root_zone_soil_wetness'    ,&
+    LONG_NAME          = 'soil_wetness_rootzone'     ,&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'WET2'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1915,7 +1915,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'ave_prof_soil__moisture'   ,&
+    LONG_NAME          = 'soil_wetness_profile'      ,&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'WET3'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1924,7 +1924,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'water_surface_layer'       ,&
+    LONG_NAME          = 'soil_moisture_surface'     ,&
     UNITS              = 'm3 m-3'                    ,&
     SHORT_NAME         = 'WCSF'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1933,7 +1933,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'water_root_zone'           ,&
+    LONG_NAME          = 'soil_moisture_rootzone'    ,&
     UNITS              = 'm3 m-3'                    ,&
     SHORT_NAME         = 'WCRZ'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1942,8 +1942,8 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'water_ave_prof'            ,&
-    UNITS              = 'm3 m-3'                   ,&
+    LONG_NAME          = 'soil_moisture_profile'     ,&
+    UNITS              = 'm3 m-3'                    ,&
     SHORT_NAME         = 'WCPR'                      ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
@@ -1951,7 +1951,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_1' ,&
+    LONG_NAME          = 'soil_temperature_layer_1'  ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP1'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1960,7 +1960,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_2' ,&
+    LONG_NAME          = 'soil_temperature_layer_2'  ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP2'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1969,7 +1969,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_3' ,&
+    LONG_NAME          = 'soil_temperature_layer_3'  ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP3'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1978,7 +1978,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_4' ,&
+    LONG_NAME          = 'soil_temperature_layer_4'  ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP4'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1987,7 +1987,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_5' ,&
+    LONG_NAME          = 'soil_temperature_layer_5'  ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP5'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -1996,7 +1996,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'soil_temperatures_layer_6' ,&
+    LONG_NAME          = 'soil_temperature_layer_6'  ,&
     UNITS              = 'K'                         ,&  ! units now K, rreichle & borescan, 6 Nov 2020
     SHORT_NAME         = 'TP6'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2014,7 +2014,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_albedo_visible_beam',&
+    LONG_NAME          = 'surface_reflectivity_visible_beam',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ALBVR'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2023,7 +2023,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_albedo_visible_diffuse',&
+    LONG_NAME          = 'surface_reflectivity_visible_diffuse',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ALBVF'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2032,7 +2032,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_albedo_near_infrared_beam',&
+    LONG_NAME          = 'surface_reflectivity_near_infrared_beam',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ALBNR'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2041,7 +2041,7 @@ subroutine SetServices ( GC, RC )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'surface_albedo_near_infrared_diffuse',&
+    LONG_NAME          = 'surface_reflectivity_near_infrared_diffuse',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ALBNF'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -2323,7 +2323,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'EVLAND',                    &
-    LONG_NAME          = 'Total_evapotranspiration_land',          &
+    LONG_NAME          = 'total_evapotranspiration_land',          &
     UNITS              = 'kg m-2 s-1',                &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2350,7 +2350,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'DRPARLAND',                 &
-    LONG_NAME          = 'surface_downwelling_par_beam_flux', &
+    LONG_NAME          = 'surface_downwelling_PAR_beam_flux', &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2359,7 +2359,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'DFPARLAND',                 &
-    LONG_NAME          = 'surface_downwelling_par_diffuse_flux', &
+    LONG_NAME          = 'surface_downwelling_PAR_diffuse_flux', &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2378,7 +2378,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SWNETSNOW',                    &
-    LONG_NAME          = 'Net_shortwave_snow',        &
+    LONG_NAME          = 'Net_shortwave_flux_snow',        &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2462,7 +2462,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SWLAND',                    &
-    LONG_NAME          = 'Net_shortwave_land',        &
+    LONG_NAME          = 'Net_shortwave_flux_land',   &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2471,7 +2471,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'SWDOWNLAND',                &
-    LONG_NAME          = 'Incident_shortwave_land',   &
+    LONG_NAME          = 'Incident_shortwave_flux_land',   &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2481,7 +2481,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'LWLAND',                    &
-    LONG_NAME          = 'Net_longwave_land',         &
+    LONG_NAME          = 'Net_longwave_flux_land',    &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2491,7 +2491,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'GHLAND',                    &
-    LONG_NAME          = 'Ground_heating_land',       &
+    LONG_NAME          = 'Ground_heating_flux_land',  &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2500,7 +2500,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'GHTSKIN',                   &
-    LONG_NAME          = 'Ground_heating_skin_temp',  &
+    LONG_NAME          = 'Ground_heating_flux_for_skin_temp_land',  &
     UNITS              = 'W m-2',                     &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2519,7 +2519,7 @@ subroutine SetServices ( GC, RC )
 
   call MAPL_AddExportSpec(GC,                    &
     SHORT_NAME         = 'TWLAND',                    &
-    LONG_NAME          = 'Avail_water_storage_land',  &
+    LONG_NAME          = 'total_water_storage_land',  &
     UNITS              = 'kg m-2',                    &
     DIMS               = MAPL_DimsTileOnly,           &
     VLOCATION          = MAPL_VLocationNone,          &
@@ -2921,7 +2921,7 @@ subroutine Initialize ( GC, IMPORT, EXPORT, CLOCK, RC )
     call MAPL_TimerOn(MAPL,"INITIALIZE")
 
 
-    ! retrieve interal state
+    ! retrieve internal state
 
     call ESMF_UserCompGetInternalState ( GC, 'CatchInternal',wrap,status )
     VERIFY_(STATUS)
@@ -5159,15 +5159,15 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
 
         QC(:,FSNW) = QSAT(:,FSNW)
         
-! --------------------------------------------------------------------------
+	! --------------------------------------------------------------------------
         ! get total solid precip
         ! --------------------------------------------------------------------------
 
         SLDTOT = SNO+ICE+FRZR
         
-! protect the forcing from unsavory values, as per practice in offline
-! driver
-! --------------------------------------------------------------------------
+	! protect the forcing from unsavory values, as per practice in offline
+	! driver
+	! --------------------------------------------------------------------------
 
         _ASSERT(count(PLS<0.)==0,'needs informative message')
         _ASSERT(count(PCU<0.)==0,'needs informative message')

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
@@ -1332,7 +1332,7 @@ subroutine SetServices ( GC, RC )
 
   if (CATCH_INTERNAL_STATE%SNOW_ALBEDO_INFO == 1) then
     call MAPL_AddInternalSpec(GC                        ,&
-       LONG_NAME          = 'effective_snow_albedo'     ,&
+       LONG_NAME          = 'effective_snow_reflectivity'     ,&
        UNITS              = '1'                         ,&
        SHORT_NAME         = 'SNOWALB'                   ,&
        FRIENDLYTO         = trim(COMP_NAME)             ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
@@ -178,7 +178,7 @@ contains
 ! -----------------------------------------------------------
 
     call MAPL_AddImportSpec(GC,                          &
-         LONG_NAME          = 'runoff_flux'               ,&
+         LONG_NAME          = 'runoff_total_flux'         ,&
          UNITS              = 'kg m-2 s-1'                ,&
          SHORT_NAME         = 'RUNOFF'                    ,&
          DIMS               = MAPL_DimsTileOnly           ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSvegdyn_GridComp/GEOS_VegdynGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSvegdyn_GridComp/GEOS_VegdynGridComp.F90
@@ -217,7 +217,7 @@ contains
 
     call MAPL_AddExportSpec(GC                                ,&
        SHORT_NAME = 'GRN'                                     ,&
-       LONG_NAME  = 'greeness_fraction'			      ,&
+       LONG_NAME  = 'vegetation_greenness_fraction'           ,&
        UNITS      = '1'                                       ,&
        DIMS       = MAPL_DimsTileOnly                         ,&
        VLOCATION  = MAPL_VLocationNone                        ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -596,7 +596,7 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snow_broadband_albedo',   &
+    LONG_NAME          = 'snow_broadband_reflectivity',   &
     UNITS              = '1'                ,&
     SHORT_NAME         = 'SNOWALB'                   ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -605,7 +605,7 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'aggregated_snow_ice_broadband_albedo',   &
+    LONG_NAME          = 'aggregated_snow_ice_broadband_reflectivity',   &
     UNITS              = '1'                ,&
     SHORT_NAME         = 'SNICEALB'                   ,&
     DIMS               = MAPL_DimsTileOnly           ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -198,7 +198,7 @@ module GEOS_LandiceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_beam',   &
+        LONG_NAME          = 'surface_reflectivity_for_visible_beam',   &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -207,7 +207,7 @@ module GEOS_LandiceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_diffuse',&
+        LONG_NAME          = 'surface_reflectivity_for_visible_diffuse',&
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -216,7 +216,7 @@ module GEOS_LandiceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_beam', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_beam', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -225,7 +225,7 @@ module GEOS_LandiceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_diffuse', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_diffuse', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -235,7 +235,7 @@ module GEOS_LandiceGridCompMod
 
      call MAPL_AddExportSpec(GC,                             &
         SHORT_NAME         = 'TST',                               &
-        LONG_NAME          = 'surface_skin_temperature',          &
+        LONG_NAME          = 'surface_temperature',          &
         UNITS              = 'K',                                 &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
@@ -397,7 +397,7 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'fractional_area_of_glaciated_surface_snowcover',&
+    LONG_NAME          = 'fractional_snow_covered_area_of_glaciated_surface',&
     UNITS              = '1'                         ,&
     SHORT_NAME         = 'ASNOW_GL'                  ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -485,7 +485,7 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'top_snow_layer_mass_change_due_to_sub_con',   &
+    LONG_NAME          = 'top_snow_layer_mass_change_due_to_sublimation_and_condensation',   &
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'WESNSC'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -569,7 +569,7 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'contribution_to_smb_from_refreezed_rain_over_bare_ice',   &
+    LONG_NAME          = 'contribution_to_surface_mass_balance_from_rain_frozen_onto_bare_ice',   &
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'RAINRFZ'                   ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -578,7 +578,7 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'snowmelt_flux'             ,&
+    LONG_NAME          = 'snow_melt_flux'             ,&
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'SMELT'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -587,7 +587,7 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'icemelt_flux'             ,&
+    LONG_NAME          = 'ice_melt_flux'             ,&
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'IMELT'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -623,7 +623,7 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'melt_water_content',   &
+    LONG_NAME          = 'snowpack_meltwater_content',   &
     UNITS              = 'kg m-2'                ,&
     SHORT_NAME         = 'MELTWTRCONT'               ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -641,7 +641,7 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
-    LONG_NAME          = 'runoff_flux'               ,&
+    LONG_NAME          = 'runoff_total_flux'         ,&
     UNITS              = 'kg m-2 s-1'                ,&
     SHORT_NAME         = 'RUNOFF'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
@@ -848,7 +848,7 @@ module GEOS_LandiceGridCompMod
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
-        LONG_NAME          = 'Ground_heating_for_tskin'  ,&
+        LONG_NAME          = 'glacier_ice_heating_flux'  ,&
         UNITS              = 'W m-2'                     ,&
         SHORT_NAME         = 'GHTSKIN'                   ,&
         DIMS               = MAPL_DimsTileOnly           ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_CICE4ColumnPhysGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_CICE4ColumnPhysGridComp.F90
@@ -181,7 +181,7 @@ module GEOS_CICE4ColumnPhysGridComp
                                                        _RC  )
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_beam',   &
+        LONG_NAME          = 'surface_reflectivity_for_visible_beam',   &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -189,7 +189,7 @@ module GEOS_CICE4ColumnPhysGridComp
                                                        _RC  )
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_diffuse',&
+        LONG_NAME          = 'surface_reflectivity_for_visible_diffuse',&
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -197,7 +197,7 @@ module GEOS_CICE4ColumnPhysGridComp
                                                        _RC  )
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_beam', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_beam', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -205,7 +205,7 @@ module GEOS_CICE4ColumnPhysGridComp
                                                        _RC  )
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_diffuse', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_diffuse', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -1266,7 +1266,7 @@ module GEOS_CICE4ColumnPhysGridComp
 
   call MAPL_AddExportSpec(GC,                             &
     SHORT_NAME         = 'SIALB'                       ,&
-    LONG_NAME          = 'broad_band_sea_ice_albedo'   ,&
+    LONG_NAME          = 'broad_band_sea_ice_reflectivity'   ,&
     UNITS              = '1'                           ,&
     DIMS               = MAPL_DimsTileOnly             ,&
     VLOCATION          = MAPL_VLocationNone            ,&
@@ -1388,7 +1388,7 @@ module GEOS_CICE4ColumnPhysGridComp
 
   call MAPL_AddExportSpec(GC,                             &
          SHORT_NAME         = 'ialb_CMIP5'                   ,&
-        LONG_NAME          = 'bare_sea_ice_albedo'          ,&
+        LONG_NAME          = 'bare_sea_ice_reflectivity'          ,&
         UNITS              = '1'                            ,&
         DIMS               = MAPL_DimsTileOnly              ,&
         VLOCATION          = MAPL_VLocationNone             ,&
@@ -1527,7 +1527,7 @@ module GEOS_CICE4ColumnPhysGridComp
 
    call MAPL_AddExportSpec(GC,                     &
         SHORT_NAME         = 'ALBIN'                    ,&
-        LONG_NAME          = 'ice_surface_albedo_over_ice_categories' ,&
+        LONG_NAME          = 'ice_surface_reflectivity_over_ice_categories' ,&
         UNITS              = '1'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         UNGRIDDED_DIMS     = (/NUM_ICE_CATEGORIES/)      ,&
@@ -1536,7 +1536,7 @@ module GEOS_CICE4ColumnPhysGridComp
 
    call MAPL_AddExportSpec(GC,                     &
         SHORT_NAME         = 'ALBSN'                    ,&
-        LONG_NAME          = 'snow_surface_albedo_over_ice_categories' ,&
+        LONG_NAME          = 'snow_surface_reflectivity_over_ice_categories' ,&
         UNITS              = '1'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         UNGRIDDED_DIMS     = (/NUM_ICE_CATEGORIES/)      ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -192,7 +192,7 @@ module GEOS_OpenwaterGridCompMod
                                                        _RC)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_beam',   &
+        LONG_NAME          = 'surface_reflectivity_for_visible_beam',   &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -200,7 +200,7 @@ module GEOS_OpenwaterGridCompMod
                                                        _RC)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_diffuse',&
+        LONG_NAME          = 'surface_reflectivity_for_visible_diffuse',&
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -208,7 +208,7 @@ module GEOS_OpenwaterGridCompMod
                                                        _RC)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_beam', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_beam', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -216,7 +216,7 @@ module GEOS_OpenwaterGridCompMod
                                                        _RC)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_diffuse', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_diffuse', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SaltWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SaltWaterGridComp.F90
@@ -183,7 +183,7 @@ module GEOS_SaltwaterGridCompMod
                                                        _RC)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_beam',   &
+        LONG_NAME          = 'surface_reflectivity_for_visible_beam',   &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -191,7 +191,7 @@ module GEOS_SaltwaterGridCompMod
                                                        _RC)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_diffuse',&
+        LONG_NAME          = 'surface_reflectivity_for_visible_diffuse',&
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -199,7 +199,7 @@ module GEOS_SaltwaterGridCompMod
                                                        _RC)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_beam', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_beam', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -207,7 +207,7 @@ module GEOS_SaltwaterGridCompMod
                                                        _RC)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_diffuse', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_diffuse', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SeaiceInterfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SeaiceInterfaceGridComp.F90
@@ -164,7 +164,7 @@ module GEOS_SeaiceInterfaceGridComp
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_beam',   &
+        LONG_NAME          = 'surface_reflectivity_for_visible_beam',   &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -173,7 +173,7 @@ module GEOS_SeaiceInterfaceGridComp
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_visible_diffuse',&
+        LONG_NAME          = 'surface_reflectivity_for_visible_diffuse',&
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBVF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -182,7 +182,7 @@ module GEOS_SeaiceInterfaceGridComp
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_beam', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_beam', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNR',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -191,7 +191,7 @@ module GEOS_SeaiceInterfaceGridComp
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_diffuse', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_diffuse', &
         UNITS              = '1',                                 &
         SHORT_NAME         = 'ALBNF',                             &
         DIMS               = MAPL_DimsTileOnly,                   &
@@ -1283,7 +1283,7 @@ module GEOS_SeaiceInterfaceGridComp
 
    call MAPL_AddExportSpec(GC,                     &
         SHORT_NAME         = 'ALBIN'                    ,&
-        LONG_NAME          = 'ice_surface_albedo_over_ice_categories' ,&
+        LONG_NAME          = 'ice_surface_reflectivity_over_ice_categories' ,&
         UNITS              = '1'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         UNGRIDDED_DIMS     = (/NUM_ICE_CATEGORIES/)      ,&
@@ -1293,7 +1293,7 @@ module GEOS_SeaiceInterfaceGridComp
 
    call MAPL_AddExportSpec(GC,                     &
         SHORT_NAME         = 'ALBSN'                    ,&
-        LONG_NAME          = 'snow_surface_albedo_over_ice_categories' ,&
+        LONG_NAME          = 'snow_surface_reflectivity_over_ice_categories' ,&
         UNITS              = '1'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         UNGRIDDED_DIMS     = (/NUM_ICE_CATEGORIES/)      ,&

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
@@ -135,33 +135,33 @@ module GEOS_SimpleSeaiceGridCompMod
         VLOCATION          = MAPL_VLocationNone,                  &
                                                        _RC)
 
-     call MAPL_AddExportSpec(GC,                             &
+     call MAPL_AddExportSpec(GC,                                  &
         SHORT_NAME         = 'ALBVR',                             &
-        LONG_NAME          = 'surface_albedo_for_visible_beam',   &
+        LONG_NAME          = 'surface_reflectivity_for_visible_beam', &
         UNITS              = '1',                                 &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
                                                        _RC)
 
-     call MAPL_AddExportSpec(GC,                             &
+     call MAPL_AddExportSpec(GC,                                  &
         SHORT_NAME         = 'ALBVF',                             &
-        LONG_NAME          = 'surface_albedo_for_visible_diffuse',&
+        LONG_NAME          = 'surface_reflectivity_for_visible_diffuse', &
         UNITS              = '1',                                 &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
                                                        _RC)
 
-     call MAPL_AddExportSpec(GC,                             &
+     call MAPL_AddExportSpec(GC,                                  &
         SHORT_NAME         = 'ALBNR',                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_beam', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_beam', &
         UNITS              = '1',                                 &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
                                                        _RC)
 
-     call MAPL_AddExportSpec(GC,                             &
+     call MAPL_AddExportSpec(GC,                                  &
         SHORT_NAME         = 'ALBNF',                             &
-        LONG_NAME          = 'surface_albedo_for_near_infrared_diffuse', &
+        LONG_NAME          = 'surface_reflectivity_for_near_infrared_diffuse', &
         UNITS              = '1',                                 &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentRst.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentRst.F90
@@ -577,7 +577,7 @@ contains
            call MAPL_VarRead ( CatchFmt ,'SNOWALB', this%snowalb, __RC__)
            if ( .not. this%meta%has_variable('SNOWALB')) then
               var = Variable(type=pFIO_REAL32, dimensions='tile')
-              call var%add_attribute('long_name', 'snow_albedo')
+              call var%add_attribute('long_name', 'snow_reflectivity')
               call var%add_attribute('units', '1')
               call this%meta%add_variable('SNOWALB', var)
            endif


### PR DESCRIPTION
The primary objective of the present PR is to bring the file specs changes from M21C into "develop".  The corresponding M21C PR is #637 (merged on 8 Dec 2022).

Additionally, the present PR changes the "regrid_method" for the input (obs) precipitation from PRECIP_FILE in `GEOS_SurfaceGridComp.F90` to "conserve".  This is of no consequence for FP-like systems that do not use observed precip inputs.  The change was made with a view towards future reanalysis and S2S systems.

No changes were made to GEOS_CatchCNCLM45GridComp.F90 because this CatchCN model version is scientifically obsolete and has been disabled.  (Proper cleanup of the repo remains pending.)

In M21C, most LONG_NAME attributes for "albedo" were changed to "reflectivity".  For consistency, I applied this change in a few more places where it was not applied in M21C (https://github.com/GEOS-ESM/GEOSgcm_GridComp/commit/3790723abae6e09cdfede8d0f8e349ab97fdbc9e, https://github.com/GEOS-ESM/GEOSgcm_GridComp/commit/e31cda3931f6e250e6a80baaa165dc95f80529e6).

**Specific comments:**

`GEOS_SurfaceGridComp.F90`
- It looks like OBIO is not in M21C, and the exports FSWBAND and FSWBANDNA have been replaced with DRBAND and DFBAND.  This remains as in develop.
- The AICE field in the M21C file specs ("slv" collection) uses the OFRACI export.  I did my best to transfer this export from M21C to "develop" but I can't promise that I didn't mess up.  This will require further inspection and testing.

`GEOSsaltwater_GridComp/*.F90`
- There are several LONG_NAME attributes that include the term "skin" temperature.  I don't know enough about the ocean and sea ice variables to tell whether the fields should be called "**skin** temps" or "**surface** temps".  This requires further discussion and input from the @GEOS-ESM/ocean-team 

`GEOS_SeaiceInterfaceGridComp.F90`
- There are two LONG_NAME attributes of "downwelling"/"downward" longwave fluxes.  Elsewhere in the code this was corrected to "absorbed" longwave flux.  I don't know enough about sea ice to know if the change applies here as well (although I would be surprised if it did not).  This requires further discussion and input from the @GEOS-ESM/ocean-team 





