### PR TITLE
[MKIAU] Initial prototype of a CFFI-based fortran/python bridge

### DIFF
--- a/GEOSmkiau_GridComp/CMakeLists.txt
+++ b/GEOSmkiau_GridComp/CMakeLists.txt
@@ -1,5 +1,7 @@
 esma_set_this()
 
+option(BUILD_PYMKIAU_INTERFACE "Build pyMKIAU interface" OFF)
+
 set (srcs
   IAU_GridCompMod.F90
   GEOS_mkiauGridComp.F90
@@ -8,6 +10,90 @@ set (srcs
   DynVec_GridComp.F90
   )
 
-set(dependencies MAPL_cfio_r4 NCEP_sp_r4i4 GEOS_Shared GMAO_mpeu MAPL FVdycoreCubed_GridComp ESMF::ESMF NetCDF::NetCDF_Fortran)
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies})
+if (BUILD_PYMKIAU_INTERFACE)
+  list (APPEND srcs
+    pyMKIAU/interface/interface.f90
+    pyMKIAU/interface/interface.c)
 
+  message(STATUS "Building pyMKIAU interface")
+
+  add_definitions(-DPYMKIAU_INTEGRATION)
+
+  # The Python library creation requires mpiexec/mpirun to run on a
+  # compute node. Probably a weird SLURM thing?
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+  # Set up some variables in case names change
+  set(PYMKIAU_INTERFACE_LIBRARY     ${CMAKE_CURRENT_BINARY_DIR}/libpyMKIAU_interface_py.so)
+  set(PYMKIAU_INTERFACE_HEADER_FILE ${CMAKE_CURRENT_BINARY_DIR}/pyMKIAU_interface_py.h)
+  set(PYMKIAU_INTERFACE_FLAG_HEADER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/pyMKIAU/interface/interface.h)
+  set(PYMKIAU_INTERFACE_SRCS        ${CMAKE_CURRENT_SOURCE_DIR}/pyMKIAU/interface/interface.py)
+
+  # This command creates the shared object library from Python
+  add_custom_command(
+    OUTPUT ${PYMKIAU_INTERFACE_LIBRARY}
+    # Note below is essentially:
+    #  mpirun -np 1 python file
+    # but we use the CMake options as much as we can for flexibility
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PYMKIAU_INTERFACE_FLAG_HEADER_FILE} ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${Python3_EXECUTABLE} ${PYMKIAU_INTERFACE_SRCS}
+    BYPRODUCTS ${PYMKIAU_INTERFACE_HEADER_FILE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    MAIN_DEPENDENCY ${PYMKIAU_INTERFACE_SRCS}
+    COMMENT "Building pyMKIAU interface library with Python"
+    VERBATIM
+  )
+
+  # This creates a target we can use for dependencies and post build
+  add_custom_target(generate_pyMKIAU_interface_library DEPENDS ${PYMKIAU_INTERFACE_LIBRARY})
+
+  # Because of the weird hacking of INTERFACE libraries below, we cannot
+  # use the "usual" CMake calls to install() the .so. I think it's because
+  # INTERFACE libraries don't actually produce any artifacts as far as
+  # CMake is concerned. So we add a POST_BUILD custom command to "install"
+  # the library into install/lib
+  add_custom_command(TARGET generate_pyMKIAU_interface_library
+    POST_BUILD
+    # We first need to make a lib dir if it doesn't exist. If not, then
+    # the next command can copy the script into a *file* called lib because
+    # of a race condition (if install/lib/ isn't mkdir'd first)
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_INSTALL_PREFIX}/lib
+    # Now we copy the file (if different...though not sure if this is useful)
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PYMKIAU_INTERFACE_LIBRARY}" ${CMAKE_INSTALL_PREFIX}/lib
+    )
+
+  # We use INTERFACE libraries to create a sort of "fake" target library we can use
+  # to make libFVdycoreCubed_GridComp.a depend on. It seems to work!
+  add_library(pyMKIAU_interface_py INTERFACE)
+
+  # The target_include_directories bits were essentially stolen from the esma_add_library
+  # code...
+  target_include_directories(pyMKIAU_interface_py INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # stubs
+    # modules and copied *.h, *.inc
+    $<BUILD_INTERFACE:${esma_include}/${this}>
+    $<INSTALL_INTERFACE:include/${this}>
+    )
+  target_link_libraries(pyMKIAU_interface_py INTERFACE ${PYMKIAU_INTERFACE_LIBRARY})
+
+  # This makes sure the library is built first
+  add_dependencies(pyMKIAU_interface_py generate_pyMKIAU_interface_library)
+
+  # This bit is to resolve an issue and Google told me to do this. I'm not
+  # sure that the LIBRARY DESTINATION bit actually does anything since
+  # this is using INTERFACE
+  install(TARGETS pyMKIAU_interface_py
+    EXPORT ${PROJECT_NAME}-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+    )
+
+endif ()
+
+if (BUILD_PYMKIAU_INTERFACE)
+  set(dependencies pyMKIAU_interface_py MAPL_cfio_r4 NCEP_sp_r4i4 GEOS_Shared GMAO_mpeu MAPL FVdycoreCubed_GridComp ESMF::ESMF NetCDF::NetCDF_Fortran)
+else ()
+  set(dependencies MAPL_cfio_r4 NCEP_sp_r4i4 GEOS_Shared GMAO_mpeu MAPL FVdycoreCubed_GridComp ESMF::ESMF NetCDF::NetCDF_Fortran)
+endif ()
+
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies})

--- a/GEOSmkiau_GridComp/pyMKIAU/.gitignore
+++ b/GEOSmkiau_GridComp/pyMKIAU/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache
+*.egg-info/
+test_data/
+.gt_cache_*
+.translate-*/
+.vscode
+test_data/
+sandbox/
+*.mod

--- a/GEOSmkiau_GridComp/pyMKIAU/README.md
+++ b/GEOSmkiau_GridComp/pyMKIAU/README.md
@@ -1,0 +1,39 @@
+# Fortran - Python bridge prototype
+
+Nomenclatura: we call the brige "fpy" and "c", "f" and "py" denotes functions in their respective language.
+
+Building: you have to pass `-DBUILD_PYMKIAU_INTERFACE=ON` to your `cmake` command to turn on the interface build and execution.
+
+## Pipeline
+
+Here's a quick rundown of how a buffer travels through the interface and back.
+  
+- From Fortran in `GEOS_MKIAUGridComp:488` we call `pyMKIAU_interface_f_run` with the buffer passed as argument
+- This pings the interface, located at `pyMKIAU/interface/interface.f90`. This interface uses the `iso_c_binding` to marshall the parameters downward (careful about the user type, look at the code)
+- Fortran then call into C at `pyMKIAU/interface/interface.c`. Those functions now expect that a few `extern` hooks have been made available on the python side, they are define in `pyMKIAU/interface/interface.h`
+- At runtime, the hooks are found and code carries to the python thanks to cffi. The .so that exposes the hooks is in `pyMKIAU/interface/interface.py`. Within this code, we: expose extern functions via `ffi.extern`, build a shared library to link for runtime and pass the code down to the `pyMKIAU` python package which lives at `pyMKIAU/pyMKIAU`
+- In the package, the `serservices` or `run` function is called.
+
+## Fortran <--> C: iso_c_binding
+
+We leverage Fortan `iso_c_binding` extension to do conform Fortran and C calling structure. Which comes with a bunch of easy type casting and some pretty steep potholes.
+The two big ones are:
+
+- strings need to be send/received as a buffer plus a length,
+- pointers/buffers are _not_ able to be pushed into a user type.
+
+## C <->Python: CFFI based glue
+
+The interface is based on CFFI which is reponsible for the heavy lifting of
+
+- spinning a python interpreter
+- passing memory between C and Python without a copy
+
+## Running python
+
+The last trick is to make sure your package is callable by the `interface.py`. Basically your code has to be accessible by the interpreter, be via virtual env, conda env or PYTHONPATH. The easy way to know is that you need to be able to get into your environment and run in a python terminal
+
+```python
+from pyMKIAU.core import pyMKIAU_init
+pyMKIAU_init()
+```

--- a/GEOSmkiau_GridComp/pyMKIAU/README.md
+++ b/GEOSmkiau_GridComp/pyMKIAU/README.md
@@ -31,7 +31,8 @@ The interface is based on CFFI which is reponsible for the heavy lifting of
 
 ## Running python
 
-The last trick is to make sure your package is callable by the `interface.py`. Basically your code has to be accessible by the interpreter, be via virtual env, conda env or PYTHONPATH. The easy way to know is that you need to be able to get into your environment and run in a python terminal
+The last trick is to make sure your package is callable by the `interface.py`. Basically your code has to be accessible by the interpreter, be via virtual env, conda env or PYTHONPATH.
+The easy way to know is that you need to be able to get into your environment and run in a python terminal:
 
 ```python
 from pyMKIAU.core import pyMKIAU_init

--- a/GEOSmkiau_GridComp/pyMKIAU/interface/interface.c
+++ b/GEOSmkiau_GridComp/pyMKIAU/interface/interface.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <time.h>
+#include "interface.h"
+
+extern int pyMKIAU_interface_c_setservice()
+{
+    // Check magic number
+    int return_code = pyMKIAU_interface_py_setservices();
+
+    if (return_code < 0)
+    {
+        exit(return_code);
+    }
+}
+
+extern int pyMKIAU_interface_c_run(a_pod_struct_t *options, const float *in_buffer, float *out_buffer)
+{
+    // Check magic number
+    if (options->mn_123456789 != 123456789)
+    {
+        printf("Magic number failed, pyMKIAU interface is broken on the C side\n");
+        exit(-1);
+    }
+
+    int return_code = pyMKIAU_interface_py_run(options, in_buffer, out_buffer);
+
+    if (return_code < 0)
+    {
+        exit(return_code);
+    }
+}

--- a/GEOSmkiau_GridComp/pyMKIAU/interface/interface.f90
+++ b/GEOSmkiau_GridComp/pyMKIAU/interface/interface.f90
@@ -1,0 +1,43 @@
+module pyMKIAU_interface_mod
+
+   use iso_c_binding, only: c_int, c_float, c_double, c_bool, c_ptr
+
+   implicit none
+
+   private
+   public :: pyMKIAU_interface_f_setservice, pyMKIAU_interface_f_run
+   public :: a_pod_struct_type
+
+   !-----------------------------------------------------------------------
+   ! See `interface.h` for explanation of the POD-strict struct
+   !-----------------------------------------------------------------------
+   type, bind(c) :: a_pod_struct_type
+      integer(kind=c_int) :: npx
+      integer(kind=c_int) :: npy
+      integer(kind=c_int) :: npz
+      ! Magic number
+      integer(kind=c_int) :: make_flags_C_interop = 123456789
+   end type
+
+
+   interface
+
+      subroutine pyMKIAU_interface_f_setservice() bind(c, name='pyMKIAU_interface_c_setservice')
+      end subroutine pyMKIAU_interface_f_setservice
+
+      subroutine pyMKIAU_interface_f_run(options, in_buffer, out_buffer) bind(c, name='pyMKIAU_interface_c_run')
+
+         import c_float, a_pod_struct_type
+
+         implicit none
+         ! This is an interface to a C function, the intent ARE NOT enforced
+         ! by the compiler. Consider them developer hints
+         type(a_pod_struct_type), intent(in) :: options
+         real(kind=c_float), dimension(*), intent(in) :: in_buffer
+         real(kind=c_float), dimension(*), intent(out) :: out_buffer
+
+      end subroutine pyMKIAU_interface_f_run
+   
+   end interface
+
+end module pyMKIAU_interface_mod

--- a/GEOSmkiau_GridComp/pyMKIAU/interface/interface.h
+++ b/GEOSmkiau_GridComp/pyMKIAU/interface/interface.h
@@ -1,0 +1,40 @@
+#pragma once
+
+/***
+ * C Header for the interface to python.
+ * Define here any POD-strict structures and external functions
+ * that will get exported by cffi from python (see interface.py)
+ ***/
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+// POD-strict structure to pack options and flags efficiently
+// Struct CANNOT hold pointers. The iso_c_binding does not allow for foolproof
+// pointer memory packing.
+// We use the low-embedded trick of the magic number to attempt to catch
+// any type mismatch betweeen Fortran and C. This is not a foolproof method
+// but it bring a modicum of check at the cost of a single integer.
+typedef struct
+{
+	int npx;
+	int npy;
+	int npz;
+	// Magic number needs to be last item
+	int mn_123456789;
+} a_pod_struct_t;
+
+// For complex type that can be exported with different
+// types (like the MPI communication object), you can rely on C `union`
+typedef union
+{
+	int comm_int;
+	void *comm_ptr;
+} MPI_Comm_t;
+
+// Python hook functions: defined as external so that the .so can link out ot them
+// Though we define `in_buffer` as a `const float*` it is _not_ enforced
+// by the interface. Treat as a developer hint only.
+
+extern int pyMKIAU_interface_py_run(a_pod_struct_t *options, const float *in_buffer, float *out_buffer);
+extern int pyMKIAU_interface_py_setservices();

--- a/GEOSmkiau_GridComp/pyMKIAU/interface/interface.py
+++ b/GEOSmkiau_GridComp/pyMKIAU/interface/interface.py
@@ -1,0 +1,46 @@
+import cffi  # type: ignore
+
+TMPFILEBASE = "pyMKIAU_interface_py"
+
+ffi = cffi.FFI()
+
+source = """
+from {} import ffi
+from datetime import datetime
+from pyMKIAU.core import pyMKIAU_init, pyMKIAU_run #< User code starts here
+import traceback
+
+@ffi.def_extern()
+def pyMKIAU_interface_py_setservices() -> int:
+
+    try:
+        # Calling out off the bridge into the python
+        pyMKIAU_init()
+    except Exception as err:
+        print("Error in Python:")
+        print(traceback.format_exc())
+        return -1
+    return 0
+
+@ffi.def_extern()
+def pyMKIAU_interface_py_run(options, in_buffer, out_buffer) -> int:
+
+    try:
+        # Calling out off the bridge into the python
+        pyMKIAU_run(options, in_buffer, out_buffer)
+    except Exception as err:
+        print("Error in Python:")
+        print(traceback.format_exc())
+        return -1
+    return 0
+""".format(TMPFILEBASE)
+
+with open("interface.h") as f:
+    data = "".join([line for line in f if not line.startswith("#")])
+    data = data.replace("CFFI_DLLEXPORT", "")
+    ffi.embedding_api(data)
+
+ffi.set_source(TMPFILEBASE, '#include "interface.h"')
+
+ffi.embedding_init_code(source)
+ffi.compile(target="lib" + TMPFILEBASE + ".so", verbose=True)

--- a/GEOSmkiau_GridComp/pyMKIAU/pyMKIAU/core.py
+++ b/GEOSmkiau_GridComp/pyMKIAU/pyMKIAU/core.py
@@ -1,0 +1,74 @@
+from _cffi_backend import _CDataBase as CFFIObj  # type: ignore
+import dataclasses
+from pyMKIAU.f_py_conversion import FortranPythonConversion
+from pyMKIAU.cuda_profiler import TimedCUDAProfiler
+import numpy as np
+from typing import Dict, List
+
+
+@dataclasses.dataclass
+class FPYOptions:
+    npx: int = 0
+    npy: int = 0
+    npz: int = 0
+    mn_123456789: int = 0
+
+
+def options_fortran_to_python(
+    f_options: CFFIObj,
+) -> FPYOptions:
+    if f_options.mn_123456789 != 123456789:  # type:ignore
+        raise RuntimeError(
+            "Magic number failed, pyMoist interface is broken on the python side"
+        )
+
+    py_flags = FPYOptions()
+    keys = list(filter(lambda k: not k.startswith("__"), dir(type(py_flags))))
+    for k in keys:
+        if hasattr(f_options, k):
+            setattr(py_flags, k, getattr(f_options, k))
+    return py_flags
+
+
+F_PY_MEMORY_CONV = None
+
+
+def pyMKIAU_init():
+    print("[pyMKIAU] Init called")
+
+
+def pyMKIAU_run(
+    f_options: CFFIObj,
+    f_in_buffer: CFFIObj,
+    f_out_buffer: CFFIObj,
+):
+    print("[pyMKIAU] Run called")
+    options = options_fortran_to_python(f_options)
+    print(f"[pyMKIAU] Options: {options}")
+
+    # Dev Note: this should be doen better in it's own class
+    #           and the `np` should be driven by the user code requirements
+    #           for GPU or CPU memory
+    global F_PY_MEMORY_CONV
+    if F_PY_MEMORY_CONV is None:
+        F_PY_MEMORY_CONV = FortranPythonConversion(
+            options.npx,
+            options.npy,
+            options.npz,
+            np,
+        )
+
+    # Move memory into a manipulable numpy array
+    in_buffer = F_PY_MEMORY_CONV.fortran_to_python(f_in_buffer)
+    out_buffer = F_PY_MEMORY_CONV.fortran_to_python(f_out_buffer)
+
+    # Here goes math and dragons
+    timings: Dict[str, List[float]] = {}
+    with TimedCUDAProfiler("pyMKIAU bogus math", timings):
+        out_buffer[:, :, :] = in_buffer[:, :, :] * 2
+
+    print(f"[pyMKIAU] At 5,5,5 in python OUT is: {out_buffer[5,5,5]}")
+    print(f"[pyMKIAU] Timers: {timings}")
+
+    # Go back to fortran
+    F_PY_MEMORY_CONV.python_to_fortran(out_buffer, f_out_buffer)

--- a/GEOSmkiau_GridComp/pyMKIAU/pyMKIAU/cuda_profiler.py
+++ b/GEOSmkiau_GridComp/pyMKIAU/pyMKIAU/cuda_profiler.py
@@ -1,0 +1,76 @@
+import time
+from typing import Dict, List
+
+
+# Conditional cupy import for non-GPU machines
+try:
+    import cupy as cp
+except ModuleNotFoundError:
+    cp = None
+
+# Run a deviceSynchronize() to check
+# that the GPU is present and ready to run
+if cp is not None:
+    try:
+        cp.cuda.runtime.deviceSynchronize()
+        GPU_AVAILABLE = True
+    except cp.cuda.runtime.CUDARuntimeError:
+        GPU_AVAILABLE = False
+else:
+    GPU_AVAILABLE = False
+
+
+class CUDAProfiler:
+    """Leverages NVTX & NSYS to profile CUDA kernels."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    def __enter__(self):
+        if GPU_AVAILABLE:
+            cp.cuda.runtime.deviceSynchronize()
+            cp.cuda.nvtx.RangePush(self.label)
+
+    def __exit__(self, _type, _val, _traceback):
+        if GPU_AVAILABLE:
+            cp.cuda.runtime.deviceSynchronize()
+            cp.cuda.nvtx.RangePop()
+
+    @classmethod
+    def sync_device(cls):
+        if GPU_AVAILABLE:
+            cp.cuda.runtime.deviceSynchronize()
+
+    @classmethod
+    def start_cuda_profiler(cls):
+        if GPU_AVAILABLE:
+            cp.cuda.profiler.start()
+
+    @classmethod
+    def stop_cuda_profiler(cls):
+        if GPU_AVAILABLE:
+            cp.cuda.profiler.stop()
+
+    @classmethod
+    def mark_cuda_profiler(cls, message: str):
+        if GPU_AVAILABLE:
+            cp.cuda.nvtx.Mark(message)
+
+
+class TimedCUDAProfiler(CUDAProfiler):
+    def __init__(self, label: str, timings: Dict[str, List[float]]) -> None:
+        super().__init__(label)
+        self._start_time = 0
+        self._timings = timings
+
+    def __enter__(self):
+        super().__enter__()
+        self._start_time = time.perf_counter()
+
+    def __exit__(self, _type, _val, _traceback):
+        super().__exit__(_type, _val, _traceback)
+        t = time.perf_counter() - self._start_time
+        if self.label not in self._timings:
+            self._timings[self.label] = [t]
+        else:
+            self._timings[self.label].append(t)

--- a/GEOSmkiau_GridComp/pyMKIAU/pyMKIAU/f_py_conversion.py
+++ b/GEOSmkiau_GridComp/pyMKIAU/pyMKIAU/f_py_conversion.py
@@ -1,0 +1,219 @@
+from math import prod
+from types import ModuleType
+from typing import List, Optional, Tuple, TypeAlias
+
+import cffi
+import numpy as np
+
+# Conditional cupy import for non-GPU machines
+try:
+    import cupy as cp
+except ModuleNotFoundError:
+    cp = None
+
+
+# Dev note: we would like to use cp.ndarray for Device and
+# Union of np and cp ndarray for Python but we can't
+# because cp might not be importable!
+DeviceArray: TypeAlias = np.ndarray
+PythonArray: TypeAlias = np.ndarray
+
+# Default floating point cast
+BaseFloat = np.float32
+
+
+class NullStream:
+    def __init__(self):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
+class FortranPythonConversion:
+    """
+    Convert Fortran arrays to NumPy and vice-versa
+    """
+
+    def __init__(
+        self,
+        npx: int,
+        npy: int,
+        npz: int,
+        numpy_module: ModuleType,
+    ):
+        # Python numpy-like module is given by the caller leaving
+        # optional control of upload/download in the case
+        # of GPU/CPU system
+        self._target_np = numpy_module
+
+        # Device parameters
+        #  Pace targets gpu: we want the Pace layout to be on device
+        self._python_targets_gpu = self._target_np == cp
+        if self._python_targets_gpu:
+            self._stream_A = cp.cuda.Stream(non_blocking=True)
+            self._stream_B = cp.cuda.Stream(non_blocking=True)
+        else:
+            self._stream_A = NullStream()
+            self._stream_B = NullStream()
+        self._current_stream = self._stream_A
+
+        # Layout & indexing
+        self._npx, self._npy, self._npz = npx, npy, npz
+
+        # cffi init
+        self._ffi = cffi.FFI()
+        self._TYPEMAP = {
+            "float": np.float32,
+            "double": np.float64,
+            "int": np.int32,
+        }
+
+    def device_sync(self):
+        """Synchronize the working CUDA streams"""
+        self._stream_A.synchronize()
+        self._stream_B.synchronize()
+
+    def _fortran_to_numpy(
+        self,
+        fptr: "cffi.FFI.CData",
+        dim: Optional[List[int]] = None,
+    ) -> np.ndarray:
+        """
+        Input: Fortran data pointed to by fptr and of shape dim = (i, j, k)
+        Output: C-ordered double precision NumPy data of shape (i, j, k)
+        """
+        if not dim:
+            dim = [self._npx, self._npy, self._npz]
+        ftype = self._ffi.getctype(self._ffi.typeof(fptr).item)
+        assert ftype in self._TYPEMAP
+        return np.frombuffer(
+            self._ffi.buffer(fptr, prod(dim) * self._ffi.sizeof(ftype)),
+            self._TYPEMAP[ftype],
+        )
+
+    def _upload_and_transform(
+        self,
+        host_array: np.ndarray,
+        dim: Optional[List[int]] = None,
+        swap_axes: Optional[Tuple[int, int]] = None,
+    ) -> DeviceArray:
+        """Upload to device & transform to Pace compatible layout"""
+        with self._current_stream:
+            device_array = cp.asarray(host_array)
+            final_array = self._transform_from_fortran_layout(
+                device_array,
+                dim,
+                swap_axes,
+            )
+            self._current_stream = (
+                self._stream_A
+                if self._current_stream == self._stream_B
+                else self._stream_B
+            )
+            return final_array
+
+    def _transform_from_fortran_layout(
+        self,
+        array: PythonArray,
+        dim: Optional[List[int]] = None,
+        swap_axes: Optional[Tuple[int, int]] = None,
+    ) -> PythonArray:
+        """Transform from Fortran layout into a Pace compatible layout"""
+        if not dim:
+            dim = [self._npx, self._npy, self._npz]
+        trf_array = array.reshape(tuple(reversed(dim))).transpose().astype(BaseFloat)
+        if swap_axes:
+            trf_array = self._target_np.swapaxes(
+                trf_array,
+                swap_axes[0],
+                swap_axes[1],
+            )
+        return trf_array
+
+    def fortran_to_python(
+        self,
+        fptr: "cffi.FFI.CData",
+        dim: Optional[List[int]] = None,
+        swap_axes: Optional[Tuple[int, int]] = None,
+    ) -> PythonArray:
+        """Move fortran memory into python space"""
+        np_array = self._fortran_to_numpy(fptr, dim)
+        if self._python_targets_gpu:
+            return self._upload_and_transform(np_array, dim, swap_axes)
+        else:
+            return self._transform_from_fortran_layout(
+                np_array,
+                dim,
+                swap_axes,
+            )
+
+    def _transform_and_download(
+        self,
+        device_array: DeviceArray,
+        dtype: type,
+        swap_axes: Optional[Tuple[int, int]] = None,
+    ) -> np.ndarray:
+        with self._current_stream:
+            if swap_axes:
+                device_array = cp.swapaxes(
+                    device_array,
+                    swap_axes[0],
+                    swap_axes[1],
+                )
+            host_array = cp.asnumpy(
+                device_array.astype(dtype).flatten(order="F"),
+            )
+            self._current_stream = (
+                self._stream_A
+                if self._current_stream == self._stream_B
+                else self._stream_B
+            )
+            return host_array
+
+    def _transform_from_python_layout(
+        self,
+        array: PythonArray,
+        dtype: type,
+        swap_axes: Optional[Tuple[int, int]] = None,
+    ) -> np.ndarray:
+        """Copy back a numpy array in python layout to Fortran"""
+
+        if self._python_targets_gpu:
+            numpy_array = self._transform_and_download(array, dtype, swap_axes)
+        else:
+            numpy_array = array.astype(dtype).flatten(order="F")
+            if swap_axes:
+                numpy_array = np.swapaxes(
+                    numpy_array,
+                    swap_axes[0],
+                    swap_axes[1],
+                )
+        return numpy_array
+
+    def python_to_fortran(
+        self,
+        array: PythonArray,
+        fptr: "cffi.FFI.CData",
+        ptr_offset: int = 0,
+        swap_axes: Optional[Tuple[int, int]] = None,
+    ) -> np.ndarray:
+        """
+        Input: Fortran data pointed to by fptr and of shape dim = (i, j, k)
+        Output: C-ordered double precision NumPy data of shape (i, j, k)
+        """
+        ftype = self._ffi.getctype(self._ffi.typeof(fptr).item)
+        assert ftype in self._TYPEMAP
+        dtype = self._TYPEMAP[ftype]
+        numpy_array = self._transform_from_python_layout(
+            array,
+            dtype,
+            swap_axes,
+        )
+        self._ffi.memmove(fptr + ptr_offset, numpy_array, 4 * numpy_array.size)

--- a/GEOSmkiau_GridComp/pyMKIAU/setup.py
+++ b/GEOSmkiau_GridComp/pyMKIAU/setup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""pyMKIAU - python sub-component of GEOS MKIAU."""
+
+from setuptools import find_namespace_packages, setup
+
+
+with open("README.md", encoding="utf-8") as readme_file:
+    readme = readme_file.read()
+
+setup(
+    author="NASA",
+    python_requires=">=3.11",
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache 2 License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3.11",
+    ],
+    description=("pyMKIAU - python sub-component of GEOS MKIAU."),
+    install_requires=[],
+    extras_require={},
+    long_description=readme,
+    include_package_data=True,
+    name="pyMKIAU",
+    packages=find_namespace_packages(include=["pyMKIAU", "pyMKIAU.*"]),
+    setup_requires=[],
+    url="https://github.com/GEOS-ESM/GEOSgcm_GridComp",
+    version="0.0.0",
+    zip_safe=False,
+)


### PR DESCRIPTION
:warning: This might not be PR'ed back into the right branch :warning:

- Fortran-first bridge that call down to a `pyMKIAU` package that can run Fortran
- Bogus data & code to show usage in `GEOSmkiau_GridComp/GEOS_mkiauGridComp.F90`
- Ships with a Fortran/Python memory converted and a Timer capable of GPU via `cupy`

**Dev note**: this is the current strategy in the SMT to integrate Fortran & Python as it gives us control over overhead. We might evolve the technique as we look more into CPU-CPU bridging. We also aim to deliver a generator so that the boilerplate code is can be code generated and reduce bugs.

Poke @jli-99 
Poke @katherbreen 