### PR TITLE
v11: Add dependency to fms_r4

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -36,6 +36,12 @@ esma_add_library (${this}
   SRCS ${srcs}
   DEPENDENCIES GEOS_Shared GMAO_mpeu MAPL Chem_Shared Chem_Base ESMF::ESMF)
 
+# We need to add_dependencies for fms_r4 because CMake doesn't know we
+# need it for include purposes. In R4R8, we only ever link against
+# fms_r4, so it doesn't know we need to build it.
+# NOTE NOTE NOTE: This should *not* be included in GEOSgcm v12
+#     because FMS is pre-built library in that case.
+add_dependencies (${this} fms_r4)
 get_target_property (extra_incs fms_r4 INCLUDE_DIRECTORIES)
 target_include_directories(${this} PRIVATE
    $<BUILD_INTERFACE:${extra_incs}>

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -38,7 +38,7 @@ esma_add_library (${this}
 
 # We need to add_dependencies for fms_r4 because CMake doesn't know we
 # need it for include purposes. In R4R8, we only ever link against
-# fms_r4, so it doesn't know we need to build it.
+# fms_r8, so it doesn't know to build the target fms_r4
 # NOTE NOTE NOTE: This should *not* be included in GEOSgcm v12
 #     because FMS is pre-built library in that case.
 add_dependencies (${this} fms_r4)


### PR DESCRIPTION
This PR adds a dependency to `fms_r4`. We need this because of the weird way we build FV3 as r4 but link to the r8 version of FMS. In that case, we still need to point to the include files from r4 FMS. 

But, CMake in that case has no idea that to build, say, Moist, that we need to build `fms_r4` before building this.

## NOTE NOTE NOTE

This change is *NOT* needed in GEOSgcm v12 because in that case FMS is in Baselibs/Spack and so CMake doesn't need to know. I've added a big fat comment for the inevitable case when a merge to v12 happens and the build fails.