### PR TITLE
[NDSL] pyMoist Interface Platform Compatibility

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -36,7 +36,7 @@ if (BUILD_PYMOIST_INTERFACE)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
   # Set up some variables in case names change
-  set(PYMOIST_INTERFACE_LIBRARY     ${CMAKE_CURRENT_BINARY_DIR}/libpyMoist_interface_py.so)
+  set(PYMOIST_INTERFACE_LIBRARY     ${CMAKE_CURRENT_BINARY_DIR}/libpyMoist_interface_py${CMAKE_SHARED_LIBRARY_SUFFIX})
   set(PYMOIST_INTERFACE_HEADER_FILE ${CMAKE_CURRENT_BINARY_DIR}/pymoist_interface_py.h)
   set(PYMOIST_INTERFACE_FLAG_HEADER_FILE ${CMAKE_CURRENT_SOURCE_DIR}/pyMoist/pyMoist/interface/cffi_lib/moist.h)
   set(PYMOIST_INTERFACE_SRCS        ${CMAKE_CURRENT_SOURCE_DIR}/pyMoist/pyMoist/interface/cffi_lib/interface.py)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/cffi_lib/interface.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/cffi_lib/interface.py
@@ -1,6 +1,7 @@
+from distutils.sysconfig import get_config_var
+
 import cffi
 from mpi4py import MPI
-from distutils.sysconfig import get_config_var
 
 
 TMPFILEBASE = "pyMoist_interface_py"

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/cffi_lib/interface.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/cffi_lib/interface.py
@@ -1,5 +1,6 @@
 import cffi
 from mpi4py import MPI
+from distutils.sysconfig import get_config_var
 
 
 TMPFILEBASE = "pyMoist_interface_py"
@@ -105,7 +106,10 @@ with open("moist.h") as f:
     data = data.replace("CFFI_DLLEXPORT", "")
     ffi.embedding_api(data)
 
-ffi.set_source(TMPFILEBASE, '#include "moist.h"')
-
+ffi.set_source(
+    TMPFILEBASE,
+    '#include "moist.h"',
+    library_dirs=[get_config_var("LIBDIR")],
+)
 ffi.embedding_init_code(source)
-ffi.compile(target="lib" + TMPFILEBASE + ".so", verbose=True)
+ffi.compile(target="lib" + TMPFILEBASE + ".*", verbose=3)


### PR DESCRIPTION
Changed interface.py and CMakeLists.txt to enable pyMoist build compatibility on multiple platforms.