### PR TITLE
v12: Fix CMake for FMS and Spack

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -37,13 +37,7 @@ esma_add_library (${this}
   SRCS ${srcs}
   DEPENDENCIES GEOS_Shared GMAO_mpeu MAPL Chem_Shared Chem_Base ESMF::ESMF)
 
-# We need to add_dependencies for fms_r4 because CMake doesn't know we
-# need it for include purposes. In R4R8, we only ever link against
-# fms_r8, so it doesn't know to build the target fms_r4
-# NOTE NOTE NOTE: This should *not* be included in GEOSgcm v12
-#     because FMS is pre-built library in that case.
-add_dependencies (${this} fms_r4)
-get_target_property (extra_incs fms_r4 INCLUDE_DIRECTORIES)
+get_target_property (extra_incs FMS::fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(${this} PRIVATE
    $<BUILD_INTERFACE:${extra_incs}>
    )


### PR DESCRIPTION
A bad merge from v11 overwrote some CMake needed for Spack builds. This fixes it.