### PR TITLE
[NDSL] Protect `pyMoist` from being called despite AGCM.rc turning it off

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_GFDL_1M_InterfaceMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_GFDL_1M_InterfaceMod.F90
@@ -66,6 +66,7 @@ module GEOS_GFDL_1M_InterfaceMod
   integer :: C_LMELTFRZ, C_LHYDROSTATIC, C_LPHYS_HYDROSTATIC
   logical :: USE_PYMOIST_GFDL1M_EVAP = .FALSE. ! Replace EVAP with pyMoist port
   logical :: USE_PYMOIST_GFDL1M_DRIVER = .FALSE. ! Replace Aer Activation with pyMoist port
+  logical :: USE_PYMOIST = .FALSE.
 #endif
 
 public :: GFDL_1M_Setup, GFDL_1M_Initialize, GFDL_1M_Run
@@ -300,6 +301,7 @@ subroutine GFDL_1M_Initialize (MAPL, RC)
 #ifdef PYMOIST_INTEGRATION
     call MAPL_GetResource(MAPL, USE_PYMOIST_GFDL1M_EVAP, 'USE_PYMOIST_GFDL1M_EVAP:', default=.FALSE., RC=STATUS); VERIFY_(STATUS);
     call MAPL_GetResource(MAPL, USE_PYMOIST_GFDL1M_DRIVER, 'USE_PYMOIST_GFDL1M_DRIVER:', default=.FALSE., RC=STATUS); VERIFY_(STATUS);
+    call MAPL_GetResource(MAPL, USE_PYMOIST, 'USE_PYMOIST:', default=.FALSE., RC=STATUS); VERIFY_(STATUS);
 #endif
 
 end subroutine GFDL_1M_Initialize
@@ -376,7 +378,7 @@ subroutine GFDL_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
 
 #ifdef PYMOIST_INTEGRATION
     integer                               :: NX, NY
-    type(gfdl_1m_flags_interface_type)      :: gfdl_1m_flags
+    type(gfdl_1m_flags_interface_type)    :: gfdl_1m_flags
     logical                               :: init_gfdl_1m_flags = .true.
     ! IEEE trapping see below
     logical                               :: halting_mode(5)
@@ -835,7 +837,7 @@ subroutine GFDL_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
          RAD_QG = QGRAUPEL
         ! Run the driver
 #ifdef PYMOIST_INTEGRATION
-        if (init_gfdl_1m_flags) then
+        if (USE_PYMOIST .and. init_gfdl_1m_flags) then
             init_gfdl_1m_flags = .false.
             call make_gfdl_1m_flags_C_interop(LPHYS_HYDROSTATIC, LHYDROSTATIC, do_qa, fix_negative, fast_sat_adj, &
                 const_vi, const_vs, const_vg, const_vr, use_ccn, do_bigg, do_evap, &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
@@ -54,6 +54,7 @@ module GEOS_MoistGridCompMod
   real    :: CCN_OCN
   real    :: CCN_LND
 #ifdef PYMOIST_INTEGRATION
+  LOGICAL :: USE_PYMOIST = .false. ! Allow use of pyMoist
   LOGICAL :: USE_PYMOIST_AER = .false. ! Replace Aer Activation with pyMoist port
 #endif
   ! !PUBLIC MEMBER FUNCTIONS:
@@ -5332,9 +5333,10 @@ contains
        ! pyMoist requires the `n_modes` parameter to be readable for AerActivation, this is written
        ! in the Chemistry init and order of inits is not guaranteed so we wait for first execution
        ! to run initialization
+     call MAPL_GetResource(MAPL, USE_PYMOIST, 'USE_PYMOIST:', default=.false., RC=STATUS); VERIFY_(STATUS);
      call MAPL_GetResource(MAPL, USE_PYMOIST_AER, 'USE_PYMOIST_AER:', default=.false., RC=STATUS); VERIFY_(STATUS);
      call ESMF_AttributeGet(AERO, name='number_of_aerosol_modes', value=n_modes, __RC__)
-     if (init_pymoist) then
+     if (USE_PYMOIST .and. init_pymoist) then
           call cpu_time(start)
           init_pymoist = .false.
           call MAPL_Get(MAPL, IM=IM, JM=JM, LM=LM, INTERNAL_ESMF_STATE=INTERNAL, RC=STATUS ); VERIFY_(STATUS)


### PR DESCRIPTION
The initialize call for the `pyMoist` code is not properly hooked on AGCM.rc