### PR TITLE
updated default cice config for 1440x1080

### DIFF
--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
@@ -101,7 +101,7 @@
     restart_lvl  = .true.
     tr_pond_topo = .false.
     restart_pond_topo = .false.
-    tr_pond_lvl  = .false.
+    tr_pond_lvl  = .true.
     restart_pond_lvl  = .false.
     tr_snow      = .false.
     restart_snow = .false.
@@ -181,9 +181,9 @@
     albsnowv        = 0.98
     albsnowi        = 0.70 
     ahmax           = 0.3
-    R_ice           = -1.
-    R_pnd           = -1.
-    R_snw           = -1.
+    R_ice           = 0.
+    R_pnd           = 0.
+    R_snw           = 0.
     dT_mlt          = 1.5
     rsnw_mlt        = 1500.
     kalg            = 0.0


### PR DESCRIPTION
This PR updated a few options in CIUCE6 at 1440x1080 config.
 - the dEdd albedo tuning parameters are updated based on the latest V12 RC12 results
 - turned on `tr_pond_lvl` by default