### PR TITLE
[NDSL] UW: Fixes to numerics

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
@@ -6571,6 +6571,8 @@ def update_output_variables(
             qiten = 0.0
             qiten_sink = 0.0
             qlten = 0.0
+            umf_zint[0, 0, 1] = 0.0
+            zifc0 = 0.0
 
         if del_CIN <= 0.0:
             umf_outvar = umf_out

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
@@ -3195,7 +3195,9 @@ def buoyancy_sorting(
                                     thlu = (thle + ssthl0 / fer - ssthl0 * dpe / 2.0) - (
                                         thle + ssthl0 * dpe / 2.0 - thlu[0, 0, -1] + ssthl0 / fer
                                     ) * exp(-fer * dpe)
-
+                                    qtu = (qte + ssqt0 / fer - ssqt0 * dpe / 2.0) - (
+                                        qte + ssqt0 * dpe / 2.0 - qtu[0, 0, -1] + ssqt0 / fer
+                                    ) * exp(-fer * dpe)
                                     uu = (ue + (1.0 - PGFc) * ssu0 / fer - ssu0 * dpe / 2.0) - (
                                         ue + ssu0 * dpe / 2.0 - uu[0, 0, -1] + (1.0 - PGFc) * ssu0 / fer
                                     ) * exp(-fer * dpe)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/uwshcu_functions.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/uwshcu_functions.py
@@ -84,35 +84,6 @@ def slope_mid(
 
 
 @gtscript.function
-def slope_top(
-    max_k: Int,
-    field: FloatField,
-    p0: FloatField,
-):
-    """
-    Function that calculates slope at mid layers of a field.
-
-    Inputs:
-    max_k (Int): Max k level (e.g., 71)
-    field (FloatField): Field of interest [N/A]
-    p0 (FloatField): Pressure [Pa]
-
-    Returns:
-    slope (Float): Slope of the field of interest [N/A]
-    """
-
-    if THIS_K == max_k:
-        above_value = (field[0, 0, -1] - field) / (p0[0, 0, -1] - p0)
-        below_value = (field - field[0, 0, -2]) / (p0 - p0[0, 0, -2])
-        if above_value > 0.0:
-            slope = max(0.0, min(above_value, below_value))
-        else:
-            slope = min(0.0, max(above_value, below_value))
-
-    return slope
-
-
-@gtscript.function
 def ice_fraction(
     temp: Float,
     cnv_frc: Float,


### PR DESCRIPTION
- `slope_top` not needed as we read from above level of fields
- Use 3D uplus/vplus fields at K-1 instead of 2D
- Missing fields reset