### PR TITLE
Updated introductory comments in GEOS_SurfaceGridComp.rc

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/GEOS_SurfaceGridComp.rc
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/GEOS_SurfaceGridComp.rc
@@ -2,15 +2,11 @@
 #                                                                                  #
 #    Resource file for surface parameters, *jointly* used by the GCM and GEOSldas. #     
 #                                                                                  #
-#    Different default values for the GCM and GEOSldas are supported as follows:   #
-#                                                                                  #
-#    - Lines that are NOT commented out can be used to specify GCM defaults as     #
-#        needed, because they are ignored by GEOSldas.                             #
-#                                                                                  #
-#    - The string "GEOSldas=>" identifies the GEOSldas default.                    # 
-#                                                                                  #
-#    This works because this resource file is processed by the GEOSldas            #
-#      script "ldas_setup".                                                        #
+#    Different default values for the GCM and GEOSldas are supported because       #
+#    because this resource file is processed by setup scripts (gcm_setup,          #
+#    fvsetup, ldas_setup).                                                         #
+#    The setup scripts uncomment the appropriate default values by removing the    #
+#    the appropriate '# GEOS[xxxx]=>' strings.                                     # 
 #                                                                                  #
 #    NOTE: For the GCM, there must NOT be white space between the resource         #
 #          parameter name and the colon.                                           #                                         


### PR DESCRIPTION
This PR updates the introductory comments in the GEOS_SurfaceGridComp.rc file.  The comments were outdated because they reflect the time when the AGCM did not use this rc file.  Presently, all setup scripts process this rc file by uncommenting the lines with the appropriate defaults (either "GEOSldas=>" or "GEOSagcm=>").

Besides updating the documentation, this PR also supports simplifications in ldas_setup by removing the explicit occurrence of the string "GEOSldas=>" in the introductory comment.  