### PR TITLE
v12: Support for GCC 15

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -23,7 +23,16 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_BUILD_TYPE MATCHES Aggress
 endif ()
 
 if (CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_BUILD_TYPE MATCHES Release)
-   string (REPLACE "${FOPT3}" "${FOPT2}" CMAKE_Fortran_FLAGS_RELEASE ${CMAKE_Fortran_FLAGS_RELEASE})
+  string (REPLACE "${FOPT3}" "${FOPT2}" CMAKE_Fortran_FLAGS_RELEASE ${CMAKE_Fortran_FLAGS_RELEASE})
+  # There is some odd interaction between GCC 15 and the GF code. FPEs
+  # that do not occur with GCC 14 or earlier. For now, we compile GF
+  # codes with -O1 which seems to avoid the bad instruction. Tests show
+  # not much of a speed difference with GCC 14
+  if (${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 15)
+    message (STATUS "[GCC15+] Setting GF Code to use -O1 for GCC 15")
+    set_source_files_properties(ConvPar_GF2020.F90 PROPERTIES COMPILE_OPTIONS ${FOPT1})
+    set_source_files_properties(ConvPar_GF_GEOS5.F90 PROPERTIES COMPILE_OPTIONS ${FOPT1})
+  endif()
 endif ()
 
 # Note For unknown reasons, BACM_1M_Interface takes 20 minutes to compile at O3


### PR DESCRIPTION
This PR has a fix for v12 in Moist CMake to allow running with GCC 15. For some reason, GCC 15 does not seem to like GF code at high optimization levels. At some point, I'd like to figure it out, but debugging has been hard. `-O0` works and if I put the optimized code in a debugger like DDT, it throws errors *before* we get to the GF error! Aah!

So, for now, we just degrade the optimization so it works.