### PR TITLE
Updates for the new MAPL_GridCompAddSpec interface

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -50,6 +50,7 @@ module GEOS_GwdGridCompMod
    use mapl3g_UngriddedDims, only: UngriddedDims
    use mapl3g_Geom_API, only: MAPL_GridGet
    use mapl3g_State_API, only: MAPL_StateGetPointer
+   use mapl3g_UngriddedDim, only: UngriddedDim
 
    use gw_rdg, only : gw_rdg_init
    use gw_oro, only : gw_oro_init
@@ -130,6 +131,7 @@ contains
 
       type (wrap_)                                :: wrap
       type (GEOS_GwdGridComp), pointer               :: self
+      type(UngriddedDim) :: ungrd_16
       integer :: num_threads
 
       ! Begin...
@@ -161,6 +163,7 @@ contains
 
       ! Set the state variable specs.
       ! -----------------------------
+      ungrd_16 = UngriddedDim(16, name="sixteen", units="1")
 #include "GWD_Import___.h"
 #include "GWD_Export___.h"
 #include "GWD_Internal___.h"

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GWD_StateSpecs.rc
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GWD_StateSpecs.rc
@@ -8,14 +8,14 @@ category: INTERNAL
  NAME   | UNITS   | DIMS | VLOC | UNGRIDDED  | LONG NAME
 #--------------------------------------------------------------------------------------------------------------------
  SGH30  | m       | xy   | N    |            | standard deviation of 30s elevation from 3km cube
- KWVRDG | km      | xy   | N    | [16]       | horizonal wwavenumber of mountain ridges
- EFFRDG | km      | xy   | N    | [16]       | efficiency of mountain ridge scheme
+ KWVRDG | km      | xy   | N    | ungrd_16   | horizonal wwavenumber of mountain ridges
+ EFFRDG | km      | xy   | N    | ungrd_16   | efficiency of mountain ridge scheme
  GBXAR  | NA      | xy   | N    |            | grid box area
- HWDTH  | km      | xy   | N    | [16]       | width of mountain ridges
- CLNGT  | km      | xy   | N    | [16]       | width of mountain ridges
- MXDIS  | NA      | xy   | N    | [16]       | NA
- ANGLL  | NA      | xy   | N    | [16]       | NA
- ANIXY  | NA      | xy   | N    | [16]       | NA
+ HWDTH  | km      | xy   | N    | ungrd_16   | width of mountain ridges
+ CLNGT  | km      | xy   | N    | ungrd_16   | width of mountain ridges
+ MXDIS  | NA      | xy   | N    | ungrd_16   | NA
+ ANGLL  | NA      | xy   | N    | ungrd_16   | NA
+ ANIXY  | NA      | xy   | N    | ungrd_16   | NA
 
 category: IMPORT
 #-------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`MAPL_GridCompAddSpec` interface has been updated. The input arg `ungridded_dims` is now an array of type `UngriddedDim`, instead of an array of integers. This PR updates the GWD gridcomp to use the new interface.