### PR TITLE
CatchCN CLM51 fix endrun exit issue

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/CNBalanceCheckMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/CNBalanceCheckMod.F90
@@ -5,6 +5,9 @@ module CNBalanceCheckMod
   ! Module for carbon/nitrogen mass balance checking.
   !
   ! !USES:
+
+  use ESMF
+  
   use shr_kind_mod                    , only : r8 => shr_kind_r8
   use nanMod                          , only : nan
   use shr_log_mod                     , only : errMsg => shr_log_errMsg
@@ -220,6 +223,7 @@ contains
     real(r8) :: som_c_leached_grc(bounds%begg:bounds%endg)
     real(r8) :: hrv_xsmrpool_amount_left_to_dribble(bounds%begg:bounds%endg)
     real(r8) :: dwt_conv_cflux_amount_left_to_dribble(bounds%begg:bounds%endg)
+    integer  :: rc       
     !-----------------------------------------------------------------------
 
     associate(                                                                            & 
@@ -307,7 +311,7 @@ contains
          write(iulog,*)'wood_harvestc            = ',wood_harvestc(c)*dt
          write(iulog,*)'grainc_to_cropprodc      = ',grainc_to_cropprodc(c)*dt
          write(iulog,*)'-1*som_c_leached         = ',som_c_leached(c)*dt
-         call endrun(msg=errMsg(sourcefile, __LINE__))
+         call endrun(msg=errMsg(sourcefile, __LINE__),rc)
       end if
 
       ! Repeat error check at the gridcell level
@@ -379,11 +383,13 @@ contains
          write(iulog,*)'dwt_seedc_to_deadstem_grc =', dwt_seedc_to_deadstem_grc(g) * dt
          write(iulog,*)'--- Outputs ---'
          write(iulog,*)'-1*som_c_leached_grc    = ', som_c_leached_grc(g) * dt
-         call endrun(msg=errMsg(sourcefile, __LINE__))
+         call endrun(msg=errMsg(sourcefile, __LINE__),rc)
       end if
 
     end associate
 
+    RETURN_(ESMF_SUCCESS)
+    
   end subroutine CBalanceCheck
 
   !-----------------------------------------------------------------------
@@ -426,6 +432,7 @@ contains
     real(r8):: grc_ninputs(bounds%begg:bounds%endg)
     real(r8):: grc_noutputs(bounds%begg:bounds%endg)
     real(r8):: grc_errnb(bounds%begg:bounds%endg)
+    integer :: rc
     !-----------------------------------------------------------------------
 
     associate(                                                                             & 
@@ -545,7 +552,7 @@ contains
         
          
          
-         call endrun(msg=errMsg(sourcefile, __LINE__))
+         call endrun(msg=errMsg(sourcefile, __LINE__),rc)
       end if
 
       ! Repeat error check at the gridcell level
@@ -619,11 +626,13 @@ contains
          write(iulog,*) 'grc_noutputs_partial     =', grc_noutputs_partial(g) * dt
          write(iulog,*) 'dwt_conv_nflux_grc       =', dwt_conv_nflux_grc(g) * dt
          write(iulog,*) 'product_loss_grc         =', product_loss_grc(g) * dt
-         call endrun(msg=errMsg(sourcefile, __LINE__))
+         call endrun(msg=errMsg(sourcefile, __LINE__),rc)
       end if
 
     end associate
 
+    RETURN_(ESMF_SUCCESS)    
+    
   end subroutine NBalanceCheck
 
 end module CNBalanceCheckMod

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/CNBalanceCheckMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/CNBalanceCheckMod.F90
@@ -5,9 +5,6 @@ module CNBalanceCheckMod
   ! Module for carbon/nitrogen mass balance checking.
   !
   ! !USES:
-
-  use ESMF
-  
   use shr_kind_mod                    , only : r8 => shr_kind_r8
   use nanMod                          , only : nan
   use shr_log_mod                     , only : errMsg => shr_log_errMsg
@@ -223,7 +220,6 @@ contains
     real(r8) :: som_c_leached_grc(bounds%begg:bounds%endg)
     real(r8) :: hrv_xsmrpool_amount_left_to_dribble(bounds%begg:bounds%endg)
     real(r8) :: dwt_conv_cflux_amount_left_to_dribble(bounds%begg:bounds%endg)
-    integer  :: rc       
     !-----------------------------------------------------------------------
 
     associate(                                                                            & 
@@ -311,7 +307,7 @@ contains
          write(iulog,*)'wood_harvestc            = ',wood_harvestc(c)*dt
          write(iulog,*)'grainc_to_cropprodc      = ',grainc_to_cropprodc(c)*dt
          write(iulog,*)'-1*som_c_leached         = ',som_c_leached(c)*dt
-         call endrun(msg=errMsg(sourcefile, __LINE__),rc)
+         call endrun(msg=errMsg(sourcefile, __LINE__))
       end if
 
       ! Repeat error check at the gridcell level
@@ -383,13 +379,11 @@ contains
          write(iulog,*)'dwt_seedc_to_deadstem_grc =', dwt_seedc_to_deadstem_grc(g) * dt
          write(iulog,*)'--- Outputs ---'
          write(iulog,*)'-1*som_c_leached_grc    = ', som_c_leached_grc(g) * dt
-         call endrun(msg=errMsg(sourcefile, __LINE__),rc)
+         call endrun(msg=errMsg(sourcefile, __LINE__))
       end if
 
     end associate
 
-    RETURN_(ESMF_SUCCESS)
-    
   end subroutine CBalanceCheck
 
   !-----------------------------------------------------------------------
@@ -432,7 +426,6 @@ contains
     real(r8):: grc_ninputs(bounds%begg:bounds%endg)
     real(r8):: grc_noutputs(bounds%begg:bounds%endg)
     real(r8):: grc_errnb(bounds%begg:bounds%endg)
-    integer :: rc
     !-----------------------------------------------------------------------
 
     associate(                                                                             & 
@@ -552,7 +545,7 @@ contains
         
          
          
-         call endrun(msg=errMsg(sourcefile, __LINE__),rc)
+         call endrun(msg=errMsg(sourcefile, __LINE__))
       end if
 
       ! Repeat error check at the gridcell level
@@ -626,13 +619,11 @@ contains
          write(iulog,*) 'grc_noutputs_partial     =', grc_noutputs_partial(g) * dt
          write(iulog,*) 'dwt_conv_nflux_grc       =', dwt_conv_nflux_grc(g) * dt
          write(iulog,*) 'product_loss_grc         =', product_loss_grc(g) * dt
-         call endrun(msg=errMsg(sourcefile, __LINE__),rc)
+         call endrun(msg=errMsg(sourcefile, __LINE__))
       end if
 
     end associate
 
-    RETURN_(ESMF_SUCCESS)    
-    
   end subroutine NBalanceCheck
 
 end module CNBalanceCheckMod

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/abortutils.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/abortutils.F90
@@ -7,6 +7,8 @@ module abortutils
   ! Abort the model for abnormal termination
   !-----------------------------------------------------------------------
 
+  use ESMF
+  
   private
   save
 
@@ -20,7 +22,7 @@ module abortutils
 CONTAINS
 
   !-----------------------------------------------------------------------
-  subroutine endrun_vanilla(msg, additional_msg)
+  subroutine endrun_vanilla(msg, additional_msg, rc)
 
     !-----------------------------------------------------------------------
     ! !DESCRIPTION:
@@ -39,6 +41,7 @@ CONTAINS
     ! and then just assert against msg.
     character(len=*), intent(in), optional :: msg            ! string to be passed to shr_sys_abort
     character(len=*), intent(in), optional :: additional_msg ! string to be printed, but not passed to shr_sys_abort
+    integer,          intent(out),optional :: rc             ! return code
     !-----------------------------------------------------------------------
 
     if (present (additional_msg)) then
@@ -47,12 +50,14 @@ CONTAINS
        write(iulog,*)'ENDRUN:'
     end if
 
-    call shr_sys_abort(msg)
+    call shr_sys_abort(msg,rc)
+
+    RETURN_(ESMF_SUCCESS)
 
   end subroutine endrun_vanilla
 
   !-----------------------------------------------------------------------
-  subroutine endrun_globalindex(decomp_index, clmlevel, msg, additional_msg)
+  subroutine endrun_globalindex(decomp_index, clmlevel, msg, additional_msg, rc)
 
     !-----------------------------------------------------------------------
     ! Description:
@@ -74,6 +79,7 @@ CONTAINS
     ! and then just assert against msg.
     character(len=*), intent(in), optional :: msg            ! string to be passed to shr_sys_abort
     character(len=*), intent(in), optional :: additional_msg ! string to be printed, but not passed to shr_sys_abort
+    integer,          intent(out),optional :: rc             ! return code    
     !
     ! Local Variables:
     integer :: igrc, ilun, icol 
@@ -88,8 +94,10 @@ CONTAINS
        write(iulog,*)'ENDRUN:'
     end if
 
-    call shr_sys_abort(msg)
+    call shr_sys_abort(msg, rc)
 
+    RETURN_(ESMF_SUCCESS)
+    
   end subroutine endrun_globalindex
 
 end module abortutils

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/abortutils.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/abortutils.F90
@@ -7,8 +7,6 @@ module abortutils
   ! Abort the model for abnormal termination
   !-----------------------------------------------------------------------
 
-  use ESMF
-  
   private
   save
 
@@ -22,7 +20,7 @@ module abortutils
 CONTAINS
 
   !-----------------------------------------------------------------------
-  subroutine endrun_vanilla(msg, additional_msg, rc)
+  subroutine endrun_vanilla(msg, additional_msg)
 
     !-----------------------------------------------------------------------
     ! !DESCRIPTION:
@@ -41,7 +39,6 @@ CONTAINS
     ! and then just assert against msg.
     character(len=*), intent(in), optional :: msg            ! string to be passed to shr_sys_abort
     character(len=*), intent(in), optional :: additional_msg ! string to be printed, but not passed to shr_sys_abort
-    integer,          intent(out),optional :: rc             ! return code
     !-----------------------------------------------------------------------
 
     if (present (additional_msg)) then
@@ -50,14 +47,12 @@ CONTAINS
        write(iulog,*)'ENDRUN:'
     end if
 
-    call shr_sys_abort(msg,rc)
-
-    RETURN_(ESMF_SUCCESS)
+    call shr_sys_abort(msg)
 
   end subroutine endrun_vanilla
 
   !-----------------------------------------------------------------------
-  subroutine endrun_globalindex(decomp_index, clmlevel, msg, additional_msg, rc)
+  subroutine endrun_globalindex(decomp_index, clmlevel, msg, additional_msg)
 
     !-----------------------------------------------------------------------
     ! Description:
@@ -65,7 +60,7 @@ CONTAINS
     !
     use shr_sys_mod       , only: shr_sys_abort
     use clm_varctl        , only: iulog
-   ! use GetGlobalValuesMod, only: GetGlobalWrite
+    !use GetGlobalValuesMod, only: GetGlobalWrite
     !
     ! Arguments:
     implicit none
@@ -79,14 +74,13 @@ CONTAINS
     ! and then just assert against msg.
     character(len=*), intent(in), optional :: msg            ! string to be passed to shr_sys_abort
     character(len=*), intent(in), optional :: additional_msg ! string to be printed, but not passed to shr_sys_abort
-    integer,          intent(out),optional :: rc             ! return code    
     !
     ! Local Variables:
     integer :: igrc, ilun, icol 
     !-----------------------------------------------------------------------
 
-   ! write(6,*)'calling getglobalwrite with decomp_index= ',decomp_index,' and clmlevel= ',trim(clmlevel)
-   ! call GetGlobalWrite(decomp_index, clmlevel)
+    !write(6,*)'calling getglobalwrite with decomp_index= ',decomp_index,' and clmlevel= ',trim(clmlevel)
+    !call GetGlobalWrite(decomp_index, clmlevel)
 
     if (present (additional_msg)) then
        write(iulog,*)'ENDRUN: ', additional_msg
@@ -94,10 +88,8 @@ CONTAINS
        write(iulog,*)'ENDRUN:'
     end if
 
-    call shr_sys_abort(msg, rc)
+    call shr_sys_abort(msg)
 
-    RETURN_(ESMF_SUCCESS)
-    
   end subroutine endrun_globalindex
 
 end module abortutils

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/shr_abort_mod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/shr_abort_mod.F90
@@ -1,5 +1,3 @@
-#include "MAPL_Generic.h"
-
 module shr_abort_mod
   ! This module defines procedures that can be used to abort the model cleanly in a
   ! system-specific manner
@@ -11,17 +9,15 @@ module shr_abort_mod
 
   use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
 
-  use ESMF
-  use MAPL_ExceptionHandling
   use shr_kind_mod, only : shr_kind_in, shr_kind_cx
-  !use shr_mpi_mod , only : shr_mpi_initialized, shr_mpi_abort
+  use shr_mpi_mod , only : shr_mpi_initialized, shr_mpi_abort
   use shr_log_mod , only : s_logunit => shr_log_Unit
 
-!#ifdef CPRNAG
-!  ! NAG does not provide this as an intrinsic, but it does provide modules
-!  ! that implement commonly used POSIX routines.
-!  use f90_unix_proc, only: abort
-!#endif
+#ifdef CPRNAG
+  ! NAG does not provide this as an intrinsic, but it does provide modules
+  ! that implement commonly used POSIX routines.
+  use f90_unix_proc, only: abort
+#endif
 
   implicit none
 
@@ -34,7 +30,7 @@ module shr_abort_mod
   ! (shr_sys_abort, shr_sys_backtrace). (This is for consistency with older code, from
   ! when these routines were defined in shr_sys_mod.)
   public :: shr_abort_abort     ! abort a program
-  !public :: shr_abort_backtrace ! print a backtrace, if possible
+  public :: shr_abort_backtrace ! print a backtrace, if possible
 
 contains
 
@@ -43,11 +39,11 @@ contains
     ! Consistent stopping mechanism
 
     !----- arguments -----
-    character(len=*)    , intent(in) , optional :: string  ! error message string
-    integer(shr_kind_in), intent(out), optional :: rc      ! return code
-    
+    character(len=*)    , intent(in), optional :: string  ! error message string
+    integer(shr_kind_in), intent(in), optional :: rc      ! error code
+
     !----- local -----
-    !logical :: flag
+    logical :: flag
 
     ! Local version of the string.
     ! (Gets a default value if string is not present.)
@@ -62,71 +58,75 @@ contains
 
     call print_error_to_logs("ERROR", local_string)
 
-    !call shr_abort_backtrace()
+    call shr_abort_backtrace()
 
-    !call shr_mpi_initialized(flag)
+    call shr_mpi_initialized(flag)
 
-    _ASSERT(.FALSE.,trim(local_string))
+    if (flag) then
+       if (present(rc)) then
+          call shr_mpi_abort(trim(local_string),rc)
+       else
+          call shr_mpi_abort(trim(local_string))
+       endif
+    endif
 
     ! A compiler's abort method may print a backtrace or do other nice
     ! things, but in fact we can rarely leverage this, because MPI_Abort
     ! usually sends SIGTERM to the process, and we don't catch that signal.
-    !call abort()
-    
-    RETURN_(ESMF_SUCCESS)
-    
+    call abort()
+
   end subroutine shr_abort_abort
   !===============================================================================
 
   !===============================================================================
-!  subroutine shr_abort_backtrace()
-!    ! This routine uses compiler-specific facilities to print a backtrace to
-!    ! error_unit (standard error, usually unit 0).
-!
-!#if defined(CPRIBM)
-!
-!    ! This theoretically should be in xlfutility, but using it from that
-!    ! module doesn't seem to always work.
-!    interface
-!       subroutine xl_trbk()
-!       end subroutine xl_trbk
-!    end interface
-!
-!    call xl__trbk()
-!
-!#elif defined(CPRGNU) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8 ))
-!
-!    ! gfortran 4.8 and later implement this intrinsic. We explicitly call it
-!    ! out as such to make sure that it really is available, just in case the
-!    ! CPP logic above screws up.
-!    intrinsic :: backtrace
-!
-!    call backtrace()
-!
-!#elif defined(CPRINTEL)
-!
-!    ! tracebackqq uses optional arguments, so *must* have an explicit
-!    ! interface.
-!    use ifcore, only: tracebackqq
-!
-!    ! An exit code of -1 is a special value that prevents this subroutine
-!    ! from aborting the run.
-!    call tracebackqq(user_exit_code=-1)
-!
-!#else
-!
-!    ! Currently we have no means to request a backtrace from the NAG runtime,
-!    ! even though it is capable of emitting backtraces itself, if you use the
-!    ! "-gline" option.
-!
-!    ! Similarly, PGI has a -traceback option, but no user interface for
-!    ! requesting a backtrace to be printed.
-!
-!#endif
-!
-!    flush(error_unit)
-!
-!  end subroutine shr_abort_backtrace
+  subroutine shr_abort_backtrace()
+    ! This routine uses compiler-specific facilities to print a backtrace to
+    ! error_unit (standard error, usually unit 0).
+
+#if defined(CPRIBM)
+
+    ! This theoretically should be in xlfutility, but using it from that
+    ! module doesn't seem to always work.
+    interface
+       subroutine xl_trbk()
+       end subroutine xl_trbk
+    end interface
+
+    call xl__trbk()
+
+#elif defined(CPRGNU) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8 ))
+
+    ! gfortran 4.8 and later implement this intrinsic. We explicitly call it
+    ! out as such to make sure that it really is available, just in case the
+    ! CPP logic above screws up.
+    intrinsic :: backtrace
+
+    call backtrace()
+
+#elif defined(CPRINTEL)
+
+    ! tracebackqq uses optional arguments, so *must* have an explicit
+    ! interface.
+    use ifcore, only: tracebackqq
+
+    ! An exit code of -1 is a special value that prevents this subroutine
+    ! from aborting the run.
+    call tracebackqq(user_exit_code=-1)
+
+#else
+
+    ! Currently we have no means to request a backtrace from the NAG runtime,
+    ! even though it is capable of emitting backtraces itself, if you use the
+    ! "-gline" option.
+
+    ! Similarly, PGI has a -traceback option, but no user interface for
+    ! requesting a backtrace to be printed.
+
+#endif
+
+    flush(error_unit)
+
+  end subroutine shr_abort_backtrace
   !===============================================================================
 
   !===============================================================================

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/shr_abort_mod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/shr_abort_mod.F90
@@ -38,21 +38,15 @@ module shr_abort_mod
 contains
 
   !===============================================================================
-  subroutine shr_abort_abort(string,ec,rc)
-    ! Consistent stopping mechanism
-
+  subroutine shr_abort_abort(string, ec, rc)
     !----- arguments -----
-    character(len=*)    , intent(in) , optional :: string  ! error message string
-    integer(shr_kind_in), intent(in) , optional :: ec      ! error code
-    integer(shr_kind_in), intent(out), optional :: rc      ! error code
-    
-    !----- local -----
-    !logical :: flag
+    character(len=*),     intent(in),  optional :: string
+    integer(shr_kind_in), intent(in),  optional :: ec
+    integer(shr_kind_in), intent(out), optional :: rc
 
-    ! Local version of the string.
-    ! (Gets a default value if string is not present.)
+    !----- local -----
     character(len=shr_kind_cx) :: local_string
-    !-------------------------------------------------------------------------------
+    integer :: exit_code
 
     if (present(string)) then
        local_string = trim(string)
@@ -60,24 +54,16 @@ contains
        local_string = "Unknown error submitted to shr_abort_abort."
     end if
 
+    ! Log to stdout/stderr and flush.
     call print_error_to_logs("ERROR", local_string)
 
- !   call shr_abort_backtrace()
+    exit_code = 1
+    if (present(ec)) exit_code = ec
+    if (present(rc)) rc = exit_code
 
-!    call shr_mpi_initialized(flag)
-
-    if (present(ec)) then
-       _ASSERT(.FALSE.,trim(local_string))
-    else
-       _ASSERT(.FALSE.,trim(local_string))
-    endif
-
-    ! A compiler's abort method may print a backtrace or do other nice
-    ! things, but in fact we can rarely leverage this, because MPI_Abort
-    ! usually sends SIGTERM to the process, and we don't catch that signal.
-    !call abort()
-
+    error stop "shr_abort_abort: hard abort"   ! prints and exits nonzero
   end subroutine shr_abort_abort
+
   !===============================================================================
 
   !===============================================================================

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/shr_abort_mod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM51_GridComp/CLM51/shr_abort_mod.F90
@@ -11,9 +11,10 @@ module shr_abort_mod
 
   use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
 
+  use ESMF
   use MAPL_ExceptionHandling
   use shr_kind_mod, only : shr_kind_in, shr_kind_cx
-!  use shr_mpi_mod , only : shr_mpi_initialized, shr_mpi_abort
+  !use shr_mpi_mod , only : shr_mpi_initialized, shr_mpi_abort
   use shr_log_mod , only : s_logunit => shr_log_Unit
 
 !#ifdef CPRNAG
@@ -33,20 +34,25 @@ module shr_abort_mod
   ! (shr_sys_abort, shr_sys_backtrace). (This is for consistency with older code, from
   ! when these routines were defined in shr_sys_mod.)
   public :: shr_abort_abort     ! abort a program
-  ! public :: shr_abort_backtrace ! print a backtrace, if possible
+  !public :: shr_abort_backtrace ! print a backtrace, if possible
 
 contains
 
   !===============================================================================
-  subroutine shr_abort_abort(string, ec, rc)
-    !----- arguments -----
-    character(len=*),     intent(in),  optional :: string
-    integer(shr_kind_in), intent(in),  optional :: ec
-    integer(shr_kind_in), intent(out), optional :: rc
+  subroutine shr_abort_abort(string,rc)
+    ! Consistent stopping mechanism
 
+    !----- arguments -----
+    character(len=*)    , intent(in) , optional :: string  ! error message string
+    integer(shr_kind_in), intent(out), optional :: rc      ! return code
+    
     !----- local -----
+    !logical :: flag
+
+    ! Local version of the string.
+    ! (Gets a default value if string is not present.)
     character(len=shr_kind_cx) :: local_string
-    integer :: exit_code
+    !-------------------------------------------------------------------------------
 
     if (present(string)) then
        local_string = trim(string)
@@ -54,16 +60,22 @@ contains
        local_string = "Unknown error submitted to shr_abort_abort."
     end if
 
-    ! Log to stdout/stderr and flush.
     call print_error_to_logs("ERROR", local_string)
 
-    exit_code = 1
-    if (present(ec)) exit_code = ec
-    if (present(rc)) rc = exit_code
+    !call shr_abort_backtrace()
 
-    error stop "shr_abort_abort: hard abort"   ! prints and exits nonzero
+    !call shr_mpi_initialized(flag)
+
+    _ASSERT(.FALSE.,trim(local_string))
+
+    ! A compiler's abort method may print a backtrace or do other nice
+    ! things, but in fact we can rarely leverage this, because MPI_Abort
+    ! usually sends SIGTERM to the process, and we don't catch that signal.
+    !call abort()
+    
+    RETURN_(ESMF_SUCCESS)
+    
   end subroutine shr_abort_abort
-
   !===============================================================================
 
   !===============================================================================


### PR DESCRIPTION
`NOTE: We can't merge this until Nitrogen balance error is resolved. `

**Issue :** 
During CatchCN run we see error message but run doesn't exit it proceeds and finishes successfully. 

In code we have calls to endrun in right locations but down the stream final code just did assert print /log not exit.

**With Branch fix:** 
**Code stops** and prints error and trace to error, example from my 1day run:
**`In GEOSldas_log_txt trace:`**
 ENDRUN:
 ERROR: 
 ERROR in CNBalanceCheckMod.F90 at line                                      548
 
===================================================================================
=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
=   RANK 0 PID 27588 RUNNING AT borgk145
=   KILLED BY SIGNAL: 9 (Killed)

**`In GEOSldas_err_txt trace:`**
No errorforrtl: severe (174): SIGSEGV, segmentation fault occurred
Image              PC                Routine            Line        Source
libpthread-2.31.s  00001495FB25A910  Unknown               Unknown  Unknown
GEOSldas.x         0000000000445658  Unknown               Unknown  Unknown
libpthread-2.31.s  00001495FB25A910  Unknown               Unknown  Unknown
No errorshr_abort_abort: hard abort
shr_abort_abort: hard abort
shr_abort_abort: hard abort

@gmao-rreichle  @weiyuan-jiang 
