### PR TITLE
Feature/narnold1/#1155 fix uw tendency

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/uwshcu.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/uwshcu.F90
@@ -2699,7 +2699,10 @@ contains
 
             umf(k) = umf(km1) * exp( dpe * ( fer(k) - fdr(k) ) )
             emf(k) = 0.
-   
+
+            ! Limit umf based on (2x) the CFL condition
+            umf(k) = min(umf(k),2.*dp0(k)/g/dt)
+            
             dcm(k) = 0.5*(umf(k)+umf(km1))*rei(k)*dpe*min(1.,max(0.,xsat-xc))
 !           dcm(k) = min(1.,max(0.,xsat-xc))
 


### PR DESCRIPTION
Limits the UW mass flux based on the CFL condition to reduce occurrence of large tendencies.  Tests indicate minimal impact on UMF<0.15 kg/m2/s and temperature increments less than 5K, while UMF>0.2 and increments >10K are almost eliminated.