### PR TITLE
update a couple of CICE6 forcing nml variables

### DIFF
--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
@@ -240,7 +240,9 @@
     iceruf_ocn      = 0.03
     emissivity      = 0.985
     fbot_xfer_type  = 'constant'
-    update_ocn_f    = .true.
+    update_ocn_f    = .false.
+    cpl_frazil      = 'fresh_ice_correction'
+    saltflux_option = 'prognostic'
     l_mpond_fresh   = .false.
     tfrz_option     = 'linear_salt'
     oceanmixed_ice  = .false.

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/540x458/ice_in
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/540x458/ice_in
@@ -240,7 +240,9 @@
     iceruf_ocn      = 0.03
     emissivity      = 0.985
     fbot_xfer_type  = 'constant'
-    update_ocn_f    = .true.
+    update_ocn_f    = .false.
+    cpl_frazil      = 'fresh_ice_correction'
+    saltflux_option = 'prognostic'
     l_mpond_fresh   = .false.
     tfrz_option     = 'linear_salt'
     oceanmixed_ice  = .false.

--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/72x36/ice_in
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/72x36/ice_in
@@ -241,6 +241,8 @@
     emissivity      = 0.985
     fbot_xfer_type  = 'constant'
     update_ocn_f    = .false.
+    cpl_frazil      = 'fresh_ice_correction'
+    saltflux_option = 'prognostic'
     l_mpond_fresh   = .false.
     tfrz_option     = 'linear_salt'
     oceanmixed_ice  = .false.


### PR DESCRIPTION
This PR updated a few forcing nml parameters to be compatible with mushy layer scheme now as default.

