### PR TITLE
[NDSL] Restore missing interface

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_GFDL_1M_InterfaceMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_GFDL_1M_InterfaceMod.F90
@@ -411,6 +411,8 @@ subroutine GFDL_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
 
     call ESMF_TimeIntervalGet(TINT,   S_R8=DT_R8,RC=STATUS); VERIFY_(STATUS)
     DT_MOIST = DT_R8
+
+    call cpu_time(start)
 #ifdef PYMOIST_INTEGRATION
     IF (USE_PYMOIST_GFDL_1M) THEN
       IF (.NOT. GFDL_1M_READY) THEN
@@ -1012,7 +1014,9 @@ subroutine GFDL_1M_Run (GC, IMPORT, EXPORT, CLOCK, RC)
 #ifdef PYMOIST_INTEGRATION
   ENDIF
 #endif
-     call MAPL_TimerOff(MAPL,"--GFDL_1M",RC=STATUS)
+  call cpu_time(finish)
+  print *, 'gfdl_1m: time taken = ', finish - start, 's'
+  call MAPL_TimerOff(MAPL,"--GFDL_1M",RC=STATUS)
 
 end subroutine GFDL_1M_Run
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_UW_InterfaceMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_UW_InterfaceMod.F90
@@ -34,6 +34,7 @@ module GEOS_UW_InterfaceMod
   logical :: USE_PYMOIST_UW = .FALSE.
   logical :: INIT_PYMOIST_UW = .FALSE.
 #endif
+  real :: start, finish
 
   public :: UW_Setup, UW_Initialize, UW_Run
 
@@ -357,6 +358,8 @@ subroutine UW_Run (GC, IMPORT, EXPORT, CLOCK, RC)
     QLTOT = QLLS+QLCN
     QITOT = QILS+QICN
 
+    call cpu_time(start)
+
 #ifdef PYMOIST_INTEGRATION
     if (USE_PYMOIST_UW) then
       ncnst = size(CNV_Tracers)
@@ -475,6 +478,10 @@ subroutine UW_Run (GC, IMPORT, EXPORT, CLOCK, RC)
 #ifdef PYMOIST_INTEGRATION
     endif
 #endif
+
+      call cpu_time(finish)
+      print *, 'uw shallow convection: time taken = ', finish - start, 's'
+
       !  Apply tendencies
       !--------------------------------------------------------------
         Q  = Q  + DQVDT_SC * UW_DT    ! note this adds to the convective

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/cffi_lib/interface.f90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/cffi_lib/interface.f90
@@ -14,8 +14,7 @@ module pymoist_interface_mod
    public :: pymoist_interface_f_init
    public :: pymoist_interface_f_finalize
    public :: gfdl_1m_interface_f_init
-   public :: pymoist_interface_f_run_GFDL1M
-   public :: pymoist_interface_f_run_GFDL_1M_driver
+   public :: pymoist_interface_f_run_GFDL_1M
    public :: pymoist_interface_f_run_AerActivation
    public :: compute_uwshcu_f_init
    public :: compute_uwshcu_f_run_compute_uwshcu
@@ -132,6 +131,9 @@ module pymoist_interface_mod
 
    interface
 
+      subroutine pymoist_interface_f_finalize() bind(c, name='pymoist_interface_c_finalize')
+      end subroutine pymoist_interface_f_finalize
+
       subroutine pymoist_interface_f_init(IMPORT, EXPORT, MAPL_COMP, moist_flags) bind(c, name='pymoist_interface_c_init')
 
          import c_ptr, c_int, c_float, c_double, c_bool, moist_flags_interface_type
@@ -152,70 +154,8 @@ module pymoist_interface_mod
 
       end subroutine gfdl_1m_interface_f_init
 
-      subroutine pymoist_interface_f_run_GFDL1M( &
-         dw_land, dw_ocean, PDFSHAPE, TURNRHCRIT_PARAM, &
-         DT_MOIST, CCW_EVAP_EFF, CCI_EVAP_EFF, &
-         LMELTFRZ, &
-         AREA, CNV_FRC, SRF_TYPE, &
-         KLCL, &
-         EIS, PLmb, PLEmb, NACTL, NACTI, QST,&
-         T, Q, QLCN, QICN, QLLS, QILS, CLLS, CLCN, &
-         SUBLC, EVAPC, RHX )  bind(c, name='pymoist_interface_c_run_GFDL1M')
-
-         import c_int, c_float, c_bool
-
-         implicit none
-
-         ! Input
-
-         ! All parameters should be in `init`
-         real(kind=c_float), value, intent(in) :: dw_land, dw_ocean ! Namelist flags
-         real(kind=c_float), value, intent(in) :: TURNRHCRIT_PARAM, DT_MOIST, CCW_EVAP_EFF, CCI_EVAP_EFF
-         integer(kind=c_int), value, intent(in) :: PDFSHAPE, LMELTFRZ
-
-
-         real(kind=c_float), dimension(*), intent(in) :: AREA, CNV_FRC, SRF_TYPE, EIS, PLmb, PLEmb, NACTL, NACTI, QST
-         integer(kind=c_int), dimension(*), intent(in) :: KLCL
-
-         ! InOut
-         real(kind=c_float), dimension(*), intent(inout) :: T, Q, QLCN, QICN, QLLS, QILS, CLCN, CLLS
-
-         ! Output
-         real(kind=c_float), dimension(*), intent(out) :: SUBLC, EVAPC, RHX
-
-      end subroutine pymoist_interface_f_run_GFDL1M
-
-      subroutine pymoist_interface_f_run_GFDL_1M_driver( &
-         RAD_QV, RAD_QL, RAD_QR, RAD_QI, RAD_QS, RAD_QG, RAD_CF, NACTAll, &
-         DQVDTmic, DQLDTmic, DQRDTmic, DQIDTmic, &
-         DQSDTmic, DQGDTmic, DQADTmic, DTDTmic, &
-         T, W, U, V, DUDTmic, DVDTmic, DZ, DP, &
-         AREA, DT_MOIST, FRLAND, CNV_FRC, SRF_TYPE, EIS, &
-         RHCRIT3D, ANV_ICEFALL, LS_ICEFALL, &
-         REV_LS, RSU_LS, &
-         PRCP_RAIN, PRCP_SNOW, PRCP_ICE, PRCP_GRAUPEL, &
-         PFL_LS, PFI_LS, &
-         LHYDROSTATIC, LPHYS_HYDROSTATIC ) bind(c, name='pymoist_interface_c_run_GFDL_1M_driver')
-
-         import c_int, c_float, c_bool
-
-         implicit none
-
-         ! Input
-         real(kind=c_float), dimension(*), intent(in) :: RAD_QV, RAD_QL, RAD_QR, RAD_QI, RAD_QS, RAD_QG, RAD_CF, NACTAll
-         real(kind=c_float), dimension(*), intent(in) :: T, W, U, V, DUDTmic, DVDTmic, DZ, DP
-
-         real(kind=c_float), dimension(*), intent(in) :: AREA, FRLAND, CNV_FRC, SRF_TYPE, EIS, RHCRIT3D
-         real(kind=c_float), value, intent(in) :: DT_MOIST, LS_ICEFALL, ANV_ICEFALL
-         integer(kind=c_int), value, intent(in) :: LHYDROSTATIC, LPHYS_HYDROSTATIC ! Actually bool but LOGICAL(4) and (1) are fighting
-
-         ! Output
-         real(kind=c_float), dimension(*), intent(inout) :: DQVDTmic, DQLDTmic, DQRDTmic, DQIDTmic, DQSDTmic, DQGDTmic, DQADTmic, DTDTmic
-         real(kind=c_float), dimension(*), intent(inout) :: REV_LS, RSU_LS
-         real(kind=c_float), dimension(*), intent(inout) :: PRCP_RAIN, PRCP_SNOW, PRCP_ICE, PRCP_GRAUPEL
-         real(kind=c_float), dimension(*), intent(inout) :: PFL_LS, PFI_LS
-
-      end subroutine pymoist_interface_f_run_GFDL_1M_driver
+      subroutine pymoist_interface_f_run_GFDL_1M()  bind(c, name='pymoist_interface_c_run_GFDL_1M')
+      end subroutine pymoist_interface_f_run_GFDL_1M
 
       !!-----------------------------------------------------------------------
       !! Interface: Aerosol Activation                                       !!


### PR DESCRIPTION
Merge killed the top-level GFDL_1M interface fortran side. Lack of unit testing for the interface means I missed it.

This PR restores the missing interface and introduce two minor timers for benchmarking online runs.