### PR TITLE
v11: Updates for GCC 15 and Moist

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/CMakeLists.txt
@@ -23,14 +23,21 @@ endif ()
 
 if (CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_BUILD_TYPE MATCHES Release)
   string (REPLACE "${FOPT3}" "${FOPT2}" CMAKE_Fortran_FLAGS_RELEASE ${CMAKE_Fortran_FLAGS_RELEASE})
-  # There is some odd interaction between GCC 15 and the GF code. FPEs
-  # that do not occur with GCC 14 or earlier. For now, we compile GF
+
+  # GCC 15+ workaround for some moist sources
+  # There is some odd interaction between GCC 15 and some moist code. FPEs
+  # that do not occur with GCC 14 or earlier. For now, we compile some
   # codes with -O1 which seems to avoid the bad instruction. Tests show
   # not much of a speed difference with GCC 14
-  if (${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 15)
-    message (STATUS "[GCC15+] Setting GF Code to use -O1 for GCC 15")
-    set_source_files_properties(ConvPar_GF2020.F90 PROPERTIES COMPILE_OPTIONS ${FOPT1})
-    set_source_files_properties(ConvPar_GF_GEOS5.F90 PROPERTIES COMPILE_OPTIONS ${FOPT1})
+  if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+    message(STATUS "[GCC15+] Setting GF Code to use -O1 for GCC 15")
+    set(degrade_o1_sources
+      ConvPar_GF2020.F90
+      ConvPar_GF_GEOS5.F90
+      aer_actv_single_moment.F90
+    )
+    set_source_files_properties(${degrade_o1_sources}
+      PROPERTIES COMPILE_OPTIONS "${FOPT1}")
   endif()
 endif ()
 


### PR DESCRIPTION
This PR has updates for v11 when using GCC 15 and Moist.

Tests run with v12 and GCC 15 found that there was an occasional issue with `aer_actv_single_moment.F90` as well as the GF codes we already degrade. So here we compile `aer_actv_single_moment.F90` with `-O1` as well.

Note: This is non-zero-diff for GCC 15 but 0-diff for running with Intel, so I'll just label as 0-diff.