### PR TITLE
[DSL] Update model code to NDSL v2025.10.00-dirty

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/.gitignore
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/.gitignore
@@ -4,3 +4,4 @@
 /@GEOSradiation_GridComp
 /GEOSradiation_GridComp
 /GEOSradiation_GridComp@
+**/build/*

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/.gitignore
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/.gitignore
@@ -13,3 +13,4 @@ sandbox/
 .gt4py_cache/
 .gt_cache_*/
 .translate*/
+**/build/

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/driver.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/driver.py
@@ -84,7 +84,10 @@ class MicrophysicsDriver:
         # generate saturation specific humidity tables
         # -----------------------------------------------------------------------
 
-        self.sat_tables = get_tables(stencil_factory.backend)
+        self.sat_tables = get_tables(
+            stencil_factory.backend,
+            stencil_factory.config.dace_config,
+        )
 
         # -----------------------------------------------------------------------
         # initialize stencils

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/sat_tables.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/sat_tables.py
@@ -2,7 +2,18 @@ from mpi4py import MPI
 
 from ndsl.boilerplate import get_factories_single_tile
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
-from ndsl.dsl.gt4py import FORWARD, PARALLEL, GlobalTable, K, computation, exp, interval, log, log10
+from ndsl.dsl.dace.dace_config import DaceConfig
+from ndsl.dsl.gt4py import (
+    FORWARD,
+    PARALLEL,
+    GlobalTable,
+    K,
+    computation,
+    exp,
+    interval,
+    log,
+    log10,
+)
 from ndsl.dsl.typing import Float, FloatField, Int
 from pyMoist.GFDL_1M.driver.constants import constants
 from pyMoist.shared_incloud_processes import ice_fraction
@@ -88,13 +99,17 @@ def qs_table_3(length: Int, table3: FloatField, table1: FloatField):
             # compute es over ice between - 160 deg c and 0 deg c.
             # -----------------------------------------------------------------------
             fac1 = fac0 * constants.LI2
-            fac2 = (constants.D2ICE * log(tem0 / constants.T_ICE) + fac1) / constants.RVGAS
+            fac2 = (
+                constants.D2ICE * log(tem0 / constants.T_ICE) + fac1
+            ) / constants.RVGAS
         with interval(1600, None):
             # -----------------------------------------------------------------------
             # compute es over water between 0 deg c and 102 deg c.
             # -----------------------------------------------------------------------
             fac1 = fac0 * constants.LV0
-            fac2 = (constants.DC_VAP * log(tem0 / constants.T_ICE) + fac1) / constants.RVGAS
+            fac2 = (
+                constants.DC_VAP * log(tem0 / constants.T_ICE) + fac1
+            ) / constants.RVGAS
 
     with computation(PARALLEL), interval(...):
         table3 = constants.E_00 * exp(fac2)
@@ -189,7 +204,7 @@ class GFDL_driver_tables:
     Reference Fortran: gfdl_cloud_microphys.F90: qsmith_init.py
     """
 
-    def __init__(self, backend):
+    def __init__(self, backend, dace_config: DaceConfig):
         table_compute_domain = (1, 1, constants.LENGTH)
 
         stencil_factory, quantity_factory = get_factories_single_tile(
@@ -213,7 +228,7 @@ class GFDL_driver_tables:
         # Cancel multi-node compile for tables
         # TODO: this should come for free with the rewrite of the gt:X stencils
         #       compilation mode
-        if MPI.COMM_WORLD.Get_rank() != 0:
+        if not dace_config.do_compile:
             MPI.COMM_WORLD.Barrier()
 
         compute_qs_table_1 = stencil_factory.from_origin_domain(
@@ -258,7 +273,7 @@ class GFDL_driver_tables:
             self._table4,
         )
 
-        if MPI.COMM_WORLD.Get_rank() == 0:
+        if dace_config.do_compile:
             MPI.COMM_WORLD.Barrier()
 
         self.table1 = self._table1.view[0, 0, :]
@@ -277,8 +292,8 @@ _cached_table = {
 }
 
 
-def get_tables(backend):
+def get_tables(backend, dace_config):
     if _cached_table["driver_qsat"] is None:
-        _cached_table["driver_qsat"] = GFDL_driver_tables(backend)
+        _cached_table["driver_qsat"] = GFDL_driver_tables(backend, dace_config)
 
     return _cached_table["driver_qsat"]

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/sat_tables.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/sat_tables.py
@@ -3,17 +3,7 @@ from mpi4py import MPI
 from ndsl.boilerplate import get_factories_single_tile
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.dace.dace_config import DaceConfig
-from ndsl.dsl.gt4py import (
-    FORWARD,
-    PARALLEL,
-    GlobalTable,
-    K,
-    computation,
-    exp,
-    interval,
-    log,
-    log10,
-)
+from ndsl.dsl.gt4py import FORWARD, PARALLEL, GlobalTable, K, computation, exp, interval, log, log10
 from ndsl.dsl.typing import Float, FloatField, Int
 from pyMoist.GFDL_1M.driver.constants import constants
 from pyMoist.shared_incloud_processes import ice_fraction
@@ -99,17 +89,13 @@ def qs_table_3(length: Int, table3: FloatField, table1: FloatField):
             # compute es over ice between - 160 deg c and 0 deg c.
             # -----------------------------------------------------------------------
             fac1 = fac0 * constants.LI2
-            fac2 = (
-                constants.D2ICE * log(tem0 / constants.T_ICE) + fac1
-            ) / constants.RVGAS
+            fac2 = (constants.D2ICE * log(tem0 / constants.T_ICE) + fac1) / constants.RVGAS
         with interval(1600, None):
             # -----------------------------------------------------------------------
             # compute es over water between 0 deg c and 102 deg c.
             # -----------------------------------------------------------------------
             fac1 = fac0 * constants.LV0
-            fac2 = (
-                constants.DC_VAP * log(tem0 / constants.T_ICE) + fac1
-            ) / constants.RVGAS
+            fac2 = (constants.DC_VAP * log(tem0 / constants.T_ICE) + fac1) / constants.RVGAS
 
     with computation(PARALLEL), interval(...):
         table3 = constants.E_00 * exp(fac2)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
@@ -7512,37 +7512,31 @@ class ComputeUwshcuInv:
         self.stop_cin = self.quantity_factory.zeros([X_DIM, Y_DIM], "n/a", dtype=bool)
         self.stop_buoyancy_sort = self.quantity_factory.zeros([X_DIM, Y_DIM], "n/a", dtype=bool)
 
-        self.ntracers_quantity_factory = self.make_ntracers_quantity_factory(
-            self.quantity_factory,
+        self.quantity_factory.add_data_dimensions(
+            {
+                "ntracers": constants.NCNST,
+            }
         )
 
         # Create tracer fields
-        self.trsrc = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, "ntracers"], "n/a")
-        self.trsrc_o = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, "ntracers"], "n/a")
-        self.tre = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, "ntracers"], "n/a")
-        self.trmin = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, "ntracers"], "n/a")
-        self.sstr0 = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
-        self.tr0 = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
-        self.tr0_o = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
-        self.sstr0_o = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
-        self.trten = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
-        self.tr0_s = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
-        self.tr0_inoutvar = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
-        self.tr0_inout = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
-        self.trflx = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a")
-        self.tru = self.ntracers_quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a")
-        self.tru_emf = self.ntracers_quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a"
-        )
-        self.xflx_ndim = self.ntracers_quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a"
-        )
-        self.trflx_d = self.ntracers_quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a"
-        )
-        self.trflx_u = self.ntracers_quantity_factory.zeros(
-            [X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a"
-        )
+        self.trsrc = self.quantity_factory.zeros([X_DIM, Y_DIM, "ntracers"], "n/a")
+        self.trsrc_o = self.quantity_factory.zeros([X_DIM, Y_DIM, "ntracers"], "n/a")
+        self.tre = self.quantity_factory.zeros([X_DIM, Y_DIM, "ntracers"], "n/a")
+        self.trmin = self.quantity_factory.zeros([X_DIM, Y_DIM, "ntracers"], "n/a")
+        self.sstr0 = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
+        self.tr0 = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
+        self.tr0_o = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
+        self.sstr0_o = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
+        self.trten = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
+        self.tr0_s = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
+        self.tr0_inoutvar = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
+        self.tr0_inout = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM, "ntracers"], "n/a")
+        self.trflx = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a")
+        self.tru = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a")
+        self.tru_emf = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a")
+        self.xflx_ndim = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a")
+        self.trflx_d = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a")
+        self.trflx_u = self.quantity_factory.zeros([X_DIM, Y_DIM, Z_INTERFACE_DIM, "ntracers"], "n/a")
 
         self.saturation_vapor_pressure_table = get_saturation_vapor_pressure_table(
             self.stencil_factory.backend

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/aer_activation.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/aer_activation.py
@@ -1,5 +1,3 @@
-import copy
-
 from gt4py.cartesian.gtscript import PARALLEL, computation, exp, float64, interval, log, sqrt
 
 import pyMoist.constants as constants
@@ -326,28 +324,33 @@ class AerActivation:
             raise NotImplementedError("Non NN Aerosol not implemented")
 
         # Temporary buffers
-        nmodes_quantity_factory = AerActivation.make_nmodes_quantity_factory(quantity_factory)
-        self._nact = nmodes_quantity_factory.zeros(
+        quantity_factory.add_data_dimensions(
+            **{
+                "n_modes": constants.N_MODES,
+            }
+        )
+
+        self._nact = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM, "n_modes"],
             units="n/a",
             dtype=Float,
         )
-        self._ni = nmodes_quantity_factory.zeros(
+        self._ni = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM, "n_modes"],
             units="n/a",
             dtype=Float,
         )
-        self._rg = nmodes_quantity_factory.zeros(
+        self._rg = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM, "n_modes"],
             units="n/a",
             dtype=Float,
         )
-        self._sig0 = nmodes_quantity_factory.zeros(
+        self._sig0 = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM, "n_modes"],
             units="n/a",
             dtype=Float,
         )
-        self._bibar = nmodes_quantity_factory.zeros(
+        self._bibar = quantity_factory.zeros(
             [X_DIM, Y_DIM, Z_DIM, "n_modes"],
             units="n/a",
             dtype=Float,
@@ -358,16 +361,6 @@ class AerActivation:
             func=aer_activation_stencil,
             compute_dims=[X_DIM, Y_DIM, Z_DIM],
         )
-
-    @staticmethod
-    def make_nmodes_quantity_factory(ijk_quantity_factory: QuantityFactory):
-        nmodes_quantity_factory = copy.deepcopy(ijk_quantity_factory)
-        nmodes_quantity_factory.set_extra_dim_lengths(
-            **{
-                "n_modes": constants.N_MODES,
-            }
-        )
-        return nmodes_quantity_factory
 
     def __call__(
         self,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/memory_factory.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/memory_factory.py
@@ -8,7 +8,13 @@ from _cffi_backend import _CDataBase as CFFIObj
 from MAPLpyish import MAPLBridge, MAPLState
 
 from ndsl import QuantityFactory, ndsl_log
+from ndsl.dsl.gt4py_utils import is_gpu_backend
+from ndsl.optional_imports import cupy as cp
 from pyMoist.interface.f_py_conversion import FortranPythonConversion
+
+
+if cp is None:
+    cp = np
 
 
 class MAPLMemoryRepository:
@@ -32,11 +38,12 @@ class MAPLMemoryRepository:
         self._quantity_factory = quantity_factory
         self._state = state
         self._bridge = MAPLBridge()
+        self._quantity_factory.backend
         self._f_py_converter = FortranPythonConversion(
             self._quantity_factory.sizer.nx,
             self._quantity_factory.sizer.ny,
             self._quantity_factory.sizer.nz,
-            self._quantity_factory._numpy,
+            cp if is_gpu_backend(self._quantity_factory.backend) else np,
         )
         self._fortran_pointers: dict[str, MAPLMemoryRepository.FortranMemory] = {}
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/python_bridge.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/python_bridge.py
@@ -29,7 +29,6 @@ class PYMOIST_WRAPPER:
         self.rank = MPI.COMM_WORLD.Get_rank()
         self.backend = backend
         self.flags = moist_flags_f_to_python(pyMoist_flags)
-        print(f"Moist Flags:\n{self.flags}")
         # For Fortran<->NumPy conversion
         if is_gpu_backend(self.backend):
             numpy_module = cp

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
@@ -146,7 +146,6 @@ class GEOSPyMoistWrapper:
             ny_tile=self.flags.npy * self.flags.layout_y,
             nz=self.flags.npz,
             n_halo=0,
-            extra_dim_lengths={},
             layout=layout,
             tile_partitioner=partitioner.tile,
             tile_rank=self.communicator.tile.rank,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
@@ -195,7 +195,7 @@ class GEOSPyMoistWrapper:
             f"  Orchestration : {self._is_orchestrated}\n"
             f"          Sizer : {sizer.nx}x{sizer.ny}x{sizer.nz}"
             f"(halo: {sizer.n_halo})\n"
-            f" Strides for 3D : {tmp_quantity.data.strides}"
+            f" Strides for 3D : {tmp_quantity.data.strides // 8}\n"
             f"     Device ord : {device_ordinal_info}\n"
             f"     Nvidia MPS : {MPS_is_on}"
         )

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
@@ -152,7 +152,6 @@ class GEOSPyMoistWrapper:
             tile_rank=self.communicator.tile.rank,
         )
         self.quantity_factory = QuantityFactory.from_backend(sizer=sizer, backend=backend)
-        self.nmodes_quantity_factory = AerActivation.make_nmodes_quantity_factory(self.quantity_factory)
 
         self.stencil_config = StencilConfig(
             compilation_config=CompilationConfig(backend=backend, rebuild=False, validate_args=True),
@@ -262,14 +261,6 @@ class GEOSPyMoistWrapper:
                     USE_AERSOL_NN=True,
                 )
         return self._aer_activation
-
-    def make_nmmodes_quantity(self, data):
-        qty = self.nmodes_quantity_factory.empty(
-            [X_DIM, Y_DIM, Z_DIM, "n_modes"],
-            "n/a",
-        )
-        qty.field[:, :, :, :] = qty.np.asarray(data[:, :, :, :])
-        return qty
 
     def init_gfdl_1m_configuration(
         self,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
@@ -195,7 +195,7 @@ class GEOSPyMoistWrapper:
             f"  Orchestration : {self._is_orchestrated}\n"
             f"          Sizer : {sizer.nx}x{sizer.ny}x{sizer.nz}"
             f"(halo: {sizer.n_halo})\n"
-            f" Strides for 3D : {tmp_quantity.data.strides // 8}\n"
+            f" Strides for 3D : {[s // 8 for s in tmp_quantity.data.strides]}\n"
             f"     Device ord : {device_ordinal_info}\n"
             f"     Nvidia MPS : {MPS_is_on}"
         )

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
@@ -34,7 +34,7 @@ from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.dsl.dace.build import set_distributed_caches
 from ndsl.dsl.gt4py_utils import is_gpu_backend
 from ndsl.dsl.typing import get_precision
-from ndsl.logging import ndsl_log
+from ndsl.logging import ndsl_log, ndsl_log_on_rank_0
 from ndsl.optional_imports import cupy as cp
 from pyMoist.aer_activation import AerActivation
 from pyMoist.GFDL_1M.driver.driver import MicrophysicsDriver
@@ -185,18 +185,21 @@ class GEOSPyMoistWrapper:
             and is_gpu_backend(backend)
             and os.path.exists(f"{MPS_pipe_directory}/log")
         )
-        ndsl_log.info(
-            "pyMoist <> GEOS wrapper initialized: \n"
-            f"         bridge : {self._fortran_mem_space}"
+        tmp_quantity = self.quantity_factory.empty([X_DIM, Y_DIM, Z_DIM], units="")
+        ndsl_log_on_rank_0.info(
+            "pyMoist <> GEOS wrapper initialized (Rank 0): \n"
+            f"         Bridge : {self._fortran_mem_space}"
             f" > {self._pace_mem_space}\n"
-            f"        backend : {backend}\n"
-            f"          float : {get_precision()}bit\n"
-            f"  orchestration : {self._is_orchestrated}\n"
-            f"          sizer : {sizer.nx}x{sizer.ny}x{sizer.nz}"
+            f"        Backend : {backend}\n"
+            f"      Precision : {get_precision()}bit\n"
+            f"  Orchestration : {self._is_orchestrated}\n"
+            f"          Sizer : {sizer.nx}x{sizer.ny}x{sizer.nz}"
             f"(halo: {sizer.n_halo})\n"
+            f" Strides for 3D : {tmp_quantity.data.strides}"
             f"     Device ord : {device_ordinal_info}\n"
             f"     Nvidia MPS : {MPS_is_on}"
         )
+        del tmp_quantity
 
         # Timer result dict
         self._timings: dict[str, list[float]] = {}
@@ -429,165 +432,169 @@ class GEOSPyMoistWrapper:
         self._mapl_export.register("SC_SNR", np.float32, [X_DIM, Y_DIM], True)
 
     def GFDL_1M_Microphysics(self):
-        with MAPLManagedMemory(self._mapl_internal) as mapl_internal, MAPLManagedMemory(
-            self._mapl_import
-        ) as mapl_import, MAPLManagedMemory(self._mapl_export) as mapl_export:
-            # Pull the data from the linked Fortran memory
-            self._GFDL_1M_state.update_move_memory(
-                {
-                    "mixing_ratios": {
-                        "vapor": mapl_internal.Q,
-                        "rain": mapl_internal.QRAIN,
-                        "snow": mapl_internal.QSNOW,
-                        "graupel": mapl_internal.QGRAUPEL,
-                        "convective_liquid": mapl_internal.QLCN,
-                        "convective_ice": mapl_internal.QICN,
-                        "large_scale_liquid": mapl_internal.QLLS,
-                        "large_scale_ice": mapl_internal.QILS,
-                    },
-                    "cloud_fractions": {
-                        "convective": mapl_internal.CLCN,
-                        "large_scale": mapl_internal.CLLS,
-                    },
-                    "vertical_motion": {
-                        "velocity": mapl_import.W,
-                        "variance": mapl_import.W2,
-                        "third_moment": mapl_import.W3,
-                    },
-                },
-                # We follow fortran strides and because we do this consistently it doesn't break orchestration
-                check_shape_and_strides=False,
-            )
+        with MAPLManagedMemory(self._mapl_internal) as mapl_internal:
+            with MAPLManagedMemory(self._mapl_import) as mapl_import:
+                with MAPLManagedMemory(self._mapl_export) as mapl_export:
+                    # Pull the data from the linked Fortran memory
+                    self._GFDL_1M_state.update_move_memory(
+                        {
+                            "mixing_ratios": {
+                                "vapor": mapl_internal.Q,
+                                "rain": mapl_internal.QRAIN,
+                                "snow": mapl_internal.QSNOW,
+                                "graupel": mapl_internal.QGRAUPEL,
+                                "convective_liquid": mapl_internal.QLCN,
+                                "convective_ice": mapl_internal.QICN,
+                                "large_scale_liquid": mapl_internal.QLLS,
+                                "large_scale_ice": mapl_internal.QILS,
+                            },
+                            "cloud_fractions": {
+                                "convective": mapl_internal.CLCN,
+                                "large_scale": mapl_internal.CLLS,
+                            },
+                            "vertical_motion": {
+                                "velocity": mapl_import.W,
+                                "variance": mapl_import.W2,
+                                "third_moment": mapl_import.W3,
+                            },
+                        },
+                        # We follow fortran strides and because we do this consistently
+                        # it doesn't break orchestration
+                        check_shape_and_strides=False,
+                    )
 
-            # Diagnostic for un-tested code
-            #
-            # liquid_water_static_energy = LiquidWaterStaticEnergy(
-            #     flux=mapl_import.WSL,
-            #     variance=mapl_import.SL2,
-            #     third_moment=mapl_import.SL3,
-            # )
-            # total_water = TotalWater(
-            #     flux=mapl_import.WQT,
-            #     variance=mapl_import.QT2,
-            #     third_moment=mapl_import.QT3,
-            # )
+                    # Diagnostic for un-tested code
+                    #
+                    # liquid_water_static_energy = LiquidWaterStaticEnergy(
+                    #     flux=mapl_import.WSL,
+                    #     variance=mapl_import.SL2,
+                    #     third_moment=mapl_import.SL3,
+                    # )
+                    # total_water = TotalWater(
+                    #     flux=mapl_import.WQT,
+                    #     variance=mapl_import.QT2,
+                    #     third_moment=mapl_import.QT3,
+                    # )
 
-            if mapl_export.associated("SHLW_PRC3"):
-                shallow_convective_rain = mapl_export.SHLW_PRC3
-            else:
-                shallow_convective_rain = None
-            if mapl_export.associated("SHLW_SNO3"):
-                shallow_convective_snow = mapl_export.SHLW_SNO3
-            else:
-                shallow_convective_rain = None
-            if mapl_export.associated("RHCRIT"):
-                rh_crit = mapl_export.RHCRIT
-            else:
-                rh_crit = None
+                    if mapl_export.associated("SHLW_PRC3"):
+                        shallow_convective_rain = mapl_export.SHLW_PRC3
+                    else:
+                        shallow_convective_rain = None
+                    if mapl_export.associated("SHLW_SNO3"):
+                        shallow_convective_snow = mapl_export.SHLW_SNO3
+                    else:
+                        shallow_convective_rain = None
+                    if mapl_export.associated("RHCRIT"):
+                        rh_crit = mapl_export.RHCRIT
+                    else:
+                        rh_crit = None
 
-            # Outputs: model fields originating from within GFDL
-            self._GFDL_1M_outputs.update_move_memory(
-                {
-                    "liquid_radius": mapl_export.RL,
-                    "ice_radius": mapl_export.RI,
-                    "precipitated_rain": mapl_export.PRCP_RAIN,
-                    "precipitated_snow": mapl_export.PRCP_SNOW,
-                    "precipitated_ice": mapl_export.PRCP_ICE,
-                    "precipitated_graupel": mapl_export.PRCP_GRAUPEL,
-                    "radiation_cloud_fraction": mapl_export.FCLD,
-                    "radiation_vapor": mapl_export.QV,
-                    "radiation_liquid": mapl_export.QL,
-                    "radiation_ice": mapl_export.QI,
-                    "radiation_rain": mapl_export.QR,
-                    "radiation_snow": mapl_export.QS,
-                    "radiation_graupel": mapl_export.QG,
-                    "lower_tropospheric_stability": mapl_export.LTS,
-                    "estimated_inversion_strength": mapl_export.EIS,
-                    "z_lcl": (mapl_export.ZLCL if mapl_export.associated("ZLCL") else None),
-                    "du_dt_macro": mapl_export.DUDT_macro,
-                    "dv_dt_macro": mapl_export.DVDT_macro,
-                    "dt_dt_macro": mapl_export.DTDT_macro,
-                    "dvapor_dt_macro": mapl_export.DQVDT_macro,
-                    "dliquid_dt_macro": mapl_export.DQLDT_macro,
-                    "dice_dt_macro": mapl_export.DQIDT_macro,
-                    "dcloud_fraction_dt_macro": mapl_export.DQADT_macro,
-                    "drain_dt_macro": mapl_export.DQRDT_macro,
-                    "dsnow_dt_macro": mapl_export.DQSDT_macro,
-                    "dgraupel_dt_macro": mapl_export.DQGDT_macro,
-                    "du_dt_micro": mapl_export.DUDT_micro,
-                    "dv_dt_micro": mapl_export.DVDT_micro,
-                    "dt_dt_micro": mapl_export.DTDT_micro,
-                    "dvapor_dt_micro": mapl_export.DQVDT_micro,
-                    "dliquid_dt_micro": mapl_export.DQLDT_micro,
-                    "dice_dt_micro": mapl_export.DQIDT_micro,
-                    "dcloud_fraction_dt_micro": mapl_export.DQADT_micro,
-                    "drain_dt_micro": mapl_export.DQRDT_micro,
-                    "dsnow_dt_micro": mapl_export.DQSDT_micro,
-                    "dgraupel_dt_micro": mapl_export.DQGDT_micro,
-                    "large_scale_precip": mapl_export.LS_PRCP,
-                    "large_scale_snow": mapl_export.LS_SNR,
-                    "icefall": mapl_export.ICE,
-                    "freezing_rainfall": mapl_export.FRZR,
-                    "relative_humidity_after_pdf": mapl_export.RHX,
-                    "large_scale_nonanvil_precipitation_evaporation": mapl_export.REV_LS,
-                    "large_scale_nonanvil_precipitation_sublimation": mapl_export.RSU_LS,
-                    # PFL_* are 0-72 in the fortran, but index 0 is always 0
-                    "large_scale_nonanvil_liquid_flux": mapl_export.PFL_LS[:, :, 1:],
-                    "large_scale_nonanvil_ice_flux": mapl_export.PFI_LS[:, :, 1:],
-                    "anvil_liquid_flux": mapl_export.PFL_AN[:, :, 1:],
-                    "anvil_ice_flux": mapl_export.PFI_AN[:, :, 1:],
-                    "large_scale_rainwater_source": mapl_export.DQRL
-                    if mapl_export.associated("DQRL")
-                    else None,
-                    "moist_friction_temperature_tendency": mapl_export.DTDTFRIC
-                    if mapl_export.associated("DTDTFRIC")
-                    else None,
-                    "simulated_reflectivity": mapl_export.DBZ if mapl_export.associated("DBZ") else None,
-                    "maximum_reflectivity": mapl_export.DBZ_MAX
-                    if mapl_export.associated("DBZ_MAX")
-                    else None,
-                    "one_km_agl_reflectivity": mapl_export.DBZ_1KM
-                    if mapl_export.associated("DBZ_1KM")
-                    else None,
-                    "echo_top_reflectivity": mapl_export.DBZ_TOP
-                    if mapl_export.associated("DBZ_TOP")
-                    else None,
-                    "minus_10c_reflectivity": mapl_export.DBZ_M10C
-                    if mapl_export.associated("DBZ_M10C")
-                    else None,
-                    "deep_convective_precipitation": mapl_export.CN_PRCP,
-                    "anvil_precipitation": mapl_export.AN_PRCP,
-                    "shallow_convective_precipitation": mapl_export.SC_PRCP,
-                    "deep_convective_snow": mapl_export.CN_SNR,
-                    "anvil_snow": mapl_export.AN_SNR,
-                    "shallow_convective_snow": mapl_export.SC_SNR,
-                },
-                # We follow fortran strides and because we do this consistently it doesn't break orchestration
-                check_shape_and_strides=False,
-            )
+                    # Outputs: model fields originating from within GFDL
+                    self._GFDL_1M_outputs.update_move_memory(
+                        {
+                            "liquid_radius": mapl_export.RL,
+                            "ice_radius": mapl_export.RI,
+                            "precipitated_rain": mapl_export.PRCP_RAIN,
+                            "precipitated_snow": mapl_export.PRCP_SNOW,
+                            "precipitated_ice": mapl_export.PRCP_ICE,
+                            "precipitated_graupel": mapl_export.PRCP_GRAUPEL,
+                            "radiation_cloud_fraction": mapl_export.FCLD,
+                            "radiation_vapor": mapl_export.QV,
+                            "radiation_liquid": mapl_export.QL,
+                            "radiation_ice": mapl_export.QI,
+                            "radiation_rain": mapl_export.QR,
+                            "radiation_snow": mapl_export.QS,
+                            "radiation_graupel": mapl_export.QG,
+                            "lower_tropospheric_stability": mapl_export.LTS,
+                            "estimated_inversion_strength": mapl_export.EIS,
+                            "z_lcl": (mapl_export.ZLCL if mapl_export.associated("ZLCL") else None),
+                            "du_dt_macro": mapl_export.DUDT_macro,
+                            "dv_dt_macro": mapl_export.DVDT_macro,
+                            "dt_dt_macro": mapl_export.DTDT_macro,
+                            "dvapor_dt_macro": mapl_export.DQVDT_macro,
+                            "dliquid_dt_macro": mapl_export.DQLDT_macro,
+                            "dice_dt_macro": mapl_export.DQIDT_macro,
+                            "dcloud_fraction_dt_macro": mapl_export.DQADT_macro,
+                            "drain_dt_macro": mapl_export.DQRDT_macro,
+                            "dsnow_dt_macro": mapl_export.DQSDT_macro,
+                            "dgraupel_dt_macro": mapl_export.DQGDT_macro,
+                            "du_dt_micro": mapl_export.DUDT_micro,
+                            "dv_dt_micro": mapl_export.DVDT_micro,
+                            "dt_dt_micro": mapl_export.DTDT_micro,
+                            "dvapor_dt_micro": mapl_export.DQVDT_micro,
+                            "dliquid_dt_micro": mapl_export.DQLDT_micro,
+                            "dice_dt_micro": mapl_export.DQIDT_micro,
+                            "dcloud_fraction_dt_micro": mapl_export.DQADT_micro,
+                            "drain_dt_micro": mapl_export.DQRDT_micro,
+                            "dsnow_dt_micro": mapl_export.DQSDT_micro,
+                            "dgraupel_dt_micro": mapl_export.DQGDT_micro,
+                            "large_scale_precip": mapl_export.LS_PRCP,
+                            "large_scale_snow": mapl_export.LS_SNR,
+                            "icefall": mapl_export.ICE,
+                            "freezing_rainfall": mapl_export.FRZR,
+                            "relative_humidity_after_pdf": mapl_export.RHX,
+                            "large_scale_nonanvil_precipitation_evaporation": mapl_export.REV_LS,
+                            "large_scale_nonanvil_precipitation_sublimation": mapl_export.RSU_LS,
+                            # PFL_* are 0-72 in the fortran, but index 0 is always 0
+                            "large_scale_nonanvil_liquid_flux": mapl_export.PFL_LS[:, :, 1:],
+                            "large_scale_nonanvil_ice_flux": mapl_export.PFI_LS[:, :, 1:],
+                            "anvil_liquid_flux": mapl_export.PFL_AN[:, :, 1:],
+                            "anvil_ice_flux": mapl_export.PFI_AN[:, :, 1:],
+                            "large_scale_rainwater_source": mapl_export.DQRL
+                            if mapl_export.associated("DQRL")
+                            else None,
+                            "moist_friction_temperature_tendency": mapl_export.DTDTFRIC
+                            if mapl_export.associated("DTDTFRIC")
+                            else None,
+                            "simulated_reflectivity": mapl_export.DBZ
+                            if mapl_export.associated("DBZ")
+                            else None,
+                            "maximum_reflectivity": mapl_export.DBZ_MAX
+                            if mapl_export.associated("DBZ_MAX")
+                            else None,
+                            "one_km_agl_reflectivity": mapl_export.DBZ_1KM
+                            if mapl_export.associated("DBZ_1KM")
+                            else None,
+                            "echo_top_reflectivity": mapl_export.DBZ_TOP
+                            if mapl_export.associated("DBZ_TOP")
+                            else None,
+                            "minus_10c_reflectivity": mapl_export.DBZ_M10C
+                            if mapl_export.associated("DBZ_M10C")
+                            else None,
+                            "deep_convective_precipitation": mapl_export.CN_PRCP,
+                            "anvil_precipitation": mapl_export.AN_PRCP,
+                            "shallow_convective_precipitation": mapl_export.SC_PRCP,
+                            "deep_convective_snow": mapl_export.CN_SNR,
+                            "anvil_snow": mapl_export.AN_SNR,
+                            "shallow_convective_snow": mapl_export.SC_SNR,
+                        },
+                        # We follow fortran strides and because we do this consistently
+                        # it doesn't break orchestration
+                        check_shape_and_strides=False,
+                    )
 
-            # Call the module
-            with TimedCUDAProfiler("GFDL 1M", self._timings):
-                self.gfdl_1m(
-                    geopotential_height_interface=mapl_import.ZLE,
-                    p_interface=mapl_import.PLE,
-                    t=mapl_import.T,
-                    u=mapl_import.U,
-                    v=mapl_import.V,
-                    shallow_convective_rain=shallow_convective_rain,
-                    shallow_convective_snow=shallow_convective_snow,
-                    state=self._GFDL_1M_state,
-                    outputs=self._GFDL_1M_outputs,
-                    area=mapl_import.AREA,
-                    convection_fraction=mapl_export.CNV_FRC,
-                    surface_type=mapl_export.SRF_TYPE,
-                    liquid_concentration=mapl_internal.NACTL,
-                    ice_concentration=mapl_internal.NACTI,
-                    land_fraction=mapl_import.FRLAND,
-                    rh_crit=rh_crit,
-                    evapc=mapl_export.EVAPC,
-                    sublc=mapl_export.SUBLC,
-                )
+                    # Call the module
+                    with TimedCUDAProfiler("GFDL 1M", self._timings):
+                        self.gfdl_1m(
+                            geopotential_height_interface=mapl_import.ZLE,
+                            p_interface=mapl_import.PLE,
+                            t=mapl_import.T,
+                            u=mapl_import.U,
+                            v=mapl_import.V,
+                            shallow_convective_rain=shallow_convective_rain,
+                            shallow_convective_snow=shallow_convective_snow,
+                            state=self._GFDL_1M_state,
+                            outputs=self._GFDL_1M_outputs,
+                            area=mapl_import.AREA,
+                            convection_fraction=mapl_export.CNV_FRC,
+                            surface_type=mapl_export.SRF_TYPE,
+                            liquid_concentration=mapl_internal.NACTL,
+                            ice_concentration=mapl_internal.NACTI,
+                            land_fraction=mapl_import.FRLAND,
+                            rh_crit=rh_crit,
+                            evapc=mapl_export.EVAPC,
+                            sublc=mapl_export.SUBLC,
+                        )
 
     @property
     def UW_shallow_convection(self) -> Callable:

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/saturation_tables/tables/main.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/saturation_tables/tables/main.py
@@ -150,11 +150,6 @@ class SaturationVaporPressureTable:
         self._estimated_esw = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], "n/a")
         self._estimated_esx = quantity_factory.zeros([X_DIM, Y_DIM, Z_DIM], "n/a")
 
-        compute_tables = stencil_factory.from_dims_halo(
-            func=_compute_tables,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
-        )
-
         NDSL_tables = False
         # NOTE Setting NDSL_tables to True will the tables using gt4py stencils and functions.
         # This is turned off because they do not currently verify.
@@ -163,6 +158,10 @@ class SaturationVaporPressureTable:
         #       get forced to the same precision
 
         if NDSL_tables:
+            compute_tables = stencil_factory.from_dims_halo(
+                func=_compute_tables,
+                compute_dims=[X_DIM, Y_DIM, Z_DIM],
+            )
             compute_tables(
                 self._estimated_ese,
                 self._estimated_esw,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/setup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/setup.py
@@ -10,7 +10,7 @@ with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 test_requirements = ["pytest", "pytest-subtests", "serialbox", "coverage"]
-ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2024.04.00"]
+ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2025.10.00"]
 develop_requirements = test_requirements + ndsl_requirements + ["pre-commit"]
 
 extras_requires = {

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_bergeron_partition.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_bergeron_partition.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import PARALLEL, computation, interval
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_evaporate.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_evaporate.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_hydrostatic_pdf.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_hydrostatic_pdf.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_melt_freeze.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_melt_freeze.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_phase_change.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_phase_change.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_sublimate.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/PhaseChange/translate_GFDL_1M_sublimate.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_driver.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_driver.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_driver_finish.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_driver_finish.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_driver_setup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_driver_setup.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_fall_speed.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_fall_speed.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_ice_cloud.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_ice_cloud.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_terminal_fall.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_terminal_fall.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py
@@ -187,6 +189,6 @@ class TranslateGFDL_1M_terminal_fall(TranslateFortranData2Py):
             zt=temporaries.zt,
             is_frozen=masks.is_frozen,
             precip_fall=masks.precip_fall,
-            **inputs
+            **inputs,
         )
         return inputs

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_warm_rain.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_warm_rain.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_driver_tables.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_driver_tables.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.translate import TranslateFortranData2Py
 from pyMoist.GFDL_1M.driver.sat_tables import get_tables
 
@@ -26,7 +28,6 @@ class TranslateGFDL_driver_tables(TranslateFortranData2Py):
         }
 
     def compute(self, inputs):
-
         self.sat_tables = get_tables(self.stencil_factory.backend)
 
         return {

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, Quantity, StencilFactory
+from f90nml import Namelist
+
+from ndsl import Quantity, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_finalize.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_finalize.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, Quantity, StencilFactory
+from f90nml import Namelist
+
+from ndsl import Quantity, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_radiation_coupling.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_radiation_coupling.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, Quantity, StencilFactory
+from f90nml import Namelist
+
+from ndsl import Quantity, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_redistribute_clouds.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_redistribute_clouds.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, Quantity, StencilFactory
+from f90nml import Namelist
+
+from ndsl import Quantity, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_setup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_setup.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, Quantity, StencilFactory
+from f90nml import Namelist
+
+from ndsl import Quantity, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/saturation_tables/translate_qsat_functions.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/saturation_tables/translate_qsat_functions.py
@@ -1,6 +1,8 @@
 from typing import Any
 
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.boilerplate import get_factories_single_tile
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.gt4py import FORWARD, PARALLEL, computation, interval

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/saturation_tables/translate_saturation_tables.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/saturation_tables/translate_saturation_tables.py
@@ -1,6 +1,8 @@
 from typing import Any
 
-from ndsl import Namelist, StencilFactory
+from f90nml import Namelist
+
+from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py
 from pyMoist.saturation_tables.formulation import SaturationFormulation

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/translate_aer_activation.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/translate_aer_activation.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, Quantity, StencilFactory
+from f90nml import Namelist
+
+from ndsl import Quantity, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.dsl.typing import Float
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/translate_compute_uwshcu.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/translate_compute_uwshcu.py
@@ -1,4 +1,6 @@
-from ndsl import Namelist, Quantity, QuantityFactory, StencilFactory
+from f90nml import Namelist
+
+from ndsl import Quantity, QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
 from ndsl.dsl.typing import Float, FloatField, Int
 from ndsl.stencils.testing.translate import TranslateFortranData2Py


### PR DESCRIPTION
- Update various API call that are now removed or deprecated
- Use `f90nml` instead of `ndsl` for `Namelist` type
- Fix multi-rank compile of `SaturationTables` (one rank compiles, all other waits)

_Note: the code is updated for a NDSL >2025.10.00 to take into account the future deprecation on the next release_