### PR TITLE
[NDSL] [`CI/pyMoist`] Numerical regression on github.action

### DIFF
--- a/.github/workflows/ndsl-checks.yml
+++ b/.github/workflows/ndsl-checks.yml
@@ -12,6 +12,9 @@ concurrency:
 
 jobs:
   setup:
+    env:
+      DATA_PATH: ./test_data/11.5.2/TBC_C24_L72/moist
+      DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/geos-fp/translate/11.5.2/x86_GNU/Moist/TBC_C24L72.tar.gz"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout NDSL
@@ -39,30 +42,16 @@ jobs:
           pip install -e .[develop]
           cd ${{ github.workspace }}/GCMGridComp
           pip install -e ./GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
-    
-  lint:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-        - name: Run lint via pre-commit
-          run: |
-            cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
-            pre-commit run --all-files
-  
-  translate_test:
-    runs-on: ubuntu-latest
-    needs: setup
-    env:
-      DATA_PATH: ./test_data/11.5.2/TBC_C24_L72/moist
-      DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/geos-fp/translate/11.5.2/x86_GNU/Moist/TBC_C24L72.tar.gz"
-    steps:
+      - name: Run lint via pre-commit
+        run: |
+          cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+          pre-commit run --all-files
       - name: Download test_data (if not cached)
         run: |
           cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
           mkdir -p ./test_data  && cd ./test_data
           wget ${{ env.DATA_URL }}
           tar -xzvf TBC_C24L72.tar.gz
-
       - name: Run all tests
         run: |
           cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/

--- a/.github/workflows/ndsl-checks.yml
+++ b/.github/workflows/ndsl-checks.yml
@@ -19,12 +19,12 @@ jobs:
         with:
           repository: NOAA-GFDL/NDSL
           submodules: 'recursive'
-          path: '${GITHUB_WORKSPACE}/ndsl'
+          path: '${{ github.workspace }}/ndsl'
       - name: Checkout repository
         uses: actions/checkout@master
         with:
           submodules: 'recursive'
-          path: '${GITHUB_WORKSPACE}/GCMGridComp'
+          path: '${{ github.workspace }}/GCMGridComp'
       - name: Step Python 3.11.9
         uses: actions/setup-python@v4.6.0
         with:
@@ -35,9 +35,9 @@ jobs:
       - name: Install Python packages
         run: |
           python -m pip install --upgrade pip setuptools wheel pre-commit
-          cd ${GITHUB_WORKSPACE}/ndsl
+          cd ${{ github.workspace }}/ndsl
           pip install -e .[develop]
-          cd ${${GITHUB_WORKSPACE}}/GCMGridComp
+          cd ${{ github.workspace }}/GCMGridComp
           pip install -e ./GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
     
   lint:
@@ -46,7 +46,7 @@ jobs:
     steps:
         - name: Run lint via pre-commit
           run: |
-            cd ${GITHUB_WORKSPACE}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+            cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
             pre-commit run --all-files
   
   translate_test:
@@ -58,12 +58,12 @@ jobs:
     steps:
       - name: Download test_data (if not cached)
         run: |
-          cd ${GITHUB_WORKSPACE}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+          cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
           mkdir -p ./test_data  && cd ./test_data
           wget ${{ env.DATA_URL }}
           tar -xzvf TBC_C24L72.tar.gz
 
       - name: Run all tests
         run: |
-          cd ${GITHUB_WORKSPACE}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/
+          cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/
           ./run_all.sh

--- a/.github/workflows/ndsl-checks.yml
+++ b/.github/workflows/ndsl-checks.yml
@@ -5,35 +5,65 @@ on:
     branches: [ dsl/develop ]
   workflow_dispatch:
 
+# cancel running jobs if theres a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  lint:
+  setup:
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout NDSL
-          uses: actions/checkout@master
-          with:
-            repository: NOAA-GFDL/NDSL
-            submodules: 'recursive'
-            path: 'ndsl'
-        - name: Checkout repository
-          uses: actions/checkout@master
-          with:
-            submodules: 'recursive'
-            path: 'GCMGridComp'
-        - name: Step Python 3.11.9
-          uses: actions/setup-python@v4.6.0
-          with:
-            python-version: '3.11.9'
-        - name: Install OpenMPI for gt4py
-          run: |
-            sudo apt-get install libopenmpi-dev
-        - name: Install Python packages
-          run: |
-            python -m pip install --upgrade pip setuptools wheel pre-commit
-            cd ndsl
-            pip install -e .[develop]
-            pip install -e ../GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+      - name: Checkout NDSL
+        uses: actions/checkout@master
+        with:
+          repository: NOAA-GFDL/NDSL
+          submodules: 'recursive'
+          path: '${GITHUB_WORKSPACE}/ndsl'
+      - name: Checkout repository
+        uses: actions/checkout@master
+        with:
+          submodules: 'recursive'
+          path: '${GITHUB_WORKSPACE}/GCMGridComp'
+      - name: Step Python 3.11.9
+        uses: actions/setup-python@v4.6.0
+        with:
+          python-version: '3.11.9'
+      - name: Install OpenMPI for gt4py
+        run: |
+          sudo apt-get install libopenmpi-dev
+      - name: Install Python packages
+        run: |
+          python -m pip install --upgrade pip setuptools wheel pre-commit
+          cd ${GITHUB_WORKSPACE}/ndsl
+          pip install -e .[develop]
+          cd ${${GITHUB_WORKSPACE}}/GCMGridComp
+          pip install -e ./GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+    
+  lint:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
         - name: Run lint via pre-commit
           run: |
-            cd ./GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+            cd ${GITHUB_WORKSPACE}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
             pre-commit run --all-files
+  
+  translate_test:
+    runs-on: ubuntu-latest
+    needs: setup
+    env:
+      DATA_PATH: ./test_data/11.5.2/TBC_C24_L72/moist
+      DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/geos-fp/translate/11.5.2/x86_GNU/Moist/TBC_C24L72.tar.gz"
+    steps:
+      - name: Download test_data (if not cached)
+        run: |
+          cd ${GITHUB_WORKSPACE}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+          mkdir -p ./test_data  && cd ./test_data
+          wget ${{ env.DATA_URL }}
+          tar -xzvf TBC_C24L72.tar.gz
+
+      - name: Run all tests
+        run: |
+          cd ${GITHUB_WORKSPACE}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/
+          ./run_all.sh

--- a/.github/workflows/ndsl-checks.yml
+++ b/.github/workflows/ndsl-checks.yml
@@ -55,4 +55,4 @@ jobs:
       - name: Run all tests
         run: |
           cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/
-          ./run_all.sh ${{ env.DATA_PATH }} dace:cpu_kfirst
+          ./run_all.sh ../../${{ env.DATA_PATH }} dace:cpu_kfirst

--- a/.github/workflows/ndsl-checks.yml
+++ b/.github/workflows/ndsl-checks.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Download test_data (if not cached)
         run: |
           cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
-          mkdir -p ./test_data  && cd ./test_data
+          mkdir -p ${{ env.DATA_PATH }} && cd ${{ env.DATA_PATH }}
           wget ${{ env.DATA_URL }}
           tar -xzvf TBC_C24L72.tar.gz
       - name: Run all tests
         run: |
           cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/
-          ./run_all.sh
+          ./run_all.sh ${{ env.DATA_PATH }} dace:cpu_kfirst

--- a/.github/workflows/ndsl-checks.yml
+++ b/.github/workflows/ndsl-checks.yml
@@ -1,4 +1,4 @@
-name: NDSL checks
+name: NDSL Lint & Translate Tests
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
+  main:
     env:
       DATA_PATH: ./test_data/11.5.2/TBC_C24_L72/moist
       DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/geos-fp/translate/11.5.2/x86_GNU/Moist/TBC_C24L72.tar.gz"

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/setup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/setup.py
@@ -10,7 +10,7 @@ with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 test_requirements = ["pytest", "pytest-subtests", "serialbox", "coverage"]
-ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2025.10.00"]
+ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
 develop_requirements = test_requirements + ndsl_requirements + ["pre-commit"]
 
 extras_requires = {

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/__init__.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/__init__.py
@@ -20,3 +20,29 @@ from .saturation_tables.translate_qsat_functions import Translateqsat_functions
 from .saturation_tables.translate_saturation_tables import Translatesaturation_tables
 from .translate_aer_activation import TranslateAerActivation
 from .translate_compute_uwshcu import TranslateComputeUwshcuInv
+
+
+__all__ = [
+    "TranslateGFDL_1M_driver",
+    "TranslateGFDL_1M_driver_finish",
+    "TranslateGFDL_1M_driver_setup",
+    "TranslateGFDL_1M_fall_speed",
+    "TranslateGFDL_1M_ice_cloud",
+    "TranslateGFDL_1M_terminal_fall",
+    "TranslateGFDL_1M_warm_rain",
+    "TranslateGFDL_driver_tables",
+    "TranslateGFDL_1M_bergeron_partition",
+    "TranslateGFDL_1M_evaporate",
+    "TranslateGFDL_1M_hydrostatic_pdf",
+    "TranslateGFDL_1M_melt_freeze",
+    "TranslateGFDL_1M_phase_change",
+    "TranslateGFDL_1M_sublimate",
+    "TranslateGFDL_1M_finalize",
+    "TranslateGFDL_1M_radiation_coupling",
+    "TranslateGFDL_1M_redistribute_clouds",
+    "TranslateGFDL_1M_setup",
+    "Translateqsat_functions",
+    "Translatesaturation_tables",
+    "TranslateAerActivation",
+    "TranslateComputeUwshcuInv",
+]

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/overrides.yml
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/overrides.yml
@@ -4,3 +4,13 @@ ComputeUwshcuInv:
       absolute_epsilon: 1.00e-08
       relative_fraction: 1.00e-04
       ulp_threshold: 1700.0
+
+GFDL_1M_sublimate:
+  - backend: dace:cpu_kfirst
+    multimodal:
+      ulp_threshold: 32
+
+GFDL_1M_hydrostatic_pdf:
+  - backend: dace:cpu_kfirst
+    multimodal:
+      ulp_threshold: 250

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/run_all.sh
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/run_all.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 
-# Usage: ./run_tests.sh [/path/to/data] [debug|dace:cpu_kfirst] [TranslateName]
+# Usage: ./run_tests.sh [/path/to/data] [debug|dace:cpu_kfirst]
 
 export NDSL_LITERAL_PRECISION=32
 export NDSL_TEST_N_THRESHOLD_SAMPLES=0
 export GT4PY_COMPILE_OPT_LEVEL=0
 export FV3_DACEMODE=Python
+export NDSL_LOGLEVEL=Critical
 
 # UW specific
 export GT4PY_EXTRA_COMPILE_OPT_FLAGS='-fconstexpr-ops-limit=1000000000'
 
-python -m pytest -s -v --disable-warnings --multimodal_metric \
-    -x \
+python -m pytest -s --disable-warnings --multimodal_metric \
+    -x -v \
     --data_path=$1 \
     --backend=$2\
-    --which_modules=$3 \
     --grid=default \
     --no_report \
     --threshold_overrides_file=./overrides.yml \
     ..
-
+    

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/run_all.sh
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/run_all.sh
@@ -19,4 +19,3 @@ python -m pytest -s --disable-warnings --multimodal_metric \
     --no_report \
     --threshold_overrides_file=./overrides.yml \
     ..
-    

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/run_all.sh
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/run_all.sh
@@ -12,7 +12,7 @@ export NDSL_LOGLEVEL=Critical
 export GT4PY_EXTRA_COMPILE_OPT_FLAGS='-fconstexpr-ops-limit=1000000000'
 
 python -m pytest -s --disable-warnings --multimodal_metric \
-    -x -v \
+    -x \
     --data_path=$1 \
     --backend=$2\
     --grid=default \

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/run_tests.sh
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/run_tests.sh
@@ -19,4 +19,3 @@ python -m pytest -s -v --disable-warnings --multimodal_metric \
     --no_report \
     --threshold_overrides_file=./overrides.yml \
     ..
-


### PR DESCRIPTION
Turn on selected numerical regression (translate test in NDSL lingo) on the GitHub action. This should not run over the "free" tier of actions based on other code usage in other repositories (pyFV3, pySHiELD).

This PR:
- tweaks the `ndsl_checks` github action run
- clean up `overrides` for working translate test with `ndsl==2025.10.00`
- add new `run_all.sh` scripts to ease workflow for the `ci`