### PR TITLE
[NDSL | GFDL1M] Interface performance engineering

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/sat_tables.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/sat_tables.py
@@ -168,7 +168,7 @@ def des_tables(
     table3: FloatField,
     table4: FloatField,
 ):
-    with computation(FORWARD), interval(...):
+    with computation(FORWARD), interval(0, -1):
         des1 = max(0.0, table1[0, 0, 1] - table1)
         des2 = max(0.0, table2[0, 0, 1] - table2)
         des3 = max(0.0, table3[0, 0, 1] - table3)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/setup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/setup.py
@@ -51,8 +51,6 @@ def calculate_derived_states(
     """
     Computes derived state fields required for the rest of the GFDL single moment
     microphysics module.
-
-    This stencil MUST be built using Z_INTERFACE_DIM to function properly.
     """
     from __externals__ import k_end
 
@@ -377,7 +375,6 @@ class GFDL1MSetup(NDSLRuntime):
             dsnow_dt=dsnowdt_macro,
             dgraupel_dt=dgraupeldt_macro,
         )
-
         self._calculate_derived_states(
             p_interface=p_interface,
             p_interface_mb=local_p_interface_mb,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/f_py_conversion.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/f_py_conversion.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from math import prod
 from types import ModuleType
-from typing import List, Optional, Tuple, TypeAlias
+from typing import Tuple, TypeAlias
 
 import cffi
 import numpy as np
@@ -11,7 +11,8 @@ from _cffi_backend import _CDataBase as CFFIObj
 
 from ndsl.dsl.typing import Float
 from ndsl.optional_imports import cupy as cp
-
+import numpy.lib as npl
+from functools import lru_cache
 
 # Dev note: we would like to use cp.ndarray for Device and
 # Union of np and cp ndarray for Python but we can't
@@ -34,9 +35,19 @@ class NullStream:
         pass
 
 
+@lru_cache
+def _compute_fortran_strides(shape: Tuple[int, ...], dtype: npt.DTypeLike) -> tuple[int, ...]:
+    cshp = np.cumprod(shape)
+    return np.concatenate(([1], cshp[:-1])) * np.dtype(dtype).itemsize
+
+
 class FortranPythonConversion:
     """
-    Convert Fortran arrays to NumPy and vice-versa
+    Convert Fortran arrays to NumPy and vice-versa.
+
+    The python memory will be laid out Fortran-like,
+        e.g. column-order,
+        e.g. 3D strides will be [1, dim0, dim0*dim1].
     """
 
     def __init__(
@@ -81,88 +92,67 @@ class FortranPythonConversion:
     def _fortran_to_numpy(
         self,
         fptr: cffi.FFI.CData,
-        dim: Optional[List[int]] = None,
+        dims: list[int] | None,
     ) -> np.ndarray:
         """
         Input: Fortran data pointed to by fptr and of shape dim = (i, j, k)
-        Output: C-ordered double precision NumPy data of shape (i, j, k)
+        Output: F-ordered NumPy data of shape (i, j, k) - strides are the same as input
         """
-        if not dim:
-            dim = [self._npx, self._npy, self._npz]
+        if not dims:
+            dims = [self._npx, self._npy, self._npz]
         ftype = self._ffi.getctype(self._ffi.typeof(fptr).item)
         if ftype not in self._TYPEMAP:
             raise ValueError(f"Fortran Python memory converter: cannot convert type {ftype}")
         return np.frombuffer(
-            self._ffi.buffer(fptr, prod(dim) * self._ffi.sizeof(ftype)),
+            self._ffi.buffer(fptr, prod(dims) * self._ffi.sizeof(ftype)),
             self._TYPEMAP[ftype],
         )
 
     def _upload_and_transform(
         self,
         host_array: np.ndarray,
-        dim: Optional[List[int]] = None,
-        swap_axes: Optional[Tuple[int, int]] = None,
+        dims: list[int] | None,
     ) -> DeviceArray:
         """Upload to device & transform to Pace compatible layout"""
         device_array = cp.asarray(host_array)
-        final_array = self._transform_from_fortran_layout(
-            device_array,
-            dim,
-            swap_axes,
-        )
+        final_array = self._transform_from_fortran_layout(device_array, dims)
         self._current_stream = self._stream_A if self._current_stream == self._stream_B else self._stream_B
         return final_array
 
     def _transform_from_fortran_layout(
         self,
         array: PythonArray,
-        dim: Optional[List[int]] = None,
-        swap_axes: Optional[Tuple[int, int]] = None,
+        dims: list[int] | None,
     ) -> PythonArray:
         """Transform from Fortran layout into a Pace compatible layout"""
-        if not dim:
-            dim = [self._npx, self._npy, self._npz]
-        trf_array = array.reshape(tuple(reversed(dim))).transpose().astype(Float)
-        if swap_axes:
-            trf_array = self._target_np.swapaxes(
-                trf_array,
-                swap_axes[0],
-                swap_axes[1],
-            )
+        if not dims:
+            dims = [self._npx, self._npy, self._npz]
+        trf_array = npl.stride_tricks.as_strided(
+            array,
+            shape=dims,
+            strides=_compute_fortran_strides(tuple(dims), Float),
+        )
         return trf_array
 
     def fortran_to_python(
         self,
         fptr: cffi.FFI.CData,
-        dim: Optional[List[int]] = None,
-        swap_axes: Optional[Tuple[int, int]] = None,
+        dims: list[int] | None,
+        *,
+        allow_device_transfer: bool = True,
     ) -> PythonArray:
-        """Move fortran memory into python space"""
-        np_array = self._fortran_to_numpy(fptr, dim)
-        if self._python_targets_gpu:
-            return self._upload_and_transform(np_array, dim, swap_axes)
+        """Move fortran memory into python space."""
+        np_array = self._fortran_to_numpy(fptr, dims)
+        if allow_device_transfer and self._python_targets_gpu:
+            return self._upload_and_transform(np_array, dims)
         else:
             return self._transform_from_fortran_layout(
                 np_array,
-                dim,
-                swap_axes,
+                dims,
             )
 
-    def _transform_and_download(
-        self,
-        device_array: DeviceArray,
-        dtype: type,
-        swap_axes: Optional[Tuple[int, int]] = None,
-    ) -> np.ndarray:
-        if swap_axes:
-            device_array = cp.swapaxes(
-                device_array,
-                swap_axes[0],
-                swap_axes[1],
-            )
-        host_array = cp.asnumpy(
-            device_array.astype(dtype).flatten(order="F"),
-        )
+    def _transform_and_download(self, device_array: DeviceArray, dtype: type) -> np.ndarray:
+        host_array = cp.asnumpy(device_array.astype(dtype).flatten(order="F"))
         self._current_stream = self._stream_A if self._current_stream == self._stream_B else self._stream_B
         return host_array
 
@@ -170,20 +160,13 @@ class FortranPythonConversion:
         self,
         array: PythonArray,
         dtype: type,
-        swap_axes: Optional[Tuple[int, int]] = None,
     ) -> np.ndarray:
         """Copy back a numpy array in python layout to Fortran"""
 
         if self._python_targets_gpu:
-            numpy_array = self._transform_and_download(array, dtype, swap_axes)
+            numpy_array = self._transform_and_download(array, dtype)
         else:
             numpy_array = array.astype(dtype).flatten(order="F")
-            if swap_axes:
-                numpy_array = np.swapaxes(
-                    numpy_array,
-                    swap_axes[0],
-                    swap_axes[1],
-                )
         return numpy_array
 
     def python_to_fortran(
@@ -191,20 +174,15 @@ class FortranPythonConversion:
         array: PythonArray,
         fptr: cffi.FFI.CData,
         ptr_offset: int = 0,
-        swap_axes: Optional[Tuple[int, int]] = None,
     ) -> None:
         """
         Input: Fortran data pointed to by fptr and of shape dim = (i, j, k)
-        Output: C-ordered double precision NumPy data of shape (i, j, k)
+        Output: F-ordered NumPy data of shape (i, j, k)
         """
         ftype = self._ffi.getctype(self._ffi.typeof(fptr).item)
         assert ftype in self._TYPEMAP
         dtype = self._TYPEMAP[ftype]
-        numpy_array = self._transform_from_python_layout(
-            array,
-            dtype,
-            swap_axes,
-        )
+        numpy_array = self._transform_from_python_layout(array, dtype)
         self._ffi.memmove(fptr + ptr_offset, numpy_array, 4 * numpy_array.size)
 
     def cast(self, dtype: npt.DTypeLike, void_ptr: CFFIObj) -> CFFIObj:

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/f_py_conversion.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/f_py_conversion.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from math import prod
 from types import ModuleType
 from typing import Tuple, TypeAlias
 
 import cffi
 import numpy as np
+import numpy.lib as npl
 import numpy.typing as npt
 from _cffi_backend import _CDataBase as CFFIObj
 
 from ndsl.dsl.typing import Float
 from ndsl.optional_imports import cupy as cp
-import numpy.lib as npl
-from functools import lru_cache
+
 
 # Dev note: we would like to use cp.ndarray for Device and
 # Union of np and cp ndarray for Python but we can't

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/f_py_conversion.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/f_py_conversion.py
@@ -104,17 +104,14 @@ class FortranPythonConversion:
         swap_axes: Optional[Tuple[int, int]] = None,
     ) -> DeviceArray:
         """Upload to device & transform to Pace compatible layout"""
-        with self._current_stream:
-            device_array = cp.asarray(host_array)
-            final_array = self._transform_from_fortran_layout(
-                device_array,
-                dim,
-                swap_axes,
-            )
-            self._current_stream = (
-                self._stream_A if self._current_stream == self._stream_B else self._stream_B
-            )
-            return final_array
+        device_array = cp.asarray(host_array)
+        final_array = self._transform_from_fortran_layout(
+            device_array,
+            dim,
+            swap_axes,
+        )
+        self._current_stream = self._stream_A if self._current_stream == self._stream_B else self._stream_B
+        return final_array
 
     def _transform_from_fortran_layout(
         self,
@@ -157,20 +154,17 @@ class FortranPythonConversion:
         dtype: type,
         swap_axes: Optional[Tuple[int, int]] = None,
     ) -> np.ndarray:
-        with self._current_stream:
-            if swap_axes:
-                device_array = cp.swapaxes(
-                    device_array,
-                    swap_axes[0],
-                    swap_axes[1],
-                )
-            host_array = cp.asnumpy(
-                device_array.astype(dtype).flatten(order="F"),
+        if swap_axes:
+            device_array = cp.swapaxes(
+                device_array,
+                swap_axes[0],
+                swap_axes[1],
             )
-            self._current_stream = (
-                self._stream_A if self._current_stream == self._stream_B else self._stream_B
-            )
-            return host_array
+        host_array = cp.asnumpy(
+            device_array.astype(dtype).flatten(order="F"),
+        )
+        self._current_stream = self._stream_A if self._current_stream == self._stream_B else self._stream_B
+        return host_array
 
     def _transform_from_python_layout(
         self,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/gfdl_1m.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/gfdl_1m.py
@@ -16,16 +16,15 @@ from pyMoist.interface import (
 
 
 class GFDL1MInterface:
-    def __init__(self, quantity_factory: QuantityFactory, stencil_factory: StencilFactory) -> None:
+    def __init__(
+        self,
+        quantity_factory: QuantityFactory,
+        stencil_factory: StencilFactory,
+        transfer_type: InterfaceTransferType,
+    ) -> None:
         self._stencil_factory = stencil_factory
         self._quantity_factory = quantity_factory
         self._gfdl_1m: GFDL1M | None = None
-
-        if is_gpu_backend(quantity_factory.backend):
-            transfer_type = InterfaceTransferType.CPU_TO_GPU_TO_CPU
-        else:
-            transfer_type = InterfaceTransferType.ALL_CPU
-
         self._managed_state = MAPLManagedState(
             GFDL1MState.zeros(quantity_factory),
             transfer_type,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/gfdl_1m.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/gfdl_1m.py
@@ -4,7 +4,6 @@ from mpi4py import MPI
 
 from ndsl import QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_INTERFACE_DIM
-from ndsl.dsl.gt4py_utils import is_gpu_backend
 from pyMoist.GFDL_1M import GFDL1M, GFDL1MConfig, GFDL1MState
 from pyMoist.interface import (
     InterfaceTransferType,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/managed_state.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/managed_state.py
@@ -12,7 +12,11 @@ from pyMoist.interface.mapl.memory_factory import MAPLMemoryRepository
 class MAPLManagedState:
     """Manage a NDSL <> MAPL shared state by linking MAPL pointers to NDSL state fields"""
 
-    def __init__(self, py_state: State, transfer_type: InterfaceTransferType) -> None:
+    def __init__(
+        self,
+        py_state: State,
+        transfer_type: InterfaceTransferType,
+    ) -> None:
         self._ndsl_state = py_state
         self._state_to_mapl_mapping: dict[str, Tuple[MAPLMemoryRepository, str]] = {}
         self._transfer_type = transfer_type
@@ -63,12 +67,16 @@ class MAPLManagedState:
                 )
             else:
                 mapl_array = mapl_state_.get_from_fortran(mapl_field_)
-                if cp is not None:
+                if self._transfer_type == InterfaceTransferType.CPU_TO_GPU_TO_CPU:
                     cp.cuda.runtime.deviceSynchronize()
                 if mapl_array is None:
                     setattr(ndsl_state_, ndsl_field_, None)
-                else:
+                elif self._transfer_type == InterfaceTransferType.CPU_COPY:
                     getattr(ndsl_state_, ndsl_field_).field[:] = mapl_array[:]
+                elif self._transfer_type == InterfaceTransferType.CPU_MAP:
+                    getattr(ndsl_state_, ndsl_field_).data = mapl_array
+                else:
+                    raise ValueError("Transfer type unknown for Fortran/NDSL")
 
         for ndsl_field, (mapl_state, mapl_field) in self._state_to_mapl_mapping.items():
             try:
@@ -79,6 +87,10 @@ class MAPLManagedState:
 
     def ndsl_to_fortran(self) -> None:
         """Copy all Python memory back in Fortan"""
+
+        # Skip sending back - we are mapped
+        if self._transfer_type == InterfaceTransferType.CPU_MAP:
+            return
 
         def _push_back_to_fortran(
             mapl_field_: str,
@@ -96,12 +108,18 @@ class MAPLManagedState:
                 )
             else:
                 mapl_array = mapl_state_.get_from_fortran(mapl_field_)
-                if mapl_array is not None:
+                if mapl_array is None:
+                    pass
+                elif self._transfer_type == InterfaceTransferType.CPU_COPY:
                     ndsl_array = getattr(ndsl_state_, ndsl_field_).field[:]
                     mapl_array[:] = ndsl_array[:]
                     mapl_state_.send_to_fortran(mapl_field_)
+                elif self._transfer_type == InterfaceTransferType.CPU_MAP:
+                    raise RuntimeError("Coding issue. We should never send back mapped data")
+                else:
+                    raise ValueError("Transfer type unknown for NDSL/Fortran")
 
         for ndsl_field, (mapl_state, mapl_field) in self._state_to_mapl_mapping.items():
             _push_back_to_fortran(mapl_field, mapl_state, ndsl_field, self._ndsl_state)
-        if cp is not None:
+        if self._transfer_type == InterfaceTransferType.CPU_TO_GPU_TO_CPU:
             cp.cuda.runtime.deviceSynchronize()

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/managed_state.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/managed_state.py
@@ -4,9 +4,9 @@ import numpy.typing as npt
 
 from ndsl import State
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Float
+from ndsl.optional_imports import cupy as cp
 from pyMoist.interface import InterfaceTransferType
 from pyMoist.interface.mapl.memory_factory import MAPLMemoryRepository
-from ndsl.optional_imports import cupy as cp
 
 
 class MAPLManagedState:

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/managed_state.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/managed_state.py
@@ -6,6 +6,7 @@ from ndsl import State
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Float
 from pyMoist.interface import InterfaceTransferType
 from pyMoist.interface.mapl.memory_factory import MAPLMemoryRepository
+from ndsl.optional_imports import cupy as cp
 
 
 class MAPLManagedState:
@@ -62,6 +63,8 @@ class MAPLManagedState:
                 )
             else:
                 mapl_array = mapl_state_.get_from_fortran(mapl_field_)
+                if cp is not None:
+                    cp.cuda.runtime.deviceSynchronize()
                 if mapl_array is None:
                     setattr(ndsl_state_, ndsl_field_, None)
                 else:
@@ -100,3 +103,5 @@ class MAPLManagedState:
 
         for ndsl_field, (mapl_state, mapl_field) in self._state_to_mapl_mapping.items():
             _push_back_to_fortran(mapl_field, mapl_state, ndsl_field, self._ndsl_state)
+        if cp is not None:
+            cp.cuda.runtime.deviceSynchronize()

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/memory_factory.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/mapl/memory_factory.py
@@ -29,7 +29,7 @@ class MAPLMemoryRepository:
         """Is the pointer properly associated in Fortran"""
         shape: tuple[int, ...]
         """Shape of the array"""
-        python_array: npt.NDArray
+        python_array: npt.NDArray | None
         """Synced python memory, check dirty"""
         dirty: bool = False
         """Does the memory need to be synced"""
@@ -71,24 +71,33 @@ class MAPLMemoryRepository:
             pointer=cast_ptr,
             associated=is_associated,
             shape=self._quantity_factory.sizer.get_extent(dims),
-            python_array=np.empty((0)),
+            python_array=None,
         )
 
     def get_from_fortran(
         self,
         name: str,
-    ) -> npt.NDArray:
+        *,
+        allow_device_transfer: bool = True,
+    ) -> npt.NDArray | None:
         """Retrieve the data from Fortran. Prefer using a MAPLManager."""
         try:
             fmem = self._fortran_pointers[name]
         except KeyError:
             raise KeyError(f"Pointer {name} was never registered.")
+
         if not fmem.associated:
-            return
+            return None
+
+        # We rely here on `fmem.pointer` constant, therefore we could
+        # go ahead an _not_ re-map. We don't because we want to introduce
+        # a ZERO TRUST mode where we don't rely on Fortran  being constant
+        #     return fmem.python_array
 
         fmem.python_array = self._f_py_converter.fortran_to_python(
             fptr=fmem.pointer,
-            dim=list(fmem.shape),
+            dims=list(fmem.shape),
+            allow_device_transfer=allow_device_transfer,
         )
 
         return fmem.python_array

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/memory_space.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/memory_space.py
@@ -7,5 +7,6 @@ class MemorySpace(enum.Enum):
 
 
 class InterfaceTransferType(enum.Enum):
-    ALL_CPU = enum.auto()
+    CPU_COPY = enum.auto()  # Copies because of layout mismatch
+    CPU_MAP = enum.auto()  # No copy - memory map - same layout
     CPU_TO_GPU_TO_CPU = enum.auto()

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
@@ -27,7 +27,7 @@ from ndsl import (
     TilePartitioner,
 )
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
-from ndsl.dsl.gt4py_utils import is_gpu_backend, backend_is_fortran_aligned
+from ndsl.dsl.gt4py_utils import backend_is_fortran_aligned, is_gpu_backend
 from ndsl.dsl.typing import get_precision
 from ndsl.logging import ndsl_log_on_rank_0
 from ndsl.optional_imports import cupy as cp

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
@@ -99,6 +99,7 @@ class GEOSPyMoistWrapper:
             backend=self.stencil_config.backend,
             tile_nx=self.flags.npx * self.flags.layout_x,
             tile_nz=self.flags.npz,
+            time=True,
         )
         self._is_orchestrated = self.stencil_config.dace_config.is_dace_orchestrated()
 
@@ -134,9 +135,9 @@ class GEOSPyMoistWrapper:
             f"  Orchestration : {self._is_orchestrated}\n"
             f"          Sizer : {sizer.nx}x{sizer.ny}x{sizer.nz}"
             f"(halo: {sizer.n_halo})\n"
-            f" Strides for 3D : {[s // 8 for s in tmp_quantity.data.strides]}\n"
-            f"     Device ord : {device_ordinal_info}\n"
-            f"     Nvidia MPS : {MPS_is_on}"
+            f" Strides for 3D : {tmp_quantity.data.strides}\n"
+            f"     Device ord : {device_ordinal_info}"
+            f"     Nvidia MPS : {MPS_is_on}\n"
         )
         del tmp_quantity
 
@@ -290,3 +291,6 @@ class GEOSPyMoistWrapper:
         rank = MPI.COMM_WORLD.Get_rank()
         with open(f"pymoist_timings_r{rank}.json", "w") as f:
             json.dump(self._timings, f, indent=4)
+
+        with open(f"internal_orchestration_r{rank}.json", "w") as f:
+            json.dump(self.stencil_config.dace_config.performance_collector.times_per_step, f, indent=4)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/wrapper.py
@@ -27,7 +27,7 @@ from ndsl import (
     TilePartitioner,
 )
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
-from ndsl.dsl.gt4py_utils import is_gpu_backend
+from ndsl.dsl.gt4py_utils import is_gpu_backend, backend_is_fortran_aligned
 from ndsl.dsl.typing import get_precision
 from ndsl.logging import ndsl_log_on_rank_0
 from ndsl.optional_imports import cupy as cp
@@ -108,17 +108,25 @@ class GEOSPyMoistWrapper:
         self._grid_indexing = GridIndexing.from_sizer_and_communicator(sizer=sizer, comm=self.communicator)
         self.stencil_factory = StencilFactory(config=self.stencil_config, grid_indexing=self._grid_indexing)
 
+        # Figure out the interface mode
+        tmp_quantity = self.quantity_factory.empty([X_DIM, Y_DIM, Z_DIM], units="")
+        default_3D_memory_desc = (tmp_quantity.data.shape, tmp_quantity.data.strides)
         if fortran_mem_space != MemorySpace.CPU:
             raise NotImplementedError("Interface cannot stream Fortran memory resident on GPU")
-        self._interface_type = (
-            InterfaceTransferType.CPU_TO_GPU_TO_CPU
-            if is_gpu_backend(backend)
-            else InterfaceTransferType.ALL_CPU
-        )
+        if is_gpu_backend(backend):
+            self._interface_type = InterfaceTransferType.CPU_TO_GPU_TO_CPU
+        else:
+            if backend_is_fortran_aligned(backend):
+                # This is Fortran layout - we can Map the memory
+                self._interface_type = InterfaceTransferType.CPU_MAP
+            else:
+                # All other layout have to copy the data in/out of Fortran layout
+                self._interface_type = InterfaceTransferType.CPU_COPY
+        del tmp_quantity
 
         # Feedback information
         device_ordinal_info = (
-            f"  Device PCI bus id: {cp.cuda.Device(0).pci_bus_id}\n" if is_gpu_backend(backend) else "N/A"
+            f"  Device PCI bus id: {cp.cuda.Device(0).pci_bus_id}" if is_gpu_backend(backend) else "N/A"
         )
         MPS_pipe_directory = os.getenv("CUDA_MPS_PIPE_DIRECTORY", None)
         MPS_is_on = (
@@ -126,20 +134,18 @@ class GEOSPyMoistWrapper:
             and is_gpu_backend(backend)
             and os.path.exists(f"{MPS_pipe_directory}/log")
         )
-        tmp_quantity = self.quantity_factory.empty([X_DIM, Y_DIM, Z_DIM], units="")
         ndsl_log_on_rank_0.info(
-            "pyMoist <> GEOS wrapper initialized (Rank 0): \n"
-            f"         Bridge : {self._interface_type.name} \n"
+            "pyMoist <> GEOS wrapper initialized (Rank 0):\n"
+            f"         Bridge : {self._interface_type.name}\n"
             f"        Backend : {backend}\n"
-            f"      Precision : {get_precision()}bit\n"
+            f"      Precision : {get_precision()} bit\n"
             f"  Orchestration : {self._is_orchestrated}\n"
             f"          Sizer : {sizer.nx}x{sizer.ny}x{sizer.nz}"
             f"(halo: {sizer.n_halo})\n"
-            f" Strides for 3D : {tmp_quantity.data.strides}\n"
-            f"     Device ord : {device_ordinal_info}"
+            f" Strides for 3D : {default_3D_memory_desc[1]}\n"
+            f"     Device ord : {device_ordinal_info}\n"
             f"     Nvidia MPS : {MPS_is_on}\n"
         )
-        del tmp_quantity
 
         # Timer result dict
         self._timings: dict[str, list[float]] = {}
@@ -150,7 +156,11 @@ class GEOSPyMoistWrapper:
         self._aer_activation: AerActivation | None = None
 
         # GFDL 1M
-        self._gfdl_1m_interface = GFDL1MInterface(self.quantity_factory, self.stencil_factory)
+        self._gfdl_1m_interface = GFDL1MInterface(
+            self.quantity_factory,
+            self.stencil_factory,
+            self._interface_type,
+        )
 
         # UW
         self._UW_shallow_convection: Optional[ComputeUwshcuInv] = None
@@ -294,3 +304,6 @@ class GEOSPyMoistWrapper:
 
         with open(f"internal_orchestration_r{rank}.json", "w") as f:
             json.dump(self.stencil_config.dace_config.performance_collector.times_per_step, f, indent=4)
+
+        with open(f"internal_gt4py_timings_r{rank}.json", "w") as f:
+            json.dump(self.stencil_factory.timing_collector.exec_info, f, indent=4)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interpolations.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interpolations.py
@@ -67,10 +67,9 @@ def vertical_interpolation(
         pb = pt
 
     with computation(FORWARD), interval(-1, None):
-        pt = 0.5 * (log(p_interface_mb * 100) + log(p_interface_mb[0, 0, -1] * 100))
-        pb = 0.5 * (log(p_interface_mb * 100) + log(p_interface_mb[0, 0, 1] * 100))
+        pb2: FloatFieldIJ = 0.5 * (log(p_interface_mb * 100) + log(p_interface_mb[0, 0, 1] * 100))
         if (
-            log(target_pressure) > pb
+            log(target_pressure) > pb2
             and log(target_pressure) <= log(p_interface_mb[0, 0, 1] * 100)
             and not track_points
         ):
@@ -80,9 +79,3 @@ def vertical_interpolation(
         # ensure every point was actually touched
         if track_points == False:  # noqa
             interpolated_field = field
-
-    # reset masks and temporaries for later use
-    with computation(FORWARD), interval(0, 1):
-        track_points = False
-        pb = 0
-        pt = 0

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/setup.cfg
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/setup.cfg
@@ -31,6 +31,10 @@ namespace_packages = True
 strict_optional = False
 warn_unreachable = True
 explicit_package_bases = True
+line-length = 110
+
+[tool.ruff]
+line-length = 110
 
 [coverage:run]
 parallel = true

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_Driver.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_Driver.py
@@ -100,7 +100,7 @@ class TranslateGFDL_1M_Driver(TranslateFortranData2Py):
         safe_assign_array(state.u.field[:], inputs["u"])
         safe_assign_array(state.v.field[:], inputs["v"])
         safe_assign_array(state.vertical_motion.velocity.field[:], inputs["w"])
-        safe_assign_array(locals_.dz.field[:], inputs["local_dz"])
+        safe_assign_array(locals_.layer_thickness_negative.field[:], inputs["local_dz"])
         safe_assign_array(locals_.dp.field[:], inputs["local_dp"])
         safe_assign_array(state.area.field[:], inputs["area"])
         safe_assign_array(state.land_fraction.field[:], inputs["land_fraction"])
@@ -141,7 +141,7 @@ class TranslateGFDL_1M_Driver(TranslateFortranData2Py):
             u=state.u,
             v=state.v,
             w=state.vertical_motion.velocity,
-            dz=locals_.dz,
+            dz=locals_.layer_thickness_negative,
             dp=locals_.dp,
             area=state.area,
             land_fraction=state.land_fraction,
@@ -234,7 +234,7 @@ class TranslateGFDL_1M_Driver(TranslateFortranData2Py):
                     u=state.u,
                     v=state.v,
                     w=state.vertical_motion.velocity,
-                    dz=locals_.dz,
+                    dz=locals_.layer_thickness_negative,
                     dp=locals_.dp,
                     area=state.area,
                     land_fraction=state.land_fraction,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_DriverSetup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_DriverSetup.py
@@ -80,8 +80,8 @@ class TranslateGFDL_1M_DriverSetup(TranslateFortranData2Py):
     def compute(self, inputs):
         # initalize dataclasses
         state = GFDL1MState.zeros(self.quantity_factory)
-        locals_ = GFDL1MLocals.zeros(self.quantity_factory)
-        driver_locals = GFDL1MDriverLocals.zeros(self.quantity_factory)
+        locals_ = GFDL1MLocals.make_as_state(self.quantity_factory)
+        driver_locals = GFDL1MDriverLocals.make_as_state(self.quantity_factory)
 
         # initalize constants
         config = GFDL1MConfig(**self.constants)
@@ -139,7 +139,7 @@ class TranslateGFDL_1M_DriverSetup(TranslateFortranData2Py):
             "driver_local_dry_mixing_ratio_graupel_driversetup"
         ][:, :, :, 0]
         driver_locals.cloud_fraction.field[:] = inputs["driver_local_cloud_fraction_driversetup"][:, :, :, 0]
-        locals_.dz.field[:] = inputs["local_dz_drivesetup"][:, :, :, 0]
+        locals_.layer_height_above_surface.field[:] = inputs["local_dz_drivesetup"][:, :, :, 0]
         state.u.field[:] = inputs["u_driversetup"][:, :, :, 0]
         state.v.field[:] = inputs["v_driversetup"][:, :, :, 0]
         state.vertical_motion.velocity.field[:] = inputs["w_driversetup"][:, :, :, 0]
@@ -213,7 +213,7 @@ class TranslateGFDL_1M_DriverSetup(TranslateFortranData2Py):
             dry_air_mixing_ratio_snow=driver_locals.dry_air_mixing_ratio.snow,
             dry_air_mixing_ratio_graupel=driver_locals.dry_air_mixing_ratio.graupel,
             cloud_fraction=driver_locals.cloud_fraction,
-            dz=locals_.dz,
+            dz=locals_.layer_height_above_surface,
             u_unmodified=state.u,
             u=driver_locals.u,
             v_unmodified=state.v,
@@ -298,7 +298,7 @@ class TranslateGFDL_1M_DriverSetup(TranslateFortranData2Py):
             :, :, :, 0
         ] = driver_locals.dry_air_mixing_ratio.graupel.field[:]
         outputs["driver_local_cloud_fraction_driversetup"][:, :, :, 0] = driver_locals.cloud_fraction.field[:]
-        outputs["local_dz_drivesetup"][:, :, :, 0] = locals_.dz.field[:]
+        outputs["local_dz_drivesetup"][:, :, :, 0] = locals_.layer_height_above_surface.field[:]
         outputs["u_driversetup"][:, :, :, 0] = state.u.field[:]
         outputs["v_driversetup"][:, :, :, 0] = state.v.field[:]
         outputs["w_driversetup"][:, :, :, 0] = state.vertical_motion.velocity.field[:]

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_RadiationCoupling.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_RadiationCoupling.py
@@ -4,6 +4,7 @@ from ndsl import StencilFactory
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py
+from ndsl.utils import safe_assign_array
 from pyMoist.GFDL_1M.config import GFDL1MConfig
 from pyMoist.GFDL_1M.locals import GFDL1MLocals
 from pyMoist.GFDL_1M.radiation_coupling import GFDL1MRadiationCoupling
@@ -56,37 +57,44 @@ class TranslateGFDL_1M_RadiationCoupling(TranslateFortranData2Py):
 
         # initalize dataclasses
         state = GFDL1MState.zeros(self.quantity_factory)
-        locals = GFDL1MLocals.zeros(self.quantity_factory)
+        locals_ = GFDL1MLocals.make_as_state(self.quantity_factory)
 
         # Initalize saturation tables
         saturation_tables = SaturationVaporPressureTable(self.stencil_factory.backend)
 
-        state.mixing_ratio.vapor.field[:] = inputs["mixing_ratio_vapor"]
-        state.t.field[:] = inputs["t"]
-        state.mixing_ratio.large_scale_liquid.field[:] = inputs["mixing_ratio_large_scale_liquid"]
-        state.mixing_ratio.large_scale_ice.field[:] = inputs["mixing_ratio_large_scale_ice"]
-        state.cloud_fraction.large_scale.field[:] = inputs["cloud_fraction_large_scale"]
-        state.mixing_ratio.convective_liquid.field[:] = inputs["mixing_ratio_convective_liquid"]
-        state.mixing_ratio.convective_ice.field[:] = inputs["mixing_ratio_convective_ice"]
-        state.cloud_fraction.convective.field[:] = inputs["cloud_fraction_convective"]
-        locals.p_mb.field[:] = inputs["local_p_mb"]
-        state.mixing_ratio.rain.field[:] = inputs["mixing_ratio_rain"]
-        state.mixing_ratio.snow.field[:] = inputs["mixing_ratio_snow"]
-        state.mixing_ratio.graupel.field[:] = inputs["mixing_ratio_graupel"]
-        state.concentration.liquid.field[:] = inputs["concentration_liquid"]
-        state.concentration.ice.field[:] = inputs["concentration_ice"]
-        state.radiation_field.vapor.field[:] = inputs["radiation_vapor"]
-        state.radiation_field.liquid.field[:] = inputs["radiation_liquid"]
-        state.radiation_field.ice.field[:] = inputs["radiation_ice"]
-        state.radiation_field.rain.field[:] = inputs["radiation_rain"]
-        state.radiation_field.snow.field[:] = inputs["radiation_snow"]
-        state.radiation_field.graupel.field[:] = inputs["radiation_graupel"]
-        state.radiation_field.cloud_fraction.field[:] = inputs["radiation_cloud_fraction"]
-        state.cloud_particle_effective_radius.liquid.field[:] = inputs[
-            "cloud_particle_effective_radius_liquid"
-        ]
-        state.cloud_particle_effective_radius.ice.field[:] = inputs["cloud_particle_effective_radius_ice"]
-        state.relative_humidity_after_pdf.field[:] = inputs["relative_humidity_after_pdf"]
+        safe_assign_array(state.mixing_ratio.vapor.field[:], inputs["mixing_ratio_vapor"])
+        safe_assign_array(state.t.field[:], inputs["t"])
+        safe_assign_array(
+            state.mixing_ratio.large_scale_liquid.field[:], inputs["mixing_ratio_large_scale_liquid"]
+        )
+        safe_assign_array(state.mixing_ratio.large_scale_ice.field[:], inputs["mixing_ratio_large_scale_ice"])
+        safe_assign_array(state.cloud_fraction.large_scale.field[:], inputs["cloud_fraction_large_scale"])
+        safe_assign_array(
+            state.mixing_ratio.convective_liquid.field[:], inputs["mixing_ratio_convective_liquid"]
+        )
+        safe_assign_array(state.mixing_ratio.convective_ice.field[:], inputs["mixing_ratio_convective_ice"])
+        safe_assign_array(state.cloud_fraction.convective.field[:], inputs["cloud_fraction_convective"])
+        safe_assign_array(locals_.p_mb.field[:], inputs["local_p_mb"])
+        safe_assign_array(state.mixing_ratio.rain.field[:], inputs["mixing_ratio_rain"])
+        safe_assign_array(state.mixing_ratio.snow.field[:], inputs["mixing_ratio_snow"])
+        safe_assign_array(state.mixing_ratio.graupel.field[:], inputs["mixing_ratio_graupel"])
+        safe_assign_array(state.concentration.liquid.field[:], inputs["concentration_liquid"])
+        safe_assign_array(state.concentration.ice.field[:], inputs["concentration_ice"])
+        safe_assign_array(state.radiation_field.vapor.field[:], inputs["radiation_vapor"])
+        safe_assign_array(state.radiation_field.liquid.field[:], inputs["radiation_liquid"])
+        safe_assign_array(state.radiation_field.ice.field[:], inputs["radiation_ice"])
+        safe_assign_array(state.radiation_field.rain.field[:], inputs["radiation_rain"])
+        safe_assign_array(state.radiation_field.snow.field[:], inputs["radiation_snow"])
+        safe_assign_array(state.radiation_field.graupel.field[:], inputs["radiation_graupel"])
+        safe_assign_array(state.radiation_field.cloud_fraction.field[:], inputs["radiation_cloud_fraction"])
+        safe_assign_array(
+            state.cloud_particle_effective_radius.liquid.field[:],
+            inputs["cloud_particle_effective_radius_liquid"],
+        )
+        safe_assign_array(
+            state.cloud_particle_effective_radius.ice.field[:], inputs["cloud_particle_effective_radius_ice"]
+        )
+        safe_assign_array(state.relative_humidity_after_pdf.field[:], inputs["relative_humidity_after_pdf"])
 
         # construct test stencil
         code = GFDL1MRadiationCoupling(
@@ -118,7 +126,7 @@ class TranslateGFDL_1M_RadiationCoupling(TranslateFortranData2Py):
             radiation_snow=state.radiation_field.snow,
             radiation_graupel=state.radiation_field.graupel,
             radiation_cloud_fraction=state.radiation_field.cloud_fraction,
-            local_p_mb=locals.p_mb,
+            local_p_mb=locals_.p_mb,
         )
 
         return {
@@ -130,7 +138,7 @@ class TranslateGFDL_1M_RadiationCoupling(TranslateFortranData2Py):
             "mixing_ratio_convective_liquid": state.mixing_ratio.convective_liquid.field[:],
             "mixing_ratio_convective_ice": state.mixing_ratio.convective_ice.field[:],
             "cloud_fraction_convective": state.cloud_fraction.convective.field[:],
-            "local_p_mb": locals.p_mb.field[:],
+            "local_p_mb": locals_.p_mb.field[:],
             "mixing_ratio_rain": state.mixing_ratio.rain.field[:],
             "mixing_ratio_snow": state.mixing_ratio.snow.field[:],
             "mixing_ratio_graupel": state.mixing_ratio.graupel.field[:],

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_Setup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/translate_GFDL_1M_Setup.py
@@ -3,7 +3,6 @@ from typing import Any
 from f90nml import Namelist
 
 from ndsl import StencilFactory
-from ndsl.constants import X_DIM, Y_DIM, Z_DIM
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.savepoint import DataLoader
 from ndsl.stencils.testing.translate import TranslateFortranData2Py
@@ -11,7 +10,6 @@ from pyMoist.GFDL_1M.config import GFDL1MConfig
 from pyMoist.GFDL_1M.locals import GFDL1MLocals
 from pyMoist.GFDL_1M.setup import GFDL1MSetup
 from pyMoist.GFDL_1M.state import GFDL1MState
-from pyMoist.GFDL_1M.stencils import prepare_tendencies
 from pyMoist.saturation_tables.tables.main import SaturationVaporPressureTable
 
 
@@ -106,19 +104,12 @@ class TranslateGFDL_1M_Setup(TranslateFortranData2Py):
         state.mixing_ratio.large_scale_ice.field[:] = inputs["mixing_ratio_large_scale_ice"]
         state.mixing_ratio.convective_ice.field[:] = inputs["mixing_ratio_convective_ice"]
 
-        # construct stencil that must be built outside of test class
-        self.prepare_tendencies = self.stencil_factory.from_dims_halo(
-            func=prepare_tendencies,
-            compute_dims=[X_DIM, Y_DIM, Z_DIM],
-        )
-
         # initalize test class
         code = GFDL1MSetup(
             stencil_factory=self.stencil_factory,
             quantity_factory=self.quantity_factory,
             config=config,
             saturation_tables=self.saturation_tables,
-            prepare_tendencies=self.prepare_tendencies,
         )
 
         # execute test code


### PR DESCRIPTION
We rework the Fortran/Python interface to expose three mode of computation: CPU_COPY, CPU_MAP and CPU_GPU. Those modes are resolved at init time looking at the backend called for NDSL.

The memory mapping brings the cost of interface to a negligible amount and hashing scales it with core count properly.

Also:
- some light fixes to interface code that was abusing of the "extra point" in common backend
- some fixes to the translate tests & initialization of code

:warning: This code is dependent on soon-to-be-merged updates to NDSL :warning: 