### PR TITLE
[NDSL] Pin NDSL version of pyMoist to latest release

### DIFF
--- a/.github/workflows/ndsl-checks.yml
+++ b/.github/workflows/ndsl-checks.yml
@@ -39,6 +39,11 @@ jobs:
           cd GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
           pre-commit run --all-files
 
+      - name: Build Documentation
+        run: |
+          cd GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+          mkdocs build
+
       - name: Download test_data
         run: |
           cd GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist

--- a/.github/workflows/ndsl-checks.yml
+++ b/.github/workflows/ndsl-checks.yml
@@ -17,42 +17,36 @@ jobs:
       DATA_URL: "https://portal.nccs.nasa.gov/datashare/astg/smt/geos-fp/translate/11.5.2/x86_GNU/Moist/TBC_C24L72.tar.gz"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout NDSL
-        uses: actions/checkout@master
+      - name: Step Python 3.11
+        uses: actions/setup-python@v6
         with:
-          repository: NOAA-GFDL/NDSL
-          submodules: 'recursive'
-          path: '${{ github.workspace }}/ndsl'
+          python-version: '3.11'
+
+      - name: Install MPI
+        run: pip install mpich
+
       - name: Checkout repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-          path: '${{ github.workspace }}/GCMGridComp'
-      - name: Step Python 3.11.9
-        uses: actions/setup-python@v4.6.0
-        with:
-          python-version: '3.11.9'
-      - name: Install OpenMPI for gt4py
-        run: |
-          sudo apt-get install libopenmpi-dev
+
       - name: Install Python packages
         run: |
-          python -m pip install --upgrade pip setuptools wheel pre-commit
-          cd ${{ github.workspace }}/ndsl
-          pip install -e .[develop]
-          cd ${{ github.workspace }}/GCMGridComp
-          pip install -e ./GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+          pip install ./GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist[develop]
+
       - name: Run lint via pre-commit
         run: |
-          cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+          cd GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
           pre-commit run --all-files
-      - name: Download test_data (if not cached)
+
+      - name: Download test_data
         run: |
-          cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
+          cd GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist
           mkdir -p ${{ env.DATA_PATH }} && cd ${{ env.DATA_PATH }}
           wget ${{ env.DATA_URL }}
           tar -xzvf TBC_C24L72.tar.gz
+
       - name: Run all tests
         run: |
-          cd ${{ github.workspace }}/GCMGridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/
+          cd GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/scripts/
           ./run_all.sh ../../${{ env.DATA_PATH }} dace:cpu_kfirst

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/.gitignore
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/.gitignore
@@ -15,3 +15,4 @@ sandbox/
 .translate*/
 **/build/
 .venv/
+site/

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/.gitignore
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/.gitignore
@@ -14,3 +14,4 @@ sandbox/
 .gt_cache_*/
 .translate*/
 **/build/
+.venv/

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/.pre-commit-config.yaml
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/.pre-commit-config.yaml
@@ -4,63 +4,58 @@ default_language_version:
 files: pyMoist
 
 repos:
--   repo: https://github.com/psf/black
-    rev: 20.8b1
+# Use mypyc-compiled black, which is about 2x faster
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.1.0
     hooks:
-    - id: black
-      args: ["--line-length", "110"]
-      additional_dependencies: ["click==8.0.4"]
+      - id: black
+        args: ["--line-length", "110"]
+        additional_dependencies: ["click==8.0.4"]
 
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.4.2
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
     hooks:
-    - id: isort
-      args: ["--profile", "black", "--line-length", "110"]
+      - id: isort
+        args: ["--profile", "black", "--line-length", "110"]
 
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
     hooks:
-    - id: mypy
-      name: mypy-pyMoist
-      args: [
-        --ignore-missing-imports,
-        "--follow-imports=normal",
-        --namespace-packages,
-        --no-strict-optional,
-        --warn-unreachable,
-        --explicit-package-bases,
-      ]
-      additional_dependencies: [types-PyYAML]
-      files: pyMoist
+      - id: mypy
+        name: mypy-pyMoist
+        args: [--ignore-missing-imports, "--follow-imports=normal", --namespace-packages, --no-strict-optional, --warn-unreachable, --explicit-package-bases]
+        additional_dependencies: [types-PyYAML]
+        files: pyMoist
 
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
     hooks:
-    - id: check-toml
-    - id: check-yaml
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
 
--   repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
     hooks:
-    - id: flake8
-      name: flake8
-      language_version: python3
-      args: [
-        "--exclude=docs",
-        "--ignore=W503,E302,E203,F841",
-        "--max-line-length=110"
-      ]
-      exclude: |
-        (?x)^(
-        .*/__init__.py |
-        )$
-    - id: flake8
-      name: flake8 __init__.py files
-      files: "__init__.py"
+      - id: flake8
+        name: flake8
+        language_version: python3
+        args: ["--exclude=docs", "--ignore=W503,E302,E203,F841", "--max-line-length=110"]
+        exclude: |
+          (?x)^(
+          .*/__init__.py |
+          )$
+      - id: flake8
+        name: flake8 __init__.py files
+        files: "__init__.py"
       # ignore unused import error in __init__.py files
-      args: [
-        "--exclude=docs",
-        "--ignore=W503,E302,E203,F841,F401",
-        "--max-line-length=110",]
+        args: ["--exclude=docs", "--ignore=W503,E302,E203,F841,F401", "--max-line-length=110"]
+
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.15.0
+    hooks:
+      - id: pretty-format-toml
+        args: [--autofix, --indent, "2"]
+      - id: pretty-format-yaml
+        args: [--autofix, --preserve-quotes, --indent, "2", --offset, "2"]

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/config.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/config.md
@@ -1,0 +1,3 @@
+# config
+
+::: pyMoist.GFDL_1M.PhaseChange.config

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/constants.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/constants.md
@@ -1,0 +1,3 @@
+# constants
+
+::: pyMoist.GFDL_1M.PhaseChange.constants

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/evaporate.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/evaporate.md
@@ -1,0 +1,3 @@
+# evaporate
+
+::: pyMoist.GFDL_1M.PhaseChange.evaporate

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/hydrostatic_pdf.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/hydrostatic_pdf.md
@@ -1,0 +1,3 @@
+# hydrostatic_pdf
+
+::: pyMoist.GFDL_1M.PhaseChange.hydrostatic_pdf

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/melt_freeze.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/melt_freeze.md
@@ -1,0 +1,3 @@
+# melt_freeze
+
+::: pyMoist.GFDL_1M.PhaseChange.melt_freeze

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/phase_change.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/phase_change.md
@@ -1,0 +1,3 @@
+# phase_change
+
+::: pyMoist.GFDL_1M.PhaseChange.phase_change

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/rh_calculations.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/rh_calculations.md
@@ -1,0 +1,3 @@
+# rh_calculations
+
+::: pyMoist.GFDL_1M.PhaseChange.rh_calculations

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/sublimate.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/PhaseChange/sublimate.md
@@ -1,0 +1,3 @@
+# sublimate
+
+::: pyMoist.GFDL_1M.PhaseChange.sublimate

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/config.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/config.md
@@ -1,0 +1,3 @@
+# config
+
+::: pyMoist.GFDL_1M.config

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/check_flags.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/check_flags.md
@@ -1,0 +1,3 @@
+# check_flags
+
+::: pyMoist.GFDL_1M.driver.check_flags

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/config_constants.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/config_constants.md
@@ -1,0 +1,3 @@
+# config_constants
+
+::: pyMoist.GFDL_1M.driver.config_constants

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/constants.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/constants.md
@@ -1,0 +1,3 @@
+# constants
+
+::: pyMoist.GFDL_1M.driver.constants

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/driver.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/driver.md
@@ -1,0 +1,3 @@
+# driver
+
+::: pyMoist.GFDL_1M.driver.driver

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/fall_speed.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/fall_speed.md
@@ -1,0 +1,3 @@
+# fall_speed
+
+::: pyMoist.GFDL_1M.driver.fall_speed

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/finish.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/finish.md
@@ -1,0 +1,3 @@
+# finish
+
+::: pyMoist.GFDL_1M.driver.finish

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/ice_cloud.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/ice_cloud.md
@@ -1,0 +1,3 @@
+# ice_cloud
+
+::: pyMoist.GFDL_1M.driver.ice_cloud

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/locals.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/locals.md
@@ -1,0 +1,3 @@
+# locals
+
+::: pyMoist.GFDL_1M.driver.locals

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/masks.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/masks.md
@@ -1,0 +1,3 @@
+# masks
+
+::: pyMoist.GFDL_1M.driver.masks

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/sat_tables.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/sat_tables.md
@@ -1,0 +1,3 @@
+# sat_tables
+
+::: pyMoist.GFDL_1M.driver.sat_tables

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/setup.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/setup.md
@@ -1,0 +1,3 @@
+# setup
+
+::: pyMoist.GFDL_1M.driver.setup

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/stencils.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/stencils.md
@@ -1,0 +1,3 @@
+# stencils
+
+::: pyMoist.GFDL_1M.driver.stencils

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/terminal_fall.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/terminal_fall.md
@@ -1,0 +1,3 @@
+# terminal_fall
+
+::: pyMoist.GFDL_1M.driver.terminal_fall

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/warm_rain.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/driver/warm_rain.md
@@ -1,0 +1,3 @@
+# warm_rain
+
+::: pyMoist.GFDL_1M.driver.warm_rain

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/evap_subl_pdf_core.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/evap_subl_pdf_core.md
@@ -1,3 +1,0 @@
-# evap_subl_pdf_core
-
-::: pyMoist.GFDL_1M.evap_subl_pdf_core

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/finalize.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/finalize.md
@@ -1,0 +1,3 @@
+# finalize
+
+::: pyMoist.GFDL_1M.finalize

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/locals.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/locals.md
@@ -1,0 +1,3 @@
+# locals
+
+::: pyMoist.GFDL_1M.locals

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/radiation_coupling.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/radiation_coupling.md
@@ -1,0 +1,3 @@
+# radiation_coupling
+
+::: pyMoist.GFDL_1M.radiation_coupling

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/setup.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/setup.md
@@ -1,0 +1,3 @@
+# setup
+
+::: pyMoist.GFDL_1M.setup

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/state.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/state.md
@@ -1,0 +1,3 @@
+# state
+
+::: pyMoist.GFDL_1M.state

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/stencils.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/GFDL_1M/stencils.md
@@ -1,0 +1,3 @@
+# stencils
+
+::: pyMoist.GFDL_1M.stencils

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/build_helper.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/build_helper.md
@@ -1,0 +1,3 @@
+# build_helper
+
+::: pyMoist.interface.build_helper

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/cffi_lib/interface.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/cffi_lib/interface.md
@@ -1,0 +1,3 @@
+# interface
+
+::: pyMoist.interface.cffi_lib.interface

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/gfdl_1m.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/gfdl_1m.md
@@ -1,0 +1,3 @@
+# gfdl_1m
+
+::: pyMoist.interface.gfdl_1m

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/mapl/managed_state.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/mapl/managed_state.md
@@ -1,0 +1,3 @@
+# managed_state
+
+::: pyMoist.interface.mapl.managed_state

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/mapl/memory_factory.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/mapl/memory_factory.md
@@ -1,0 +1,3 @@
+# memory_factory
+
+::: pyMoist.interface.mapl.memory_factory

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/memory_space.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/interface/memory_space.md
@@ -1,0 +1,3 @@
+# memory_space
+
+::: pyMoist.interface.memory_space

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/constants.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/constants.md
@@ -1,3 +1,0 @@
-# constants
-
-::: pyMoist.saturation.constants

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/formulation.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/formulation.md
@@ -1,3 +1,0 @@
-# formulation
-
-::: pyMoist.saturation.formulation

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/qsat.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/qsat.md
@@ -1,3 +1,0 @@
-# qsat
-
-::: pyMoist.saturation.qsat

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/qsat_ice.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/qsat_ice.md
@@ -1,3 +1,0 @@
-# qsat_ice
-
-::: pyMoist.saturation.qsat_ice

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/qsat_liquid.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/qsat_liquid.md
@@ -1,3 +1,0 @@
-# qsat_liquid
-
-::: pyMoist.saturation.qsat_liquid

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/table.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation/table.md
@@ -1,3 +1,0 @@
-# table
-
-::: pyMoist.saturation.table

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/constants.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/constants.md
@@ -1,0 +1,3 @@
+# constants
+
+::: pyMoist.saturation_tables.constants

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/formulation.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/formulation.md
@@ -1,0 +1,3 @@
+# formulation
+
+::: pyMoist.saturation_tables.formulation

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/qsat_functions.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/qsat_functions.md
@@ -1,0 +1,3 @@
+# qsat_functions
+
+::: pyMoist.saturation_tables.qsat_functions

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/tables/constants.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/tables/constants.md
@@ -1,0 +1,3 @@
+# constants
+
+::: pyMoist.saturation_tables.tables.constants

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/tables/ice_exact.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/tables/ice_exact.md
@@ -1,0 +1,3 @@
+# ice_exact
+
+::: pyMoist.saturation_tables.tables.ice_exact

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/tables/liquid_exact.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/tables/liquid_exact.md
@@ -1,0 +1,3 @@
+# liquid_exact
+
+::: pyMoist.saturation_tables.tables.liquid_exact

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/tables/main.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/tables/main.md
@@ -1,0 +1,3 @@
+# main
+
+::: pyMoist.saturation_tables.tables.main

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/types.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/saturation_tables/types.md
@@ -1,0 +1,3 @@
+# types
+
+::: pyMoist.saturation_tables.types

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/top/interpolations.md
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/docs/top/interpolations.md
@@ -1,0 +1,3 @@
+# interpolations
+
+::: pyMoist.interpolations

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/mkdocs.yml
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/mkdocs.yml
@@ -15,34 +15,34 @@ plugins:
 nav:
   - Home: index.md
   - Top Level:
-    - "aer_activation": top/aer_activation.md
-    - "constants": top/constants.md
-    - "field_types": top/field_types.md
-    - "numerical_recipes": top/numerical_recipes.md
-    - "pyMoist_constants": top/pyMoist_constants.md
-    - "radiation_coupling": top/radiation_coupling.md
-    - "redistribute_clouds": top/redistribute_clouds.md
-    - "shared_generic_math": top/shared_generic_math.md
-    - "shared_gt4py_workarounds": top/shared_gt4py_workarounds.md
-    - "shared_incloud_processes": top/shared_incloud_processes.md
+      - "aer_activation": top/aer_activation.md
+      - "constants": top/constants.md
+      - "field_types": top/field_types.md
+      - "numerical_recipes": top/numerical_recipes.md
+      - "pyMoist_constants": top/pyMoist_constants.md
+      - "radiation_coupling": top/radiation_coupling.md
+      - "redistribute_clouds": top/redistribute_clouds.md
+      - "shared_generic_math": top/shared_generic_math.md
+      - "shared_gt4py_workarounds": top/shared_gt4py_workarounds.md
+      - "shared_incloud_processes": top/shared_incloud_processes.md
   - GFDL_1M:
-    - "GFDL_1M": GFDL_1M/GFDL_1M.md
-    - "evap_subl_pdf_core": GFDL_1M/evap_subl_pdf_core.md
+      - "GFDL_1M": GFDL_1M/GFDL_1M.md
+      - "evap_subl_pdf_core": GFDL_1M/evap_subl_pdf_core.md
   - interface:
-    - "cuda_profiler": interface/cuda_profiler.md
-    - "f_py_conversion": interface/f_py_conversion.md
-    - "flags": interface/flags.md
-    - "python_bridge": interface/python_bridge.md
-    - "wrapper": interface/wrapper.md
+      - "cuda_profiler": interface/cuda_profiler.md
+      - "f_py_conversion": interface/f_py_conversion.md
+      - "flags": interface/flags.md
+      - "python_bridge": interface/python_bridge.md
+      - "wrapper": interface/wrapper.md
   - saturation:
-    - "constants": saturation/constants.md
-    - "formulation": saturation/formulation.md
-    - "qsat": saturation/qsat.md
-    - "qsat_ice": saturation/qsat_ice.md
-    - "qsat_liquid": saturation/qsat_liquid.md
-    - "table": saturation/table.md
+      - "constants": saturation/constants.md
+      - "formulation": saturation/formulation.md
+      - "qsat": saturation/qsat.md
+      - "qsat_ice": saturation/qsat_ice.md
+      - "qsat_liquid": saturation/qsat_liquid.md
+      - "table": saturation/table.md
   - UW:
-    - "compute_uwshcu": UW/compute_uwshcu.md
-    - "config": UW/config.md
-    - "temporaries": UW/temporaries.md
-    - "uwshcu_functions": UW/uwshcu_functions.md
+      - "compute_uwshcu": UW/compute_uwshcu.md
+      - "config": UW/config.md
+      - "temporaries": UW/temporaries.md
+      - "uwshcu_functions": UW/uwshcu_functions.md

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/mkdocs.yml
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/mkdocs.yml
@@ -1,16 +1,53 @@
 site_name: pyMoist Documentation
 theme:
   name: material
+  features:
+    - search.suggest
+    - search.highlight
+    - search.share
 
 plugins:
   - search
   - mkdocstrings:
       handlers:
         python:
-          paths: [.]  # Adjust this path to where your Python modules are
+          paths: [./pyMoist]  # Adjust this path to where your Python modules are
           options:
+            # Filter out anything that starts with an underscore.
+            # Exceptions for `__init__(...)` and `__call__(...)` methods.
+            filters: ["!^_", "^__init__$", "^__call__$"]
+            group_by_category: true
+            members_order: source
+            show_if_no_docstring: true
             show_source: false
-            show_root_heading: false
+
+markdown_extensions:
+  # simple glossary file
+  - abbr
+  # support for colored notes / warnings / tips / examples
+  - admonition
+  # support for "definition lists" (<dl>)
+  - def_list
+  # support for footnotes
+  - footnotes
+  # support for emojis
+  - pymdownx.emoji
+  # support for syntax highlighting
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      auto_append:
+        # hover tooltips for abbreviations (simple glossary)
+        - docs/includes/glossary.md
+  - pymdownx.superfences:
+      custom_fences:
+      # support for mermaid graphs
+        - name: mermaid
+          class: mermaid
+          format: python/name:pymdownx.superfences.fence_code_format
 
 nav:
   - Home: index.md
@@ -18,6 +55,7 @@ nav:
       - "aer_activation": top/aer_activation.md
       - "constants": top/constants.md
       - "field_types": top/field_types.md
+      - "interpolations": top/interpolations.md
       - "numerical_recipes": top/numerical_recipes.md
       - "pyMoist_constants": top/pyMoist_constants.md
       - "radiation_coupling": top/radiation_coupling.md
@@ -26,21 +64,62 @@ nav:
       - "shared_gt4py_workarounds": top/shared_gt4py_workarounds.md
       - "shared_incloud_processes": top/shared_incloud_processes.md
   - GFDL_1M:
+      - "driver":
+          - "check_flags": GFDL_1M/driver/check_flags.md
+          - "config_constants": GFDL_1M/driver/config_constants.md
+          - "constants": GFDL_1M/driver/constants.md
+          - "driver": GFDL_1M/driver/driver.md
+          - "fall_speed": GFDL_1M/driver/fall_speed.md
+          - "finish": GFDL_1M/driver/finish.md
+          - "ice_cloud": GFDL_1M/driver/ice_cloud.md
+          - "locals": GFDL_1M/driver/locals.md
+          - "masks": GFDL_1M/driver/masks.md
+          - "sat_tables": GFDL_1M/driver/sat_tables.md
+          - "setup": GFDL_1M/driver/setup.md
+          - "stencils": GFDL_1M/driver/stencils.md
+          - "terminal_fall": GFDL_1M/driver/terminal_fall.md
+          - "warm_rain": GFDL_1M/driver/warm_rain.md
+      - "PhaseChange":
+          - "config": GFDL_1M/PhaseChange/config.md
+          - "constants": GFDL_1M/PhaseChange/constants.md
+          - "evaporate": GFDL_1M/PhaseChange/evaporate.md
+          - "hydrostatic_pdf": GFDL_1M/PhaseChange/hydrostatic_pdf.md
+          - "melt_freeze": GFDL_1M/PhaseChange/melt_freeze.md
+          - "phase_change": GFDL_1M/PhaseChange/phase_change.md
+          - "rh_calculations": GFDL_1M/PhaseChange/rh_calculations.md
+          - "sublimate": GFDL_1M/PhaseChange/sublimate.md
+      - "config": GFDL_1M/config.md
+      - "finalize": GFDL_1M/finalize.md
       - "GFDL_1M": GFDL_1M/GFDL_1M.md
-      - "evap_subl_pdf_core": GFDL_1M/evap_subl_pdf_core.md
+      - "locals": GFDL_1M/locals.md
+      - "radiation_coupling": GFDL_1M/radiation_coupling.md
+      - "setup": GFDL_1M/setup.md
+      - "state": GFDL_1M/state.md
+      - "stencils": GFDL_1M/stencils.md
   - interface:
+      - "cffi_lib":
+          - "interface": interface/cffi_lib/interface.md
+      - "mapl":
+          - "managed_state": interface/mapl/managed_state.md
+          - "memory_factory": interface/mapl/memory_factory.md
+      - "build_helper": interface/build_helper.md
       - "cuda_profiler": interface/cuda_profiler.md
       - "f_py_conversion": interface/f_py_conversion.md
       - "flags": interface/flags.md
+      - "gfdl_1m": interface/gfdl_1m.md
+      - "memory_space": interface/memory_space.md
       - "python_bridge": interface/python_bridge.md
       - "wrapper": interface/wrapper.md
-  - saturation:
-      - "constants": saturation/constants.md
-      - "formulation": saturation/formulation.md
-      - "qsat": saturation/qsat.md
-      - "qsat_ice": saturation/qsat_ice.md
-      - "qsat_liquid": saturation/qsat_liquid.md
-      - "table": saturation/table.md
+  - saturation_tables:
+      - "tables":
+          - "constants": saturation_tables/tables/constants.md
+          - "ice_exact": saturation_tables/tables/ice_exact.md
+          - "liquid_exact": saturation_tables/tables/liquid_exact.md
+          - "main": saturation_tables/tables/main.md
+      - "constants": saturation_tables/constants.md
+      - "formulation": saturation_tables/formulation.md
+      - "qsat_functions": saturation_tables/qsat_functions.md
+      - "types": saturation_tables/types.md
   - UW:
       - "compute_uwshcu": UW/compute_uwshcu.md
       - "config": UW/config.md

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/PhaseChange/evaporate.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/PhaseChange/evaporate.py
@@ -31,9 +31,9 @@ def evaporate(
         )  # (100's <-^ convert from mbar to Pa)
         rhx = min(vapor / saturation_specific_humidity, 1.00)
         k1 = (
-            (constants.MAPL_LATENT_HEAT_VAPORIZATION ** 2)
+            (constants.MAPL_LATENT_HEAT_VAPORIZATION**2)
             * constants.RHO_W
-            / (constants.K_COND * constants.MAPL_RVAP * (t ** 2))
+            / (constants.K_COND * constants.MAPL_RVAP * (t**2))
         )
         k2 = constants.MAPL_RVAP * t * constants.RHO_W / (constants.DIFFU * (1000.0 / p_mb) * es)
         # Here, DIFFU is given for 1000 mb so 1000./PLmb accounts
@@ -44,7 +44,7 @@ def evaporate(
             qcm = 0.0
         radius = cloud_effective_radius_liquid(p_mb, t, qcm, liquid_concentration)
         if rhx < rh_crit and radius > 0.0:
-            evap = CCW_EVAP_EFF * convective_liquid * DT_MOIST * (rh_crit - rhx) / ((k1 + k2) * radius ** 2)
+            evap = CCW_EVAP_EFF * convective_liquid * DT_MOIST * (rh_crit - rhx) / ((k1 + k2) * radius**2)
             evap = min(evap, convective_liquid)
         else:
             evap = 0.0

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/PhaseChange/hydrostatic_pdf.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/PhaseChange/hydrostatic_pdf.py
@@ -197,8 +197,8 @@ def hydrostatic_pdf(
         t (inout): temperature
         large_scale_cloud_fraction (inout): large scale cloud fraction
         convective_cloud_fraction (inout): convective cloud fraction
-        nacti (in): ice concentration
-        rhx (inout): relative humidity after pdf
+        ice_concentration (in): ice concentration
+        relative_humidity (inout): relative humidity after pdf
         ese: saturation tables
         esw: saturation tables
         esx: saturation tables

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/PhaseChange/sublimate.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/PhaseChange/sublimate.py
@@ -31,9 +31,9 @@ def sublimate(
         )  # (100s <-^ convert from mbar to Pa)
         rhx = min(vapor / saturation_specific_humidity, 1.00)
         k1 = (
-            (constants.MAPL_LATENT_HEAT_VAPORIZATION ** 2)
+            (constants.MAPL_LATENT_HEAT_VAPORIZATION**2)
             * constants.RHO_I
-            / (constants.K_COND * constants.MAPL_RVAP * (t ** 2))
+            / (constants.K_COND * constants.MAPL_RVAP * (t**2))
         )
         k2 = constants.MAPL_RVAP * t * constants.RHO_I / (constants.DIFFU * (1000.0 / p_mb) * es)
         # Here, DIFFU is given for 1000 mb so 1000./PLmb accounts
@@ -44,7 +44,7 @@ def sublimate(
             qcm = 0.0
         radius = cloud_effective_radius_ice(p_mb, t, qcm)
         if rhx < rh_crit and radius > 0.0:
-            subl = CCI_EVAP_EFF * convective_ice * DT_MOIST * (rh_crit - rhx) / ((k1 + k2) * radius ** 2)
+            subl = CCI_EVAP_EFF * convective_ice * DT_MOIST * (rh_crit - rhx) / ((k1 + k2) * radius**2)
             subl = min(subl, convective_ice)
         else:
             subl = 0.0

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/ice_cloud.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/ice_cloud.py
@@ -182,7 +182,7 @@ def smow_melt(
     reference Fortran: gfdl_cloud_microphys.F90: function smlt
     """
     smow_melt = (c_0 * tc / rho - c_1 * dqs) * (
-        c_2 * sqrt(qsrho) + c_3 * qsrho ** 0.65625 * sqrt(rhofac)
+        c_2 * sqrt(qsrho) + c_3 * qsrho**0.65625 * sqrt(rhofac)
     ) + c_4 * tc * (psacw + psacr)
 
     return smow_melt
@@ -209,7 +209,7 @@ def graupel_melt(
     reference Fortran: gfdl_cloud_microphys.F90: function gmlt
     """
     graupel_melt = (c_0 * tc / rho - c_1 * dqs) * (
-        c_2 * sqrt(qgrho) + c_3 * qgrho ** 0.6875 / rho ** 0.25
+        c_2 * sqrt(qgrho) + c_3 * qgrho**0.6875 / rho**0.25
     ) + c_4 * tc * (pgacw + pgacr)
 
     return graupel_melt
@@ -1048,7 +1048,7 @@ def subgrid_z_proc(
                     * dq
                     * 349138.78
                     * exp(0.875 * log(ice * density))
-                    / (qsi * density * lat2 / (0.0243 * constants.RVGAS * t ** 2) + 4.42478e4)
+                    / (qsi * density * lat2 / (0.0243 * constants.RVGAS * t**2) + 4.42478e4)
                 )
             else:
                 pidep = 0.0

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/terminal_fall.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/driver/terminal_fall.py
@@ -527,7 +527,7 @@ class GFDL1MTerminalFall(NDSLRuntime):
         Args:
             t (inout): temperature (K)
             w (inout): vertical motion (m/s)
-            mixing_ratio_vapo (inout): water vapor mixing ratio (kg/kg)
+            mixing_ratio_vapor (inout): water vapor mixing ratio (kg/kg)
             mixing_ratio_liquid (inout): liquid water mixing ratio (kg/kg)
             mixing_ratio_rain (inout): rain mixing ratio (kg/kg)
             mixing_ratio_graupel (inout): graupel mixing ratio (kg/kg)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/setup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/GFDL_1M/setup.py
@@ -111,7 +111,7 @@ def find_lcl_level(
         vapor (in): water vapor mixing radio (kg/kg)
         ese (in): saturation vapor pressure table, details unknown
         esx (in): saturation vapor pressure table, details unknown
-        k_lcl (out): LCL level
+        lcl_level (out): LCL level
     """
     from __externals__ import k_end
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
@@ -1272,7 +1272,7 @@ def find_cumulus_characteristics(
                 qpert_out = 0.0
                 tpert_out = 0.0
                 if wstar > 0.001:
-                    wstar = 1.0 * wstar ** 0.3333
+                    wstar = 1.0 * wstar**0.3333
                     tpert_out = thlsrc_fac * shfx / (zrho * wstar * constants.MAPL_CP)  # K
                     qpert_out = qtsrc_fac * evap / (zrho * wstar)  # kg kg-1
                     qpert_out = max(min(qpert_out, 0.02 * qt0.at(K=0)), 0.0)  # limit to 1% of QT
@@ -1651,7 +1651,14 @@ def compute_cin_cinlcl(
                 cin = cinlcl
 
                 # ----- LCL to Top
-                (thj, qvj, qlj, qij, qse, id_check,) = conden(
+                (
+                    thj,
+                    qvj,
+                    qlj,
+                    qij,
+                    qse,
+                    id_check,
+                ) = conden(
                     pifc0[0, 0, 1],
                     thlsrc,
                     qtsrc,
@@ -1703,7 +1710,14 @@ def compute_cin_cinlcl(
             else:
                 if not condensation and K > klcl and not stop_cin:
                     thvubot = thvutop[0, 0, -1]
-                    (thj, qvj, qlj, qij, qse, id_check,) = conden(
+                    (
+                        thj,
+                        qvj,
+                        qlj,
+                        qij,
+                        qse,
+                        id_check,
+                    ) = conden(
                         pifc0[0, 0, 1],
                         thlsrc,
                         qtsrc,
@@ -1754,7 +1768,14 @@ def compute_cin_cinlcl(
         # Case 2. LCL height is lower than PBL interface ( 'pLCL > ps0(kinv-1)')
         if not condensation and klcl < kinv - 1 and not stop_cin:
             if not stop_cin and K >= kinv - 1:
-                (thj, qvj, qlj, qij, qse, id_check,) = conden(
+                (
+                    thj,
+                    qvj,
+                    qlj,
+                    qij,
+                    qse,
+                    id_check,
+                ) = conden(
                     pifc0,
                     thlsrc,
                     qtsrc,
@@ -1787,7 +1808,14 @@ def compute_cin_cinlcl(
 
                 if not condensation and not stop_cin:
                     thvubot = thj * (1.0 + zvir * qvj - qlj - qij)
-                    (thj, qvj, qlj, qij, qse, id_check,) = conden(
+                    (
+                        thj,
+                        qvj,
+                        qlj,
+                        qij,
+                        qse,
+                        id_check,
+                    ) = conden(
                         pifc0[0, 0, 1],
                         thlsrc,
                         qtsrc,
@@ -2551,7 +2579,7 @@ def calc_cumulus_base_mass_flux(
                 rho0inv = pifc0.at(K=kbelow) / (
                     constants.MAPL_RDRY * thv0top.at(K=kbelow - 1) * exnifc0.at(K=kbelow)
                 )
-                cbmf = (rho0inv * sigmaw / 2.5066) * exp(-(mu ** 2))
+                cbmf = (rho0inv * sigmaw / 2.5066) * exp(-(mu**2))
 
                 # 1. 'cbmf' constraint
                 cbmflimit = 0.9 * dp0.at(K=kbelow - 1) / constants.MAPL_GRAV / dt
@@ -2568,8 +2596,8 @@ def calc_cumulus_base_mass_flux(
                     max(
                         0.0,
                         2.0
-                        * (exp(-(mu ** 2)) / 2.5066) ** 2
-                        * (1.0 / float32(erfc(mu)) ** 2 - 0.25 / rmaxfrac ** 2),
+                        * (exp(-(mu**2)) / 2.5066) ** 2
+                        * (1.0 / float32(erfc(mu)) ** 2 - 0.25 / rmaxfrac**2),
                     )
                 )
 
@@ -2583,8 +2611,8 @@ def calc_cumulus_base_mass_flux(
             # Note that final 'cbmf' here is obtained in such that 'ufrcinv' and
             # 'ufrclcl' are smaller than ufrcmax with no instability.
 
-            cbmf = rkfre * (rho0inv * sigmaw / 2.5066) * exp((-(mu ** 2)))
-            winv = sigmaw * (2.0 / 2.5066) * exp(-(mu ** 2)) / float32(erfc(mu))
+            cbmf = rkfre * (rho0inv * sigmaw / 2.5066) * exp((-(mu**2)))
+            winv = sigmaw * (2.0 / 2.5066) * exp(-(mu**2)) / float32(erfc(mu))
             ufrcinv = cbmf / winv / rho0inv
 
 
@@ -3309,7 +3337,7 @@ def buoyancy_sorting(
                                         * rbuoy
                                         * constants.MAPL_GRAV
                                         * cridis
-                                        / wue ** 2.0
+                                        / wue**2.0
                                         * (1.0 - thvj / thv0j),
                                     ),
                                 )
@@ -3370,7 +3398,7 @@ def buoyancy_sorting(
                                                 (1.0 / (1.0 - xsat)) * thvxsat
                                             )
 
-                                        aquad = wue ** 2
+                                        aquad = wue**2
                                         bquad = (
                                             2.0
                                             * rbuoy
@@ -3378,7 +3406,7 @@ def buoyancy_sorting(
                                             * cridis
                                             * (thv_x1 - thv_x0)
                                             / thv0j
-                                            - 2.0 * wue ** 2
+                                            - 2.0 * wue**2
                                         )
                                         cquad = (
                                             2.0
@@ -3387,10 +3415,10 @@ def buoyancy_sorting(
                                             * cridis
                                             * (thv_x0 - thv0j)
                                             / thv0j
-                                            + wue ** 2
+                                            + wue**2
                                         )
                                         if kk == 1:
-                                            if (bquad ** 2 - 4.0 * aquad * cquad) >= 0.0:
+                                            if (bquad**2 - 4.0 * aquad * cquad) >= 0.0:
                                                 xs1, xs2, status = roots(aquad, bquad, cquad)
                                                 x_cu = min(
                                                     1.0,
@@ -3403,7 +3431,7 @@ def buoyancy_sorting(
                                                 x_cu = xsat
 
                                         else:
-                                            if (bquad ** 2 - 4.0 * aquad * cquad) >= 0.0:
+                                            if (bquad**2 - 4.0 * aquad * cquad) >= 0.0:
                                                 xs1, xs2, status = roots(aquad, bquad, cquad)
                                                 x_en = min(
                                                     1.0,
@@ -3438,8 +3466,8 @@ def buoyancy_sorting(
                             # being, I came back to the original limiter.
 
                             if not condensation:
-                                ee2 = xc ** 2
-                                ud2 = 1.0 - 2.0 * xc + xc ** 2
+                                ee2 = xc**2
+                                ud2 = 1.0 - 2.0 * xc + xc**2
                                 if min(scaleh, mixscale) != 0.0:
                                     rei = (
                                         (
@@ -7070,7 +7098,7 @@ def update_output_variables(
             qidet_outvar = qiten_det
             qlsub_outvar = qlten_sink
             qisub_outvar = qiten_sink
-            ndrop_out = qlten_det / (4188.787 * rdrop ** 3)
+            ndrop_out = qlten_det / (4188.787 * rdrop**3)
             nice_out = qiten_det / (3.0e-10)
             qtflx_outvar = qtflx
             slflx_outvar = slflx

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/uwshcu_functions.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/uwshcu_functions.py
@@ -308,17 +308,17 @@ def compute_mumin2(
     x0: float64 = mulow
     iteration = 0
     while iteration < 10:
-        ex: float64 = exp(-(x0 ** 2))
+        ex: float64 = exp(-(x0**2))
         ef: float64 = erfc(x0)  # Complimentary error fraction function
         exf: float64 = ex / ef
         f: float64 = (
-            float64(0.5) * exf ** 2
+            float64(0.5) * exf**2
             - float64(0.5) * (ex / float64(2.0) / rmaxfrax) ** 2
             - (mulcl * float64(2.5066) / float64(2.0)) ** 2
         )
-        fs: float64 = (float64(2.0) * exf ** 2) * (exf / sqrt(constants.MAPL_PI) - x0) + (
-            float64(0.5) * x0 * ex ** 2
-        ) / (rmaxfrax ** 2)
+        fs: float64 = (float64(2.0) * exf**2) * (exf / sqrt(constants.MAPL_PI) - x0) + (
+            float64(0.5) * x0 * ex**2
+        ) / (rmaxfrax**2)
         x1: float64 = x0 - f / fs
         x0 = x1
         iteration += 1
@@ -601,10 +601,10 @@ def roots(
                 r1 = sqrt(-c / a)
             r2 = -r1
         else:  # Form a*x**2 + b*x + c = 0
-            if (b ** 2 - 4.0 * a * c) < 0.0:  # Failure, no real roots
+            if (b**2 - 4.0 * a * c) < 0.0:  # Failure, no real roots
                 status = 3
             else:
-                q = -0.5 * (b + sign(1.0, b) * sqrt(b ** 2 - 4.0 * a * c))
+                q = -0.5 * (b + sign(1.0, b) * sqrt(b**2 - 4.0 * a * c))
                 r1 = q / a
                 r2 = c / q
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/aer_activation.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/aer_activation.py
@@ -220,16 +220,16 @@ def aer_activation_stencil(
                 sm = (float64(2.0) / sqrt(bibar[0, 0, 0][n])) * (a / (3.0 * rg[0, 0, 0][n])) ** float64(
                     1.5
                 )  # [1]
-                eta = dum ** 3 / (TWOPI * DENH2O * gamma * ni[0, 0, 0][n])  # [1]
-                f1 = float64(0.5) * exp(2.50 * xlogsigm ** 2)  # [1]
+                eta = dum**3 / (TWOPI * DENH2O * gamma * ni[0, 0, 0][n])  # [1]
+                f1 = float64(0.5) * exp(2.50 * xlogsigm**2)  # [1]
                 f2 = float64(1.0) + 0.25 * xlogsigm  # [1]
                 smax = (
                     smax
                     + (
                         f1 * (zeta / eta) ** float64(1.5)
-                        + f2 * (sm ** 2 / (eta + float64(3.0) * zeta)) ** float64(0.75)
+                        + f2 * (sm**2 / (eta + float64(3.0) * zeta)) ** float64(0.75)
                     )
-                    / sm ** 2
+                    / sm**2
                 )  # [1] - eq. (6)
                 n += 1
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/cffi_lib/compute_uwshcu.yaml
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/interface/cffi_lib/compute_uwshcu.yaml
@@ -1,86 +1,86 @@
 type: py_ftn_interface
 name: compute_uwshcu
 functions:
-    init:
-        inputs:
-            ncnst : int
-            k0 : int
-            windsrcavg : int
-    run_compute_uwshcu:
-        inputs:
-            dotransport : int
-            k0 : int
-            windsrcavg : int
-            qtsrchgt : float
-            qtsrc_fac : float
-            thlsrc_fac : float
-            frc_rasn : float
-            rbuoy : float
-            epsvarw : float
-            use_CINcin : int
-            mumin1 : float
-            rmaxfrac : float
-            PGFc : float
-            dt : float
-            niter_xc : int
-            criqc : float
-            rle : float
-            cridist_opt : int
-            mixscale : float
-            rdrag : float
-            rkm : float
-            use_self_detrain : int
-            detrhgt : float
-            use_cumpenent : int
-            rpen : float
-            use_momenflx : int
-            rdrop : float
-            iter_cin : int
-            pifc0_inv : array_float
-            zifc0_inv : array_float
-            pmid0_inv : array_float
-            zmid0_inv : array_float
-            kpbl_inv : array_float
-            exnmid0_inv : array_float
-            exnifc0_inv : array_float
-            dp0_inv : array_float
-            u0_inv : array_float
-            v0_inv : array_float
-            qv0_inv : array_float
-            ql0_inv : array_float
-            qi0_inv : array_float
-            t0_inv : array_float
-            frland_in : array_float
-            tke_inv : array_float
-            rkfre : array_float
-            cush  : array_float
-            shfx : array_float
-            evap : array_float
-            cnvtr : array_float
-            CNV_Tracers : array_float
-        outputs:
-            umf_inv : array_float
-            dcm_inv : array_float
-            qtflx_inv : array_float
-            slflx_inv : array_float
-            uflx_inv : array_float
-            vflx_inv : array_float
-            qvten_inv : array_float
-            qlten_inv : array_float
-            qiten_inv : array_float
-            tten_inv : array_float
-            uten_inv : array_float
-            vten_inv : array_float
-            qrten_inv : array_float
-            qsten_inv : array_float
-            cufrc_inv : array_float
-            fer_inv : array_float
-            fdr_inv : array_float
-            ndrop_inv : array_float
-            nice_inv : array_float
-            qldet_inv : array_float
-            qlsub_inv : array_float
-            qidet_inv : array_float
-            qisub_inv : array_float
-            tpert_out : array_float
-            qpert_out : array_float
+  init:
+    inputs:
+      ncnst: int
+      k0: int
+      windsrcavg: int
+  run_compute_uwshcu:
+    inputs:
+      dotransport: int
+      k0: int
+      windsrcavg: int
+      qtsrchgt: float
+      qtsrc_fac: float
+      thlsrc_fac: float
+      frc_rasn: float
+      rbuoy: float
+      epsvarw: float
+      use_CINcin: int
+      mumin1: float
+      rmaxfrac: float
+      PGFc: float
+      dt: float
+      niter_xc: int
+      criqc: float
+      rle: float
+      cridist_opt: int
+      mixscale: float
+      rdrag: float
+      rkm: float
+      use_self_detrain: int
+      detrhgt: float
+      use_cumpenent: int
+      rpen: float
+      use_momenflx: int
+      rdrop: float
+      iter_cin: int
+      pifc0_inv: array_float
+      zifc0_inv: array_float
+      pmid0_inv: array_float
+      zmid0_inv: array_float
+      kpbl_inv: array_float
+      exnmid0_inv: array_float
+      exnifc0_inv: array_float
+      dp0_inv: array_float
+      u0_inv: array_float
+      v0_inv: array_float
+      qv0_inv: array_float
+      ql0_inv: array_float
+      qi0_inv: array_float
+      t0_inv: array_float
+      frland_in: array_float
+      tke_inv: array_float
+      rkfre: array_float
+      cush: array_float
+      shfx: array_float
+      evap: array_float
+      cnvtr: array_float
+      CNV_Tracers: array_float
+    outputs:
+      umf_inv: array_float
+      dcm_inv: array_float
+      qtflx_inv: array_float
+      slflx_inv: array_float
+      uflx_inv: array_float
+      vflx_inv: array_float
+      qvten_inv: array_float
+      qlten_inv: array_float
+      qiten_inv: array_float
+      tten_inv: array_float
+      uten_inv: array_float
+      vten_inv: array_float
+      qrten_inv: array_float
+      qsten_inv: array_float
+      cufrc_inv: array_float
+      fer_inv: array_float
+      fdr_inv: array_float
+      ndrop_inv: array_float
+      nice_inv: array_float
+      qldet_inv: array_float
+      qlsub_inv: array_float
+      qidet_inv: array_float
+      qisub_inv: array_float
+      tpert_out: array_float
+      qpert_out: array_float

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/numerical_recipes.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/numerical_recipes.py
@@ -160,7 +160,7 @@ def Erf(x: float64) -> float64:
     """
     erf: float64 = float64(0.0)
     if x < float64(0.0e00):
-        erf = float64(-1.0) * GammP(float64(0.5), x ** 2)
+        erf = float64(-1.0) * GammP(float64(0.5), x**2)
     else:
-        erf = GammP(float64(0.5), x ** 2)
+        erf = GammP(float64(0.5), x**2)
     return erf

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/shared_incloud_processes.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/shared_incloud_processes.py
@@ -14,9 +14,7 @@ def ice_fraction_modis(
 ):
     # Use MODIS polynomial from Hu et al, DOI: (10.1029/2009JD012384)
     tc = max(-46.0, min(temp - constants.MAPL_TICE, 46.0))  # convert to celcius and limit range from -46:46 C
-    ptc = (
-        7.6725 + 1.0118 * tc + 0.1422 * tc ** 2 + 0.0106 * tc ** 3 + 0.000339 * tc ** 4 + 0.00000395 * tc ** 5
-    )
+    ptc = 7.6725 + 1.0118 * tc + 0.1422 * tc**2 + 0.0106 * tc**3 + 0.000339 * tc**4 + 0.00000395 * tc**5
     ice_frct = 1.0 - (1.0 / (1.0 + exp(-1 * ptc)))
     return ice_frct
 
@@ -156,14 +154,14 @@ def cloud_effective_radius_ice(
             # the multiplication "-2.0 * log'd result" is performed differently (~60 ULP), despite the log
             # being correct. Needs to be looked into at some point, but not critical for overall performance.
         bb = min(max(bb, -6.0), -2.0)
-        radius = 377.4 + 203.3 * bb + 37.91 * bb ** 2 + 2.3696 * bb ** 3
+        radius = 377.4 + 203.3 * bb + 37.91 * bb**2 + 2.3696 * bb**3
         radius = min(150.0e-6, max(5.0e-6, 1.0e-6 * radius))
     else:
         # Ice cloud effective radius ----- [Sun, 2001]
         tc = temperature - constants.MAPL_TICE
         zfsr = 1.2351 + 0.0105 * tc
-        aa = 45.8966 * (wc ** 0.2214)
-        bb = 0.79570 * (wc ** 0.2535)
+        aa = 45.8966 * (wc**0.2214)
+        bb = 0.79570 * (wc**0.2535)
         radius = zfsr * (aa + bb * (temperature - 83.15))
         radius = min(150.0e-6, max(5.0e-6, 1.0e-6 * radius * 0.64952))
     return radius

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/setup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/setup.py
@@ -10,13 +10,15 @@ with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 test_requirements = ["pytest", "pytest-subtests", "serialbox", "coverage"]
-ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@develop"]
-develop_requirements = test_requirements + ndsl_requirements + ["pre-commit"]
+ndsl_requirements = ["ndsl @ git+https://github.com/NOAA-GFDL/NDSL.git@2026.01.00"]
+docs_requirements = ["mkdocs-material", "mkdocstrings[python]", "mkdocs-exclude"]
+develop_requirements = test_requirements + ndsl_requirements + docs_requirements + ["pre-commit"]
 
 extras_requires = {
-    "test": test_requirements,
-    "ndsl": ndsl_requirements,
     "develop": develop_requirements,
+    "docs": docs_requirements,
+    "ndsl": ndsl_requirements,
+    "test": test_requirements,
 }
 
 setup(

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_DriverFinish.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_DriverFinish.py
@@ -212,60 +212,60 @@ class TranslateGFDL_1M_DriverFinish(TranslateFortranData2Py):
         for key in self.out_vars:
             outputs[key] = np.full((nx, ny, nz, ntimes), np.nan)
 
-        outputs["driver_local_dry_mixing_ratio_vapor_unmodified_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.vapor.field[:]
-        outputs["driver_local_dry_mixing_ratio_liquid_unmodified_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.liquid.field[:]
-        outputs["driver_local_dry_mixing_ratio_rain_unmodified_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.rain.field[:]
-        outputs["driver_local_dry_mixing_ratio_ice_unmodified_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.ice.field[:]
-        outputs["driver_local_dry_mixing_ratio_rain_unmodified_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.rain.field[:]
-        outputs["driver_local_dry_mixing_ratio_graupel_unmodified_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.graupel.field[:]
-        outputs["driver_local_cloud_fraciton_unmodified_driverfinish"][
-            :, :, :, 0
-        ] = state.radiation_field.cloud_fraction.field[:]
-        outputs["driver_local_dry_mixing_ratio_vapor_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.vapor.field[:]
-        outputs["driver_local_dry_mixing_ratio_liquid_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.liquid.field[:]
-        outputs["driver_local_dry_mixing_ratio_rain_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.rain.field[:]
-        outputs["driver_local_dry_mixing_ratio_ice_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.ice.field[:]
-        outputs["driver_local_dry_mixing_ratio_snow_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.snow.field[:]
-        outputs["driver_local_dry_mixing_ratio_graupel_driverfinish"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.graupel.field[:]
+        outputs["driver_local_dry_mixing_ratio_vapor_unmodified_driverfinish"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.vapor.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_liquid_unmodified_driverfinish"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.liquid.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_rain_unmodified_driverfinish"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.rain.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_ice_unmodified_driverfinish"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.ice.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_rain_unmodified_driverfinish"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.rain.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_graupel_unmodified_driverfinish"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.graupel.field[:]
+        )
+        outputs["driver_local_cloud_fraciton_unmodified_driverfinish"][:, :, :, 0] = (
+            state.radiation_field.cloud_fraction.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_vapor_driverfinish"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.vapor.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_liquid_driverfinish"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.liquid.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_rain_driverfinish"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.rain.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_ice_driverfinish"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.ice.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_snow_driverfinish"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.snow.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_graupel_driverfinish"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.graupel.field[:]
+        )
         outputs["local_dvapordt_driver_driverfinish"][:, :, :, 0] = locals_.driver_tendencies.dvapordt.field[
             :
         ]
-        outputs["local_dliquiddt_driver_driverfinish"][
-            :, :, :, 0
-        ] = locals_.driver_tendencies.dliquiddt.field[:]
+        outputs["local_dliquiddt_driver_driverfinish"][:, :, :, 0] = (
+            locals_.driver_tendencies.dliquiddt.field[:]
+        )
         outputs["local_draindt_driver_driverfinish"][:, :, :, 0] = locals_.driver_tendencies.draindt.field[:]
         outputs["local_dicedt_driver_driverfinish"][:, :, :, 0] = locals_.driver_tendencies.dicedt.field[:]
         outputs["local_dsnowdt_driver_driverfinish"][:, :, :, 0] = locals_.driver_tendencies.dsnowdt.field[:]
-        outputs["local_dgraupeldt_driver_driverfinish"][
-            :, :, :, 0
-        ] = locals_.driver_tendencies.dgraupeldt.field[:]
-        outputs["local_dcloudfractiondt_driver_driverfinish"][
-            :, :, :, 0
-        ] = locals_.driver_tendencies.dcloudfractiondt.field[:]
+        outputs["local_dgraupeldt_driver_driverfinish"][:, :, :, 0] = (
+            locals_.driver_tendencies.dgraupeldt.field[:]
+        )
+        outputs["local_dcloudfractiondt_driver_driverfinish"][:, :, :, 0] = (
+            locals_.driver_tendencies.dcloudfractiondt.field[:]
+        )
         outputs["driver_local_t_unmodified_driverfinish"][:, :, :, 0] = state.t.field[:]
         outputs["driver_local_t_driverfinish"][:, :, :, 0] = driver_locals.t.field[:]
         outputs["local_dtdt_driver_driverfinish"][:, :, :, 0] = locals_.driver_tendencies.dtdt.field[:]
@@ -283,8 +283,8 @@ class TranslateGFDL_1M_DriverFinish(TranslateFortranData2Py):
         outputs["surface_precip_rain_driverfinish"][:, :, 0, 0] = state.precipitation_at_surface.rain.field[:]
         outputs["surface_precip_snow_driverfinish"][:, :, 0, 0] = state.precipitation_at_surface.snow.field[:]
         outputs["surface_precip_ice_driverfinish"][:, :, 0, 0] = state.precipitation_at_surface.ice.field[:]
-        outputs["surface_precip_graupel_driverfinish"][
-            :, :, 0, 0
-        ] = state.precipitation_at_surface.graupel.field[:]
+        outputs["surface_precip_graupel_driverfinish"][:, :, 0, 0] = (
+            state.precipitation_at_surface.graupel.field[:]
+        )
 
         return outputs

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_DriverSetup.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_DriverSetup.py
@@ -248,55 +248,55 @@ class TranslateGFDL_1M_DriverSetup(TranslateFortranData2Py):
 
         outputs["t_driversetup"][:, :, :, 0] = state.t.field[:]
         outputs["local_dp_driversetup"][:, :, :, 0] = locals_.dp.field[:]
-        outputs["critical_relative_humidity_for_pdf_driversetup"][
-            :, :, :, 0
-        ] = state.critical_relative_humidity_for_pdf.field[:]
+        outputs["critical_relative_humidity_for_pdf_driversetup"][:, :, :, 0] = (
+            state.critical_relative_humidity_for_pdf.field[:]
+        )
         outputs["radiation_vapor_driversetup"][:, :, :, 0] = state.radiation_field.vapor.field[:]
         outputs["radiation_liquid_driversetup"][:, :, :, 0] = state.radiation_field.liquid.field[:]
         outputs["radiation_ice_driversetup"][:, :, :, 0] = state.radiation_field.ice.field[:]
         outputs["radiation_rain_driversetup"][:, :, :, 0] = state.radiation_field.rain.field[:]
         outputs["radiation_snow_driversetup"][:, :, :, 0] = state.radiation_field.snow.field[:]
         outputs["radiation_graupel_driversetup"][:, :, :, 0] = state.radiation_field.graupel.field[:]
-        outputs["radiation_cloud_fraction_driversetup"][
-            :, :, :, 0
-        ] = state.radiation_field.cloud_fraction.field[:]
+        outputs["radiation_cloud_fraction_driversetup"][:, :, :, 0] = (
+            state.radiation_field.cloud_fraction.field[:]
+        )
         outputs["total_concentration_driversetup"][:, :, :, 0] = locals_.total_concentration.field[:]
-        outputs["driver_local_dry_mixing_ratio_vapor_unmodified_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.vapor.field[:]
-        outputs["driver_local_dry_mixing_ratio_liquid_unmodified_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.liquid.field[:]
-        outputs["driver_local_dry_mixing_ratio_rain_unmodified_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.rain.field[:]
-        outputs["driver_local_dry_mixing_ratio_ice_unmodified_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.ice.field[:]
-        outputs["driver_local_dry_mixing_ratio_snow_unmodified_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.snow.field[:]
-        outputs["driver_local_dry_mixing_ratio_graupel_unmodified_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.unmodified.mixing_ratio.graupel.field[:]
-        outputs["driver_local_dry_mixing_ratio_vapor_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.vapor.field[:]
-        outputs["driver_local_dry_mixing_ratio_liquid_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.liquid.field[:]
-        outputs["driver_local_dry_mixing_ratio_rain_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.rain.field[:]
-        outputs["driver_local_dry_mixing_ratio_ice_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.ice.field[:]
-        outputs["driver_local_dry_mixing_ratio_snow_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.snow.field[:]
-        outputs["driver_local_dry_mixing_ratio_graupel_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.dry_air_mixing_ratio.graupel.field[:]
+        outputs["driver_local_dry_mixing_ratio_vapor_unmodified_driversetup"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.vapor.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_liquid_unmodified_driversetup"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.liquid.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_rain_unmodified_driversetup"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.rain.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_ice_unmodified_driversetup"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.ice.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_snow_unmodified_driversetup"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.snow.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_graupel_unmodified_driversetup"][:, :, :, 0] = (
+            driver_locals.unmodified.mixing_ratio.graupel.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_vapor_driversetup"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.vapor.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_liquid_driversetup"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.liquid.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_rain_driversetup"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.rain.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_ice_driversetup"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.ice.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_snow_driversetup"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.snow.field[:]
+        )
+        outputs["driver_local_dry_mixing_ratio_graupel_driversetup"][:, :, :, 0] = (
+            driver_locals.dry_air_mixing_ratio.graupel.field[:]
+        )
         outputs["driver_local_cloud_fraction_driversetup"][:, :, :, 0] = driver_locals.cloud_fraction.field[:]
         outputs["local_dz_drivesetup"][:, :, :, 0] = locals_.layer_height_above_surface.field[:]
         outputs["u_driversetup"][:, :, :, 0] = state.u.field[:]
@@ -304,9 +304,9 @@ class TranslateGFDL_1M_DriverSetup(TranslateFortranData2Py):
         outputs["w_driversetup"][:, :, :, 0] = state.vertical_motion.velocity.field[:]
         outputs["driver_local_t_driversetup"][:, :, :, 0] = driver_locals.t.field[:]
         outputs["driver_local_dp_driversetup"][:, :, :, 0] = driver_locals.dp.field[:]
-        outputs["driver_local_density_unmodified_driversetup"][
-            :, :, :, 0
-        ] = driver_locals.density_unmodified.field[:]
+        outputs["driver_local_density_unmodified_driversetup"][:, :, :, 0] = (
+            driver_locals.density_unmodified.field[:]
+        )
         outputs["driver_local_p_dry_driversetup"][:, :, :, 0] = driver_locals.p_dry.field[:]
         outputs["driver_local_mass_driversetup"][:, :, :, 0] = driver_locals.mass.field[:]
         outputs["driver_local_u_driversetup"][:, :, :, 0] = driver_locals.u.field[:]
@@ -315,33 +315,33 @@ class TranslateGFDL_1M_DriverSetup(TranslateFortranData2Py):
         outputs["driver_local_ccn_driversetup"][:, :, :, 0] = driver_locals.ccn.field[:]
         outputs["driver_local_c_praut_driversetup"][:, :, :, 0] = driver_locals.c_praut.field[:]
         outputs["driver_local_rh_limited_driversetup"][:, :, :, 0] = driver_locals.rh_limited.field[:]
-        outputs["non_anvil_large_scale_liquid_precip_flux_driversetup"][
-            :, :, :, 0
-        ] = state.non_anvil_large_scale.liquid_precip_flux.field[:, :, 0:-1]
-        outputs["non_anvil_large_scale_ice_precip_flux_driversetup"][
-            :, :, :, 0
-        ] = state.non_anvil_large_scale.ice_precip_flux.field[:, :, 0:-1]
-        outputs["non_anvil_large_scale_evaporation_driversetup"][
-            :, :, :, 0
-        ] = state.non_anvil_large_scale.evaporation.field[:]
-        outputs["non_anvil_large_scale_sublimation_driversetup"][
-            :, :, :, 0
-        ] = state.non_anvil_large_scale.sublimation.field[:]
+        outputs["non_anvil_large_scale_liquid_precip_flux_driversetup"][:, :, :, 0] = (
+            state.non_anvil_large_scale.liquid_precip_flux.field[:, :, 0:-1]
+        )
+        outputs["non_anvil_large_scale_ice_precip_flux_driversetup"][:, :, :, 0] = (
+            state.non_anvil_large_scale.ice_precip_flux.field[:, :, 0:-1]
+        )
+        outputs["non_anvil_large_scale_evaporation_driversetup"][:, :, :, 0] = (
+            state.non_anvil_large_scale.evaporation.field[:]
+        )
+        outputs["non_anvil_large_scale_sublimation_driversetup"][:, :, :, 0] = (
+            state.non_anvil_large_scale.sublimation.field[:]
+        )
 
         for k in range(nz):
-            outputs["driver_local_one_minus_sigma_driversetup"][
-                :, :, k, 0
-            ] = driver_locals.one_minus_sigma.field[:]
+            outputs["driver_local_one_minus_sigma_driversetup"][:, :, k, 0] = (
+                driver_locals.one_minus_sigma.field[:]
+            )
             outputs["area_driversetup"][:, :, k, 0] = state.area.field[:]
-            outputs["surface_precip_rain_driversetup"][
-                :, :, k, 0
-            ] = state.precipitation_at_surface.rain.field[:]
-            outputs["surface_precip_snow_driversetup"][
-                :, :, k, 0
-            ] = state.precipitation_at_surface.snow.field[:]
-            outputs["surface_precip_graupel_driversetup"][
-                :, :, k, 0
-            ] = state.precipitation_at_surface.graupel.field[:]
+            outputs["surface_precip_rain_driversetup"][:, :, k, 0] = (
+                state.precipitation_at_surface.rain.field[:]
+            )
+            outputs["surface_precip_snow_driversetup"][:, :, k, 0] = (
+                state.precipitation_at_surface.snow.field[:]
+            )
+            outputs["surface_precip_graupel_driversetup"][:, :, k, 0] = (
+                state.precipitation_at_surface.graupel.field[:]
+            )
             outputs["surface_precip_ice_driversetup"][:, :, k, 0] = state.precipitation_at_surface.ice.field[
                 :
             ]

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_FallSpeed.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_FallSpeed.py
@@ -138,33 +138,33 @@ class TranslateGFDL_1M_FallSpeed(TranslateFortranData2Py):
             # fill the output arrays so that all calls are tested
             outputs["driver_local_p_dry_fallspeed"][:, :, :, n] = driver_locals.p_dry.field[:]
             outputs["driver_local_density_fallspeed"][:, :, :, n] = driver_locals.density.field[:]
-            outputs["driver_local_dry_mixing_ratio_snow_fallspeed"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.snow.field[:]
-            outputs["driver_local_dry_mixing_ratio_ice_fallspeed"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.ice.field[:]
-            outputs["driver_local_dry_mixing_ratio_graupel_fallspeed"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.graupel.field[:]
-            outputs["driver_local_dry_mixing_ratio_liquid_fallspeed"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.liquid.field[:]
-            outputs["driver_local_terminal_speed_ice_fallspeed"][
-                :, :, :, n
-            ] = driver_locals.terminal_speed.ice.field[:]
-            outputs["driver_local_terminal_speed_snow_fallspeed"][
-                :, :, :, n
-            ] = driver_locals.terminal_speed.snow.field[:]
-            outputs["driver_local_terminal_speed_graupel_fallspeed"][
-                :, :, :, n
-            ] = driver_locals.terminal_speed.graupel.field[:]
+            outputs["driver_local_dry_mixing_ratio_snow_fallspeed"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.snow.field[:]
+            )
+            outputs["driver_local_dry_mixing_ratio_ice_fallspeed"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.ice.field[:]
+            )
+            outputs["driver_local_dry_mixing_ratio_graupel_fallspeed"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.graupel.field[:]
+            )
+            outputs["driver_local_dry_mixing_ratio_liquid_fallspeed"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.liquid.field[:]
+            )
+            outputs["driver_local_terminal_speed_ice_fallspeed"][:, :, :, n] = (
+                driver_locals.terminal_speed.ice.field[:]
+            )
+            outputs["driver_local_terminal_speed_snow_fallspeed"][:, :, :, n] = (
+                driver_locals.terminal_speed.snow.field[:]
+            )
+            outputs["driver_local_terminal_speed_graupel_fallspeed"][:, :, :, n] = (
+                driver_locals.terminal_speed.graupel.field[:]
+            )
             outputs["driver_local_t_fallspeed"][:, :, :, n] = driver_locals.t.field[:]
             outputs["driver_local_dz_unmodified_fallspeed"][:, :, :, n] = locals.dz.field[:]
             outputs["driver_local_dz_fallspeed"][:, :, :, n] = driver_locals.dz.field[:]
-            outputs["driver_local_density_unmodified_fallspeed"][
-                :, :, :, n
-            ] = driver_locals.density_unmodified.field[:]
+            outputs["driver_local_density_unmodified_fallspeed"][:, :, :, n] = (
+                driver_locals.density_unmodified.field[:]
+            )
             outputs["driver_local_density_factor_fallspeed"][:, :, :, n] = driver_locals.density_factor.field[
                 :
             ]

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_IceCloud.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/GFDL_1M/driver/translate_GFDL_1M_IceCloud.py
@@ -150,44 +150,44 @@ class TranslateGFDL_1M_IceCloud(TranslateFortranData2Py):
             outputs["driver_local_t_icecloud"][:, :, :, n] = driver_locals.t.field[:]
             outputs["driver_local_p_dry_icecloud"][:, :, :, n] = driver_locals.p_dry.field[:]
             outputs["driver_local_dp_icecloud"][:, :, :, n] = driver_locals.dp.field[:]
-            outputs["driver_local_dry_mixing_ratio_vapor_icecloud"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.vapor.field[:]
-            outputs["driver_local_dry_mixing_ratio_liquid_icecloud"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.liquid.field[:]
-            outputs["driver_local_dry_mixing_ratio_rain_icecloud"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.rain.field[:]
-            outputs["driver_local_dry_mixing_ratio_ice_icecloud"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.ice.field[:]
-            outputs["driver_local_dry_mixing_ratio_snow_icecloud"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.snow.field[:]
-            outputs["driver_local_dry_mixing_ratio_graupel_icecloud"][
-                :, :, :, n
-            ] = driver_locals.dry_air_mixing_ratio.graupel.field[:]
+            outputs["driver_local_dry_mixing_ratio_vapor_icecloud"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.vapor.field[:]
+            )
+            outputs["driver_local_dry_mixing_ratio_liquid_icecloud"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.liquid.field[:]
+            )
+            outputs["driver_local_dry_mixing_ratio_rain_icecloud"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.rain.field[:]
+            )
+            outputs["driver_local_dry_mixing_ratio_ice_icecloud"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.ice.field[:]
+            )
+            outputs["driver_local_dry_mixing_ratio_snow_icecloud"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.snow.field[:]
+            )
+            outputs["driver_local_dry_mixing_ratio_graupel_icecloud"][:, :, :, n] = (
+                driver_locals.dry_air_mixing_ratio.graupel.field[:]
+            )
             outputs["driver_local_cloud_fraction_icecloud"][:, :, :, n] = driver_locals.cloud_fraction.field[
                 :
             ]
-            outputs["driver_local_terminal_speed_snow_icecloud"][
-                :, :, :, n
-            ] = driver_locals.terminal_speed.snow.field[:]
-            outputs["driver_local_terminal_speed_graupel_icecloud"][
-                :, :, :, n
-            ] = driver_locals.terminal_speed.graupel.field[:]
-            outputs["driver_local_terminal_speed_rain_icecloud"][
-                :, :, :, n
-            ] = driver_locals.terminal_speed.rain.field[:]
+            outputs["driver_local_terminal_speed_snow_icecloud"][:, :, :, n] = (
+                driver_locals.terminal_speed.snow.field[:]
+            )
+            outputs["driver_local_terminal_speed_graupel_icecloud"][:, :, :, n] = (
+                driver_locals.terminal_speed.graupel.field[:]
+            )
+            outputs["driver_local_terminal_speed_rain_icecloud"][:, :, :, n] = (
+                driver_locals.terminal_speed.rain.field[:]
+            )
             outputs["driver_local_density_icecloud"][:, :, :, n] = driver_locals.density.field[:]
             outputs["driver_local_density_factor_icecloud"][:, :, :, n] = driver_locals.density_factor.field[
                 :
             ]
             outputs["driver_local_rh_limited_icecloud"][:, :, :, n] = driver_locals.rh_limited.field[:]
-            outputs["non_anvil_large_scale_sublimation_icecloud"][
-                :, :, :, n
-            ] = state.non_anvil_large_scale.sublimation.field[:]
+            outputs["non_anvil_large_scale_sublimation_icecloud"][:, :, :, n] = (
+                state.non_anvil_large_scale.sublimation.field[:]
+            )
             outputs["driver_local_ccn_icecloud"][:, :, :, n] = driver_locals.ccn.field[:]
 
             for k in range(nz):


### PR DESCRIPTION
The PR includes the following changes:

- Pin NDSL version at `2026.01.00`
- CI: clean-up ndsl workflow a bit, e.g. no need for separate (editable) NDSL install.
- Update the `.gitignore`  file with `.venv/` (common / standard venv name) and `site/` (the docs output directory)
- Changes `setup.py` to include dependencies for docs.
- Udpates linting toolchain to recent versions
- CI: ensure docs can build
- Adds `__init__.py`  files in all source code folders such that we get proper modules (required for docstrings to work and in any case a good practice).

I suggest to look at the first and the last commit and skip the one in the middle (which just updates the linting toolchain).
