### PR TITLE
[Feature] Python bridge integration to AGCM

### DIFF
--- a/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
@@ -1186,7 +1186,7 @@ contains
    type (ESMF_Alarm)                   :: ALARM
    type (ESMF_Alarm)                   :: ALARM4D
    type (ESMF_Config)                  :: cf
-   integer                             :: I, NQ
+   integer                             :: I, NQ, IM, JM, LM
    real                                :: POFFSET, DT
    real, pointer, dimension(:,:)       :: PHIS,SGH,VARFLT,PTR
    real, pointer, dimension(:,:,:)     :: TEND!
@@ -1222,6 +1222,11 @@ contains
 
 
     call MAPL_TimerOn(STATE,"INITIALIZE")
+
+! Spin the MAPL python bridge with the atmospheric grid dimensions
+!--------------------------
+    call MAPL_Get ( STATE, IM=IM, JM=JM, LM=LM, RC=STATUS )
+    call initialize_python_bridge( IM, JM, LM )
 
 ! Call Initialize for every Child
 


### PR DESCRIPTION
~:warning: :warning: This is a _sister_ PR to [MAPL#4369](https://github.com/GEOS-ESM/MAPL/pull/4369) and should not be merged before :warning: :warning:~ Merged!

This requries a MAPL release (poke @mathomp4)

This PR spins the python bridge with AGCM local grid size.

This is mostly required because the Python-based `MAPLPy.GetPointer` requires to be given rank and dim sizes to transform the memory properly. We record the local grid size in order to allow the user to access them from within the Python.