### PR TITLE
v11: Build ISSM based on detection of ISSM

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/CMakeLists.txt
@@ -1,15 +1,35 @@
 esma_set_this ()
 
-set (alldirs
-   GEOSissm_GridComp
-   )
+# First set alldirs to empty
+set(alldirs)
+# ... and srcs to the LandIceGridComp
+set (srcs GEOS_LandIceGridComp.F90)
 
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_LandIceGridComp.F90)
-  esma_add_library (${this}
-    SRCS GEOS_LandIceGridComp.F90
-    SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GEOS_Shared GEOS_SurfaceShared ESMF::ESMF NetCDF::NetCDF_Fortran)
-else ()
-  esma_add_subdirectories (${alldirs})
- 
+# Then try to find ISSM
+find_package (ISSM QUIET COMPONENTS Core)
+
+if(ISSM_FOUND)
+  # If ISSM is found, append the directory to alldirs
+  message(STATUS "ISSM found, building gridded component")
+  list (APPEND alldirs GEOSissm_GridComp)
+else()
+  # If ISSM is not found, append the stub component to srcs
+  message(STATUS "ISSM not found, using stub component")
+  # For esma_create_stub_component, we need the name of the *module*
+  # that the landice gc is expecting, minus the mod. Also we
+  # have to use the variable srcs but not the ${srcs} because
+  # esma_create_stub_component is expecting the list itself, not the
+  # contents of the list.
+  esma_create_stub_component(srcs GEOS_IssmGridComp)
 endif()
+
+# We have to do the above way because what esma_create_stub_component
+# does is to append the stub component it creates in the build tree to a
+# list of sources srcs.  So if ISSM is found, we go into the subdir and
+# build the real component, and if ISSM is not found, we create the stub
+# component and append it to srcs.
+
+esma_add_library (${this}
+  SRCS ${srcs}
+  SUBCOMPONENTS ${alldirs}
+  DEPENDENCIES MAPL GEOS_Shared GEOS_SurfaceShared ESMF::ESMF NetCDF::NetCDF_Fortran)


### PR DESCRIPTION
This PR is a bit of CMake to allow for optional building of ISSM based on detection of finding the ISSM package. 

Eventually when ISSM is ready, the `g5_modules` used by GEOS will have an ISSM module. Now, ISSM is (at the moment) not an easy thing to build because of its "unique" build process.[^1] So in testing with @agstub, we've been building ISSM offline using a specified compiler and MPI stack and then that module is loaded and `find_package(ISSM)` finds it.

This is sustainable on places like NCCS and NAS where we can build these. But in CI land and on non-NASA maintained machines, it becomes hard to keep up.

So, this PR does the following:

1. Looks for ISSM with `QUIET`
2. If found, then we add the ISSM GC directory and build the code
3. If not found, we use the ESMA stubber code to make a stub gridcomp.

This is all "safe" at the moment since ISSM is run-time optional. If it ever is turned on by default then we'll need some extra CMake magic to override that default at run-time.


[^1]: For example, ISSM requires petsc and it's current build process is to have users make build scripts for it, see https://github.com/ISSMteam/ISSM/tree/main/externalpackages/petsc