### PR TITLE
fix: don't import from gt4py directly (and fix UW import paths)

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/mkdocs.yml
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/mkdocs.yml
@@ -123,5 +123,5 @@ nav:
   - UW:
       - "compute_uwshcu": UW/compute_uwshcu.md
       - "config": UW/config.md
-      - "temporaries": UW/temporaries.md
+      - "locals": UW/locals.md
       - "uwshcu_functions": UW/uwshcu_functions.md

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
@@ -7384,10 +7384,10 @@ class ComputeUwshcuInv(NDSLRuntime):
         """Compute the University of Washington's Shallow Convection
 
         Args:
-            stencil_factory (StencilFactory): Factory for creating stencil computations.
-            quantity_factory (QuantityFactory): Factory for creating quantities.
-            UW_config (dataclass): Data class containing configuration dependent
-            constants.
+            stencil_factory: Factory for creating stencil computations.
+            quantity_factory: Factory for creating quantities.
+            config: Data class containing configuration dependent
+                constants.
             formulation: Saturation Formulation used for QSat.
         """
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/compute_uwshcu.py
@@ -3,7 +3,7 @@ import dace
 import pyMoist.constants as constants
 from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
-from ndsl.dsl.gtscript import (
+from ndsl.dsl.gt4py import (
     BACKWARD,
     FORWARD,
     PARALLEL,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/uwshcu_functions.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/UW/uwshcu_functions.py
@@ -1,8 +1,6 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import K, erfc, exp, float32, float64, log, sin, sqrt
-
 import pyMoist.constants as constants
 import pyMoist.pyMoist_constants as py_constants
+from ndsl.dsl.gt4py import K, erfc, exp, float32, float64, function, log, sin, sqrt
 from ndsl.dsl.typing import Float, FloatField, Int
 from pyMoist.field_types import FloatField_NTracers
 from pyMoist.saturation_tables import GlobalTable_saturation_tables, saturation_specific_humidity
@@ -13,7 +11,7 @@ zvir = Float(0.609)  # r_H2O/r_air-1
 ROVCP = constants.MAPL_RGAS / constants.MAPL_CP  # Gas constant over specific heat
 
 
-@gtscript.function
+@function
 def exnerfn(
     p: Float,
 ) -> Float:
@@ -31,7 +29,7 @@ def exnerfn(
     return (p / 100000.0) ** (constants.MAPL_RGAS / constants.MAPL_CP)
 
 
-@gtscript.function
+@function
 def slope_bot(
     field: FloatField,
     p0: FloatField,
@@ -57,7 +55,7 @@ def slope_bot(
     return slope
 
 
-@gtscript.function
+@function
 def slope_bot_tracer(
     field: FloatField_NTracers,
     p0: FloatField,
@@ -76,7 +74,7 @@ def slope_bot_tracer(
     return slope
 
 
-@gtscript.function
+@function
 def slope_mid(
     max_k: Int,
     field: FloatField,
@@ -105,7 +103,7 @@ def slope_mid(
     return slope
 
 
-@gtscript.function
+@function
 def slope_mid_tracer(
     max_k: Int,
     field: FloatField_NTracers,
@@ -126,7 +124,7 @@ def slope_mid_tracer(
     return slope
 
 
-@gtscript.function
+@function
 def ice_fraction(
     temp: Float,
     cnv_frc: Float,
@@ -196,7 +194,7 @@ def ice_fraction(
     return ice_frac
 
 
-@gtscript.function
+@function
 def conden(
     p: Float,
     thl: Float,
@@ -265,7 +263,7 @@ def conden(
     return float32(th), float32(qv), float32(ql), float32(qi), float32(rvls), id_check
 
 
-@gtscript.function
+@function
 def compute_alpha(
     del_CIN: Float,
     ke: Float,
@@ -298,7 +296,7 @@ def compute_alpha(
     return compute_alpha
 
 
-@gtscript.function
+@function
 def compute_mumin2(
     mulcl: Float,
     rmaxfrax: Float,
@@ -341,7 +339,7 @@ def compute_mumin2(
     return compute_mumin2
 
 
-@gtscript.function
+@function
 def compute_ppen(
     wtwb: Float,
     drag: Float,
@@ -406,7 +404,7 @@ def compute_ppen(
     return compute_ppen
 
 
-@gtscript.function
+@function
 def getbuoy(
     pbot: Float,
     thv0bot: Float,
@@ -467,7 +465,7 @@ def getbuoy(
     return plfc, cin  # Note: plfc and cin are returned, but not always used
 
 
-@gtscript.function
+@function
 def qsinvert(
     qt: Float,
     thl: Float,
@@ -552,7 +550,7 @@ def qsinvert(
     return float32(qsinvert)
 
 
-@gtscript.function
+@function
 def sign(
     a: Float,
     b: Float,
@@ -576,7 +574,7 @@ def sign(
     return result
 
 
-@gtscript.function
+@function
 def roots(
     a: Float,
     b: Float,
@@ -624,7 +622,7 @@ def roots(
     return r1, r2, status
 
 
-@gtscript.function
+@function
 def single_cin(
     pbot: Float,
     thv0bot: Float,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/aer_activation.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/aer_activation.py
@@ -1,8 +1,7 @@
-from gt4py.cartesian.gtscript import PARALLEL, computation, exp, float64, interval, log, sqrt
-
 import pyMoist.constants as constants
 from ndsl import NDSLRuntime, QuantityFactory, StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import PARALLEL, computation, exp, float64, interval, log, sqrt
 from ndsl.dsl.typing import Float, FloatField, FloatFieldIJ, Int
 from pyMoist.field_types import FloatField_NModes
 from pyMoist.numerical_recipes import Erf

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/field_types.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/field_types.py
@@ -1,10 +1,8 @@
-import gt4py.cartesian.gtscript as gtscript
-
-from ndsl.dsl.gt4py import IJK, Field
+from ndsl.dsl.gt4py import IJ, IJK, Field
 from ndsl.dsl.typing import Float
 from pyMoist.constants import N_MODES, NCNST
 
 
 FloatField_NModes = Field[IJK, (Float, (N_MODES))]
-FloatField_NTracers = gtscript.Field[gtscript.IJK, (Float, (int(NCNST)))]
-FloatFieldIJ_NTracers = gtscript.Field[gtscript.IJ, (Float, (int(NCNST)))]
+FloatField_NTracers = Field[IJK, (Float, (int(NCNST)))]
+FloatFieldIJ_NTracers = Field[IJ, (Float, (int(NCNST)))]

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/numerical_recipes.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/pyMoist/numerical_recipes.py
@@ -1,8 +1,7 @@
-import gt4py.cartesian.gtscript as gtscript
-from gt4py.cartesian.gtscript import exp, float64, log
+from ndsl.dsl.gt4py import exp, float64, function, log
 
 
-@gtscript.function
+@function
 def GammLn(xx: float64) -> float64:
     """
     See numerical recipes, w. press et al., 2nd edition.
@@ -34,7 +33,7 @@ def GammLn(xx: float64) -> float64:
     return tmp + log(stp * ser / x)
 
 
-@gtscript.function
+@function
 def gser(a: float64, x: float64, gln: float64) -> float64:
     """
     See numerical recipes, w. press et al., 2nd edition.
@@ -76,7 +75,7 @@ def gser(a: float64, x: float64, gln: float64) -> float64:
     return gamser
 
 
-@gtscript.function
+@function
 def gcf_matrix(a: float64, x: float64, gln: float64) -> float64:
     """
     See numerical recipes, w. press et al., 2nd edition.
@@ -119,7 +118,7 @@ def gcf_matrix(a: float64, x: float64, gln: float64) -> float64:
     return exp(-x + a * log(x) - gln) * h
 
 
-@gtscript.function
+@function
 def GammP(a: float64, x: float64) -> float64:
     """
     See numerical recipes, w. press et al., 2nd edition.
@@ -145,7 +144,7 @@ def GammP(a: float64, x: float64) -> float64:
     return gammp
 
 
-@gtscript.function
+@function
 def Erf(x: float64) -> float64:
     """
     See numerical recipes, w. press et al., 2nd edition.

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_adjust_implicit_CIN_inputs1.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_adjust_implicit_CIN_inputs1.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_adjust_implicit_CIN_inputs2.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_adjust_implicit_CIN_inputs2.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_average_initial_and_final_CIN1.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_average_initial_and_final_CIN1.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_average_initial_and_final_CIN3.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_average_initial_and_final_CIN3.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_buoyancy_sorting.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_buoyancy_sorting.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_buoyancy_sorting_fluxes.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_buoyancy_sorting_fluxes.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_cumulus_condensate_at_interface.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_cumulus_condensate_at_interface.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_entrainment_mass_flux.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_entrainment_mass_flux.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_momentum_tendency.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_momentum_tendency.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_pbl_fluxes.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_pbl_fluxes.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_ppen.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_ppen.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_thermodynamic_tendencies.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_calc_thermodynamic_tendencies.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_compute_cin_cinlcl.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_compute_cin_cinlcl.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_compute_del_CIN.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_compute_del_CIN.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_compute_diagnostic_outputs.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_compute_diagnostic_outputs.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_compute_uwshcu_invert_after.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_compute_uwshcu_invert_after.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_define_env_properties.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_define_env_properties.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_define_prel_cbmf.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_define_prel_cbmf.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_define_updraft_properties.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_define_updraft_properties.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_find_klcl.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_find_klcl.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_find_pbl.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_find_pbl.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_penetrative_entrainment_fluxes.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_penetrative_entrainment_fluxes.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_prevent_negative_condensate.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_prevent_negative_condensate.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_recalc_condensate.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_recalc_condensate.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_recalc_environmental_variables.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_recalc_environmental_variables.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_tracer_tendencies.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_tracer_tendencies.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_update_output_variables1.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_update_output_variables1.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_update_output_variables2.py
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/pyMoist/tests/savepoint/UW_translate_tests/translate_update_output_variables2.py
@@ -1,9 +1,9 @@
 from f90nml import Namelist
-from gt4py.cartesian.gtscript import int32
 
 import pyMoist.constants as constants
 from ndsl import StencilFactory
 from ndsl.constants import X_DIM, Y_DIM, Z_DIM, Z_INTERFACE_DIM
+from ndsl.dsl.gt4py import int32
 from ndsl.dsl.typing import Float, Int
 from ndsl.stencils.testing.grid import Grid
 from ndsl.stencils.testing.translate import TranslateFortranData2Py


### PR DESCRIPTION
This PR changes the import paths to import "gt4py things" through the interface that we re-expose in NDSL, see https://github.com/NOAA-GFDL/NDSL/pull/126 for context.

The import path `ndsl.dsl.gtscript`  doesn't exist and thus crashes any attempt of currently running translate, e.g.

```shell
(...)/pyMoist/tests/scripts (dsl/develop) $ ./run_tests.sh ../../test_data/from_charles/ dace:cpu GFDL_1M_Finalize
2026-02-11 14:19:33|INFO|rank 0|ndsl.logging:Constant selected: ConstantVersions.UFS
ImportError while loading conftest '(...)/pyMoist/tests/conftest.py'.
../conftest.py:1: in <module>
    import savepoint
../savepoint/__init__.py:22: in <module>
    from .translate_compute_uwshcu import TranslateComputeUwshcuInv
../savepoint/translate_compute_uwshcu.py:9: in <module>
    from pyMoist.UW.compute_uwshcu import ComputeUwshcuInv
../../pyMoist/UW/compute_uwshcu.py:6: in <module>
    from ndsl.dsl.gtscript import (
E   ModuleNotFoundError: No module named 'ndsl.dsl.gtscript'
```

since UW tests are auto-detected and those pull in UW source code (which has the non-existing import paths).