### PR TITLE
Fix module_mp_radar USE dependency invisible to CMake scanner

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOS_PhysicsGridComp.F90
@@ -1886,7 +1886,7 @@ contains
    VERIFY_(STATUS)
 
    call MAPL_AddConnectivity ( GC,                                &
-         SHORT_NAME  = (/'ALH', 'KM', 'RI'/),                                 &
+          SHORT_NAME  = (/'ALH', 'KM ', 'RI '/),                                &
          DST_ID      =  MOIST,                                     &
          SRC_ID      =  TURBL,                                      &
                                                         RC=STATUS  )

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90
@@ -5949,7 +5949,7 @@ contains
        call MAPL_TimerOn (MAPL,"---AERO_ACTIVATE")
        
        
-       if ((USE_AEROSOL_NN) .and. not (USE_NCLOUD_CLIM)) then
+       if ((USE_AEROSOL_NN) .and. .not. (USE_NCLOUD_CLIM)) then
          ! get veritical velocity
          if (all(W == 0.0)) then
            TMP3D = -OMEGA/(MAPL_GRAV*PLmb*100.0/(MAPL_RGAS*T))

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
@@ -10,6 +10,7 @@ module GEOSmoist_Process_Library
   use ESMF
   use MAPL
   use GEOS_UtilsMod
+  use module_mp_radar
   !use Aer_Actv_Single_Moment
   !use aer_cloud
 
@@ -4061,8 +4062,6 @@ subroutine update_cld( &
 
    subroutine init_refl10cm ()
 
-      USE module_mp_radar
-
       IMPLICIT NONE
 
       integer :: n
@@ -4196,8 +4195,6 @@ subroutine update_cld( &
                t1d, p1d, dBZ, rand1, kts, kte, ii, jj, &
                vt_dBZ, first_time_step, ktopin, kbotin)
 
-      USE module_mp_radar
- 
       IMPLICIT NONE
 
 !..Sub arguments


### PR DESCRIPTION
I had Claude try and figure this out. This was a thought it had...

---

## Problem

GCC and ifort fail to compile several files due to standard violations that ifort accepted silently as non-standard extensions.

## Fix 1 — `Process_Library.F90`: hoist `USE module_mp_radar` to module level

**GCC**: `Fatal Error: Cannot open module file 'module_mp_radar.mod' for reading`
**ifort**: `error #6404: This name does not have a type [XAM_R]`

**Root cause:** CMake's Fortran module dependency scanner only reads `USE` statements at the **module/program specification part** (top level). It does not see `USE` statements inside contained subprograms.

`Process_Library.F90` had `USE module_mp_radar` inside two contained subroutines (`init_refl10cm` and `calc_refl10cm`), making the dependency on `module_mp_radar.F90` invisible to CMake. This was a latent bug that never fired before because compilation order happened to put `module_mp_radar.F90` first by coincidence.

Commit `37878b71` changed `aer_actv_single_moment.F90` to `USE GEOSmoist_Process_Library`, which introduced a new intra-library dependency that reshuffled the compilation schedule and exposed the hidden gap.

Moving `USE module_mp_radar` to the module-level `USE` block of `GEOSmoist_Process_Library` makes the dependency visible to CMake. The symbols are then available to `init_refl10cm` and `calc_refl10cm` via host association, which is semantically identical.

## Fix 2 — `GEOS_MoistGridComp.F90`: replace `not()` with `.not.`

**GCC**: `Error: 'i' argument of 'not' intrinsic at (1) must be INTEGER`

**Root cause:** `not()` is the bitwise integer intrinsic; `.not.` is the logical negation operator. ifort silently accepts `not()` on logicals as a non-standard extension, but GCC correctly rejects it.

```fortran
! Before
if ((USE_AEROSOL_NN) .and. not (USE_NCLOUD_CLIM)) then
! After
if ((USE_AEROSOL_NN) .and. .not. (USE_NCLOUD_CLIM)) then
```

## Fix 3 — `GEOS_PhysicsGridComp.F90`: pad strings in CHARACTER array constructor

**GCC**: `Error: Different CHARACTER lengths (3/2) in array constructor`

**Root cause:** The Fortran standard requires all elements of an array constructor to have the same character length. `'KM'` and `'RI'` (length 2) were mixed with `'ALH'` (length 3). ifort accepted this silently; GCC correctly rejects it.

```fortran
! Before
SHORT_NAME  = (/'ALH', 'KM', 'RI'/),
! After
SHORT_NAME  = (/'ALH', 'KM ', 'RI '/),
```