### PR TITLE
change ice_strength to 0 for better ice thickness distribution

### DIFF
--- a/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
+++ b/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/cice6_app/1440x1080/ice_in
@@ -136,7 +136,7 @@
     brlx            = 300.0
     arlx            = 300.0
     advection       = 'remap'
-    kstrength       = 1
+    kstrength       = 0
     krdg_partic     = 1
     krdg_redist     = 1
     mu_rdg          = 3


### PR DESCRIPTION
This PR changes CICE6 default `ice_strength` parameter from 1 to 0. The change is based on results from DataAtm runs.