### PR TITLE
Deactivate non-ported components on release/MAPL-v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@ esma_set_this()
 
 set (alldirs
   GEOSagcm_GridComp
-  GEOSdataatm_GridComp
-  GEOSmkiau_GridComp
-  GEOSogcm_GridComp
-  GEOSwgcm_GridComp
+  # GEOSdataatm_GridComp  # not yet ported to MAPL3 - restore when ported
+  # GEOSmkiau_GridComp    # not yet ported to MAPL3 - restore when ported
+  # GEOSogcm_GridComp     # not yet ported to MAPL3 - restore when ported
+  # GEOSwgcm_GridComp     # not yet ported to MAPL3 - restore when ported
   )
 
 option(BUILD_WITH_GIGATRAJ "Build GEOSgcm with Gigatraj" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,24 +15,29 @@ endif()
 
 option(BUILD_WITH_PYMLINC "Build pyMLINC interface" OFF)
 
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_GcmGridComp.F90)
+# Temporarily bypass GEOSgcm_GridComp top-level library: GEOS_GcmGridComp.F90
+# USE-s non-ported components. Restore the block below when all SUBCOMPONENTS
+# are ported to MAPL3.
+esma_add_subdirectories (${alldirs})
 
- ecbuild_declare_project()
-  esma_add_library(${this}
-    SRCS GEOS_GcmGridComp.F90
-    SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL ESMF::ESMF)
-
-  target_compile_definitions (${this} PRIVATE $<$<BOOL:${BUILD_WITH_GIGATRAJ}>:HAS_GIGATRAJ>)
-  target_compile_definitions (${this} PRIVATE $<$<BOOL:${BUILD_WITH_PYMLINC}>:HAS_PYMLINC>)
-
-  ecbuild_install_project( NAME GEOSgcm_GridComp)
-
-else ()
-
-  esma_add_subdirectories (${alldirs})
-
-endif()
+# if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_GcmGridComp.F90)
+#
+#  ecbuild_declare_project()
+#   esma_add_library(${this}
+#     SRCS GEOS_GcmGridComp.F90
+#     SUBCOMPONENTS ${alldirs}
+#     DEPENDENCIES MAPL ESMF::ESMF)
+#
+#   target_compile_definitions (${this} PRIVATE $<$<BOOL:${BUILD_WITH_GIGATRAJ}>:HAS_GIGATRAJ>)
+#   target_compile_definitions (${this} PRIVATE $<$<BOOL:${BUILD_WITH_PYMLINC}>:HAS_PYMLINC>)
+#
+#   ecbuild_install_project( NAME GEOSgcm_GridComp)
+#
+# else ()
+#
+#   esma_add_subdirectories (${alldirs})
+#
+# endif()
 
 
 

--- a/GEOSagcm_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/CMakeLists.txt
@@ -5,25 +5,30 @@ set (alldirs
   GEOSphysics_GridComp
   )
 
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_AgcmSimpleGridComp.F90)
+# Temporarily bypass GEOSagcm top-level library: GEOS_AgcmGridComp.F90
+# USE-s non-ported components (e.g. GEOS_superdynGridCompMod). Restore
+# the block below when all SUBCOMPONENTS are ported to MAPL3.
+esma_add_subdirectories (${alldirs})
 
-  message(STATUS "Building Held-Suarez GridComp")
-  esma_add_library (${this}
-    SRCS GEOS_AgcmSimpleGridComp.F90
-    SUBCOMPONENTS GEOSsuperdyn_GridComp GEOShs_GridComp
-    DEPENDENCIES MAPL ESMF::ESMF)
-
-elseif (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_AgcmGridComp.F90)
-
-  esma_add_library (${this}
-    SRCS GEOS_AgcmGridComp.F90
-    SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GEOS_Shared Chem_Shared ESMF::ESMF)
-
-  target_compile_definitions (${this} PRIVATE $<$<BOOL:${BUILD_WITH_GIGATRAJ}>:HAS_GIGATRAJ>)
-
-else ()
-
-  esma_add_subdirectories (${alldirs})
-
-endif()
+# if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_AgcmSimpleGridComp.F90)
+#
+#   message(STATUS "Building Held-Suarez GridComp")
+#   esma_add_library (${this}
+#     SRCS GEOS_AgcmSimpleGridComp.F90
+#     SUBCOMPONENTS GEOSsuperdyn_GridComp GEOShs_GridComp
+#     DEPENDENCIES MAPL ESMF::ESMF)
+#
+# elseif (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_AgcmGridComp.F90)
+#
+#   esma_add_library (${this}
+#     SRCS GEOS_AgcmGridComp.F90
+#     SUBCOMPONENTS ${alldirs}
+#     DEPENDENCIES MAPL GEOS_Shared Chem_Shared ESMF::ESMF)
+#
+#   target_compile_definitions (${this} PRIVATE $<$<BOOL:${BUILD_WITH_GIGATRAJ}>:HAS_GIGATRAJ>)
+#
+# else ()
+#
+#   esma_add_subdirectories (${alldirs})
+#
+# endif()

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
@@ -1,25 +1,29 @@
 esma_set_this ()
 
 set (alldirs
-  GEOSchem_GridComp
-  GEOSmoist_GridComp
-  GEOSsurface_GridComp
-  GEOSturbulence_GridComp
+  # GEOSchem_GridComp      # not yet ported to MAPL3 - restore when ported
+  # GEOSmoist_GridComp     # not yet ported to MAPL3 - restore when ported
+  # GEOSsurface_GridComp   # not yet ported to MAPL3 - restore when ported
+  # GEOSturbulence_GridComp # not yet ported to MAPL3 - restore when ported
   GEOSgwd_GridComp
-  GEOSradiation_GridComp
+  # GEOSradiation_GridComp # not yet ported to MAPL3 - restore when ported
   )
 
+# Temporarily bypass GEOSphysics top-level library: GEOS_PhysicsGridComp.F90
+# USE-s non-ported components. Restore the block below when all SUBCOMPONENTS
+# are ported to MAPL3.
+esma_add_subdirectories (${alldirs})
 
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_PhysicsGridComp.F90)
-
-  esma_add_library (${this}
-    SRCS GEOS_PhysicsGridComp.F90 MBundle_IncrementMod.F90
-    SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GMAO_mpeu GMAO_stoch ESMF::ESMF)
-
-else ()
-
-  esma_add_subdirectories (${alldirs})
-
-endif()
+# if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_PhysicsGridComp.F90)
+#
+#   esma_add_library (${this}
+#     SRCS GEOS_PhysicsGridComp.F90 MBundle_IncrementMod.F90
+#     SUBCOMPONENTS ${alldirs}
+#     DEPENDENCIES MAPL GMAO_mpeu GMAO_stoch ESMF::ESMF)
+#
+# else ()
+#
+#   esma_add_subdirectories (${alldirs})
+#
+# endif()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
@@ -1,7 +1,7 @@
 esma_set_this ()
 
 set (alldirs
-  # GEOSchem_GridComp      # not yet ported to MAPL3 - restore when ported
+  GEOSchem_GridComp       # restricted to GOCART only - see GEOSchem_GridComp/CMakeLists.txt
   # GEOSmoist_GridComp     # not yet ported to MAPL3 - restore when ported
   # GEOSsurface_GridComp   # not yet ported to MAPL3 - restore when ported
   # GEOSturbulence_GridComp # not yet ported to MAPL3 - restore when ported

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
@@ -29,7 +29,9 @@ install( FILES ${resource_files}
 esma_add_library (
   ${this}
   SRCS ${srcs}
-  DEPENDENCIES GEOS_Shared MAPL MAPL.generic3g MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
+  # GEOS_Shared removed: no GWD source file actually uses it (leftover dependency)
+  # not yet ported to MAPL3 - restore GEOS_Shared when ported
+  DEPENDENCIES MAPL MAPL.generic3g MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
   )
 
 mapl_acg (

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/CMakeLists.txt
@@ -2,28 +2,33 @@ esma_set_this ()
 
 set (alldirs
   FVdycoreCubed_GridComp
-  FVdycore_GridComp
-  GEOSdatmodyn_GridComp
-  ARIESg3_GridComp
+  # FVdycore_GridComp       # not yet ported to MAPL3 - restore when ported
+  # GEOSdatmodyn_GridComp   # not yet ported to MAPL3 - restore when ported
+  # ARIESg3_GridComp        # not yet ported to MAPL3 - restore when ported
   )
 
-if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOSdatmodyn_GridComp)
+# if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOSdatmodyn_GridComp)
+#
+#   set (rename_GEOSdatmodyn_GridComp GEOS_DatmodynGridComp)
+#
+# endif ()
 
-  set (rename_GEOSdatmodyn_GridComp GEOS_DatmodynGridComp)
+# Temporarily bypass GEOSsuperdyn top-level library: GEOS_SuperdynGridComp.F90
+# USE-s non-ported components. Restore the block below when all SUBCOMPONENTS
+# are ported to MAPL3.
+esma_add_subdirectories (${alldirs})
 
-endif ()
-
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_SuperdynGridComp.F90)
-
-  esma_add_library (${this}
-    SRCS GEOS_SuperdynGridComp.F90
-    SUBCOMPONENTS ${alldirs}
-    DEPENDENCIES MAPL GEOS_Shared ESMF::ESMF)
-
-  target_compile_definitions (${this} PRIVATE $<$<BOOL:${BUILD_WITH_GIGATRAJ}>:HAS_GIGATRAJ>)
-
-else ()
-
-  esma_add_subdirectories (${alldirs})
-
-endif ()
+# if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_SuperdynGridComp.F90)
+#
+#   esma_add_library (${this}
+#     SRCS GEOS_SuperdynGridComp.F90
+#     SUBCOMPONENTS ${alldirs}
+#     DEPENDENCIES MAPL GEOS_Shared ESMF::ESMF)
+#
+#   target_compile_definitions (${this} PRIVATE $<$<BOOL:${BUILD_WITH_GIGATRAJ}>:HAS_GIGATRAJ>)
+#
+# else ()
+#
+#   esma_add_subdirectories (${alldirs})
+#
+# endif ()


### PR DESCRIPTION
## Summary

- Comments out all top-level siblings except `GEOSagcm_GridComp`; bypasses `GEOSgcm_GridComp` top-level library
- Bypasses `GEOSagcm_GridComp` top-level library
- `GEOSphysics_GridComp`: comments out all physics subdirs except `GEOSgwd_GridComp` and `GEOSchem_GridComp` (the latter restricted to GOCART-only)
- `GEOSsuperdyn_GridComp`: comments out all subdirs except `FVdycoreCubed_GridComp`; bypasses top-level library
- Removes spurious `GEOS_Shared` dependency from `GEOSgwd_GridComp` (no source file actually uses it)

## Context

Part of the MAPL3 flip work tracked in GEOS-ESM/GEOSgcm_GridComp#1359. Only components already ported to MAPL3 are compiled on `release/MAPL-v3`.