### PR TITLE
Add MAPL2 dependency for MAPL→MAPL2→MAPL3 rename

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
@@ -31,7 +31,7 @@ esma_add_library (
   SRCS ${srcs}
   # GEOS_Shared removed: no GWD source file actually uses it (leftover dependency)
   # not yet ported to MAPL3 - restore GEOS_Shared when ported
-  DEPENDENCIES MAPL MAPL.generic3g MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
+  DEPENDENCIES MAPL2 MAPL MAPL.generic3g MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
   )
 
 mapl_acg (


### PR DESCRIPTION
## Summary

- Adds `MAPL2` before `MAPL` in `GEOSgwd_GridComp` CMake `DEPENDENCIES` to support the MAPL→MAPL2→MAPL3 rename transition.

## References

- Closes #1361
- Part of the broader `release/MAPL-v3` / MAPL #4600 rename effort