### PR TITLE
Port GWD off MAPL_OpenMP_Support to use MAPL (mapl3g) directly

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -31,10 +31,10 @@ module GEOS_GwdGridCompMod
 
    use esmf
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_RTRN, MAPL_ASSERT
-   use MAPL_OpenMP_Support, only : MAPL_get_current_thread => get_current_thread
-   use MAPL_OpenMP_Support, only : MAPL_get_num_threads => get_num_threads
-   use MAPL_OpenMP_Support, only : MAPL_find_bounds => find_bounds
-   use MAPL_OpenMP_Support, only : MAPL_Interval => Interval
+   use mapl3g_OpenMP_Support, only : MAPL_get_current_thread => get_current_thread
+   use mapl3g_OpenMP_Support, only : MAPL_get_num_threads => get_num_threads
+   use mapl3g_OpenMP_Support, only : MAPL_find_bounds => find_bounds
+   use mapl3g_OpenMP_Support, only : MAPL_Interval => Interval
    use MAPL_CommsMod, only: MAPL_AM_I_ROOT, ArrayGather
    use MAPL_MaplGrid, only: MAPL2_GridGet => MAPL_GridGet
    use MAPL_GenericMod, only: MAPL_TimerAdd, MAPL_TimerOn, MAPL_TimerOff

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -31,10 +31,10 @@ module GEOS_GwdGridCompMod
 
    use esmf
    use mapl_ErrorHandling, only: MAPL_Verify, MAPL_RTRN, MAPL_ASSERT
-   use mapl3g_OpenMP_Support, only : MAPL_get_current_thread => get_current_thread
-   use mapl3g_OpenMP_Support, only : MAPL_get_num_threads => get_num_threads
-   use mapl3g_OpenMP_Support, only : MAPL_find_bounds => find_bounds
-   use mapl3g_OpenMP_Support, only : MAPL_Interval => Interval
+   use MAPL, only : MAPL_get_current_thread => get_current_thread
+   use MAPL, only : MAPL_get_num_threads => get_num_threads
+   use MAPL, only : MAPL_find_bounds => find_bounds
+   use MAPL, only : MAPL_Interval => Interval
    use MAPL_CommsMod, only: MAPL_AM_I_ROOT, ArrayGather
    use MAPL_MaplGrid, only: MAPL2_GridGet => MAPL_GridGet
    use MAPL_GenericMod, only: MAPL_TimerAdd, MAPL_TimerOn, MAPL_TimerOff


### PR DESCRIPTION
## Summary

- Closes #1379
- `GEOS_GwdGridComp.F90`: replace `use MAPL_OpenMP_Support` with `use MAPL, only: ...` to get OpenMP support directly from mapl3g instead of the legacy generic/ library
- CMake: add `MAPL` link dependency to `GEOSgwd_GridComp` target