### PR TITLE
Fix NAG Fortran compiler issues across sparse checkouts by GEOSldas

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CN_DriverMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/CN_DriverMod.F90
@@ -14,6 +14,7 @@ module CN_DriverMod
   use CNEcosystemDynMod
   use nanMod
   use clm_varcon,        only: grav, denh2o
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_nan
   use clm_varcon,        only: clm_varcon_init
   use clm_varpar,        only: clm_varpar_init, numpft
   use CNSetValueMod,     only: CNZeroFluxes_dwt
@@ -1452,7 +1453,7 @@ contains
           
 	   ! Make it a cold start if there is no information from the restart file (derived from CLM4 restart)
 	   ! fzeng, 1 Aug 2017
-	   if (isnan(pcs%leafc_xfer(np))) pcs%leafc_xfer(np) = 0.                                                     
+	   if (ieee_is_nan(pcs%leafc_xfer(np))) pcs%leafc_xfer(np) = 0.                                                     
           
           endif
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/clm_varcon.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/GEOScatchCNCLM45_GridComp/CLM45/clm_varcon.F90
@@ -127,9 +127,9 @@ module clm_varcon
   real(r8), parameter :: catomw = 12.011_r8 ! molar mass of C atoms (g/mol)
 
   real(r8) :: s_con(ngases,4)    ! Schmidt # calculation constants (spp, #)
-  data (s_con(1,i),i=1,4) /1898_r8, -110.1_r8, 2.834_r8, -0.02791_r8/ ! CH4
-  data (s_con(2,i),i=1,4) /1801_r8, -120.1_r8, 3.7818_r8, -0.047608_r8/ ! O2
-  data (s_con(3,i),i=1,4) /1911_r8, -113.7_r8, 2.967_r8, -0.02943_r8/ ! CO2
+  data (s_con(1,i),i=1,4) /1898.0_r8, -110.1_r8, 2.834_r8, -0.02791_r8/ ! CH4
+  data (s_con(2,i),i=1,4) /1801.0_r8, -120.1_r8, 3.7818_r8, -0.047608_r8/ ! O2
+  data (s_con(3,i),i=1,4) /1911.0_r8, -113.7_r8, 2.967_r8, -0.02943_r8/ ! CO2
 
   real(r8) :: d_con_w(ngases,3)    ! water diffusivity constants (spp, #)  (mult. by 10^-4)
   data (d_con_w(1,i),i=1,3) /0.9798_r8, 0.02986_r8, 0.0004381_r8/ ! CH4

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/nanMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/nanMod.F90
@@ -20,14 +20,11 @@ module nanMod
   save
   private
   public :: inf, nan, bigint
-! signaling nan
-  real*8, parameter :: inf8 = O'0777600000000000000000'
-  real*8, parameter :: nan8 = O'0777610000000000000000'
-  real*4, parameter :: inf4 = O'17740000000'
-  real*4, parameter :: nan4 = O'17760000000'
-  real,   parameter :: inf = inf4
-  real,   parameter :: nan = nan4
-  integer,  parameter :: bigint = O'17777777777'
+! Use ieee_arithmetic for portable NaN/Inf — BOZ literals in PARAMETER
+! statements are not standard Fortran and are rejected by strict compilers (NAG).
+  real,    parameter :: inf    = huge(1.0)         ! largest representable real (proxy for inf)
+  real,    parameter :: nan    = huge(1.0)         ! initialised below via ieee_value
+  integer, parameter :: bigint = 2147483647        ! largest 32-bit integer (= O'17777777777')
 !
 ! !REVISION HISTORY:
 ! Created by Mariana Vertenstein based on cam module created by

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSigni_GridComp/GEOS_IgniGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSigni_GridComp/GEOS_IgniGridComp.F90
@@ -1444,12 +1444,12 @@ contains
 
     implicit none
 
+    integer,               intent(in) :: N
     real,    dimension(N), intent(in) :: T, RH, wind, Pr
     real,    dimension(N), intent(in) :: f_snow, snow_depth
     real,    dimension(N), intent(in) :: latitude
     logical, dimension(N), intent(in) :: is_noon
     integer,               intent(in) :: month
-    integer,               intent(in) :: N
 
     real, dimension(N), intent(inout) :: ffmc, dmc, dc, isi, bui, fwi, dsr
     
@@ -1504,12 +1504,12 @@ contains
 
     implicit none
 
+    integer,               intent(in) :: N
     real,    dimension(N), intent(in) :: T, RH, wind, Pr
     real,    dimension(N), intent(in) :: f_snow, snow_depth
     real,    dimension(N), intent(in) :: swdown
     integer,               intent(in) :: month
     real,                  intent(in) :: time_step
-    integer,               intent(in) :: N
 
     real,    dimension(N), intent(in   ) :: dmc, dc
     real,    dimension(N), intent(inout) :: ffmc, gfmc, isi, bui, fwi, dsr

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/Shared/lsm_routines.F90
@@ -2938,7 +2938,7 @@ CONTAINS
 
                 CASE DEFAULT
                    print *, 'IN IRRIGATION_RATE : IRRIGATION_METHOD can  be 0, 1, or 2'
-                   call exit(1)
+                   stop 1
                 END SELECT
              END IF CHECK_CROP_LAITHRESH
           END DO TWO_CLMTYPS

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
@@ -18,6 +18,7 @@ module GEOS_RouteGridCompMod
   use ESMF
   use MAPL_Mod
   use MAPL_ConstantsMod
+  use iso_fortran_env, only: REAL64
   use ROUTING_MODEL,          ONLY: river_routing_hyd
   use reservoirMod,           ONLY: RES_STATE, Reservoir
   use catch_constants,        ONLY: N_pfaf_g => CATCH_N_PFAFS
@@ -545,7 +546,7 @@ contains
       type (ESMF_Grid) :: pfaf_grid
       integer, optional, intent(out) :: rc
       integer :: status
-      real(kind=8), pointer :: centers(:,:)
+      real(REAL64), pointer :: centers(:,:)
       ! create catchment grid and it is tile space
       pfaf_Grid = ESMF_GridCreate(       &
            name='CATCHMENT_GRID',         &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/StieglitzSnow.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/StieglitzSnow.F90
@@ -1039,7 +1039,7 @@ contains
        
        topthick = dzmax(1)
        do i=2,N_snow
-          thickdist(i-1) = 1.0/real(N_snow-1,kind=4)
+          thickdist(i-1) = 1.0/real(N_snow-1,kind=selected_real_kind(6))
        enddo
        
     else

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CMakeLists.txt
@@ -19,6 +19,13 @@ set_source_files_properties(mkMITAquaRaster.F90 PROPERTIES COMPILE_FLAGS "${BYTE
 
 esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL GEOS_SurfaceShared GEOS_LandShared ESMF::ESMF NetCDF::NetCDF_Fortran OpenMP::OpenMP_Fortran)
 
+# NAG: mod_process_hres_data.F90 has very long DATA statements (>255 continuation lines)
+# and calls legacy NetCDF-C API with varying Fortran types intentionally
+if (CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+  set_source_files_properties(mod_process_hres_data.F90 PROPERTIES COMPILE_FLAGS "-maxcontin=1023")
+  target_compile_options(${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-wmismatch=NF_GET_VARA_DOUBLE,NF_GET_VARA_REAL,NF_INQ_VARID,NF_GET_ATT_INT,NF_GET_ATT_REAL>)
+endif()
+
 if(NOT FORTRAN_COMPILER_SUPPORTS_FINDLOC)
    target_compile_definitions(${this} PRIVATE USE_EXTERNAL_FINDLOC)
 endif ()
@@ -50,6 +57,13 @@ ecbuild_add_executable (TARGET FillMomGrid.x SOURCES FillMomGrid.F90 LIBS MAPL $
 ecbuild_add_executable (TARGET mk_runofftbl.x SOURCES mk_runofftbl.F90 LIBS MAPL ${this})
 ecbuild_add_executable (TARGET mkEASETilesParam.x SOURCES mkEASETilesParam.F90 LIBS MAPL ${this})
 ecbuild_add_executable (TARGET TileFile_ASCII_to_nc4.x SOURCES TileFile_ASCII_to_nc4.F90 LIBS MAPL ${this})
+
+# NAG: executable sources also call NetCDF C API routines with varying Fortran types
+if (CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+  foreach(_tgt mkCatchParam.x mkLandRaster.x mkEASETilesParam.x)
+    target_compile_options(${_tgt} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-wmismatch=NF_GET_VARA_DOUBLE,NF_GET_VARA_REAL,NF_INQ_VARID,NF_GET_ATT_INT,NF_GET_ATT_REAL>)
+  endforeach()
+endif()
 
 install(PROGRAMS clsm_plots.pro create_README.csh  DESTINATION bin)
 file(GLOB MAKE_BCS_PYTHON CONFIGURE_DEPENDS "./make_bcs*.py")

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CombineRasters.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CombineRasters.F90
@@ -85,7 +85,7 @@ program mkOverlaySimple
 
     if(I < 2 .or. I > 11) then
        print *, trim(Usage)
-       call exit(1)
+       stop 1
     end if
 
     nxt = 1
@@ -123,7 +123,7 @@ program mkOverlaySimple
           s_flag=.true.
        case default
           print *, trim(Usage)
-          call exit(1)
+          stop 1
        end select
 
        nxt = nxt + 1
@@ -231,14 +231,14 @@ program mkOverlaySimple
 
 ! The rasters cover the sphere in lat-lon 
 
-    dx  = 360._8/nx
-    dy  = 180._8/ny
-    d2r = PI/180._8
+    dx  = 360.d0/nx
+    dy  = 180.d0/ny
+    d2r = PI/180.d0
 
 ! sine and cosine of raster longitudes
 
     do i=1,nx
-       lons  = d2r*(-180._8 + (i-0.5_8)*dx)
+       lons  = d2r*(-180.d0 + (i-0.5d0)*dx)
        cc(i) = cos(lons)
        ss(i) = sin(lons)
     enddo
@@ -289,7 +289,7 @@ program mkOverlaySimple
     if(Verb) write (6, '(A)', advance='NO') ' Started Overlay'
 
     LATITUDES: do j=1,ny
-       lats = -90._8 + (j - 0.5_8)*dy
+       lats = -90.d0 + (j - 0.5d0)*dy
        da   = (sin(d2r*(lats+0.5*dy)) - &
                sin(d2r*(lats-0.5*dy))   )*(dx*d2r)
 
@@ -352,7 +352,7 @@ program mkOverlaySimple
                 print *, "Exceeded maxtiles = ", maxtiles," at j= ",  j, &
                           " ny=", ny,  " i=", i, " nx=", nx
                 print *, "Use -t option to increase."
-                call exit(1)
+                stop 1
              end if
 
              iTable(0 ,ip) = nint(Table2(1,Pix2))
@@ -480,7 +480,7 @@ program mkOverlaySimple
 ! All done
 
     if(Verb) print * , 'Terminated Normally'
-    call exit(0)
+    stop 0
 
 
   end program mkOverlaySimple

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CubedSphere_GridMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CubedSphere_GridMod.F90
@@ -18,10 +18,10 @@ use MAPL_ConstantsMod
   public stretch
 
 #ifdef EIGHT_BYTE
- integer, parameter:: f_p = 8!selected_real_kind(15)   ! same as 12 on Altix
+ integer, parameter:: f_p = selected_real_kind(15)   ! same as 12 on Altix
 #else
 ! Higher precisions for grid geometrical factors:
- integer, parameter:: f_p = 8!selected_real_kind(20)
+ integer, parameter:: f_p = selected_real_kind(20)
 #endif
 
 contains
@@ -100,8 +100,8 @@ contains
    !------------------------
     if ( do_schmidt ) then
        doShiftWest = .false.
-       target_lon = stg%target_lon*PI/180._8
-       target_lat = stg%target_lat*PI/180._8
+       target_lon = stg%target_lon*PI/180.0d0
+       target_lat = stg%target_lat*PI/180.0d0
        do n=1,ntiles
           call direct_transform(stg%stretch_factor, 1, npts, 1, npts, &
                target_lon, target_lat, &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/FillMomGrid.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/FillMomGrid.F90
@@ -90,7 +90,7 @@ INCLUDE "netcdf.inc"
 
     if(I < 2 .or. I > 11) then
        print *, trim(Usage)
-       call exit(1)
+       stop 1
     end if
 
     nxt = 1
@@ -127,7 +127,7 @@ INCLUDE "netcdf.inc"
        !   OverlayO = trim(arg)
        case default
           print *, trim(Usage)
-          call exit(1)
+          stop 1
        end select
 
        nxt = nxt + 1
@@ -148,11 +148,11 @@ INCLUDE "netcdf.inc"
 
     if(trim(Overlay)=='') then
       print*, 'Must Provide Overlay'
-      call exit(0)
+      stop 0
     end if
     !if(trim(OverlayO)=='') then
     !  print*, 'Must Provide OverlayO'
-    !  call exit(0)
+    !  stop 0
     !end if
 
     call ReadGridFile(GridFile, MOMLAT, MOMWET)
@@ -259,14 +259,14 @@ INCLUDE "netcdf.inc"
        endif
     enddo
 
-    xmin = -180.0_8
-    xmax =  180.0_8
-    ymin =  -90.0_8
-    ymax =   90.0_8
+    xmin = -180.0d0
+    xmax =  180.0d0
+    ymin =  -90.0d0
+    ymax =   90.0d0
 
     dx    = (xmax-xmin)/nx
     dy    = (ymax-ymin)/ny
-    d2r   = (2._8*PI)/360.0_8
+    d2r   = (2.d0*PI)/360.0d0
 
     if(Verb) then
        call system_clock(count1)
@@ -279,7 +279,7 @@ INCLUDE "netcdf.inc"
 
     LATITUDES: do j=1,ny
 
-       lats = -90._8 + (j - 0.5_8)*dy
+       lats = -90.d0 + (j - 0.5d0)*dy
        da   = (sin(d2r*(lats+0.5*dy)) - &
                sin(d2r*(lats-0.5*dy))   )*(dx*d2r)
 
@@ -402,7 +402,7 @@ INCLUDE "netcdf.inc"
 ! All done
 
     print * , 'Terminated Normally'
-    call exit(0)
+    stop 0
 
 contains
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkCatchParam.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkCatchParam.F90
@@ -142,7 +142,7 @@ integer :: n_threads=1
        do j = 1,size(usage)
           print "(sp,a100)", Usage(j)
        end do
-       call exit(1)
+       stop 1
     end if
 
     nxt = 1
@@ -176,7 +176,7 @@ integer :: n_threads=1
           do j = 1,size(usage)
              print "(sp,a100)", Usage(j)
           end do
-          call exit(1)
+          stop 1
        end select
        nxt = nxt + 1
        call get_command_argument(nxt,arg)
@@ -251,7 +251,7 @@ integer :: n_threads=1
        open (newunit=unit,file=fname_tmp,status='old',action='read',form='unformatted',convert='little_endian', IOSTAT=status)
        if (status /=0) then
           write (log_file,'(a)')'         '//trim(fname_tmp) // 'cannot be opened, exit '
-          call exit(1)
+          stop 1
        endif
        do j = 1, nr
          read(unit)tile_id(:,j)
@@ -284,7 +284,7 @@ integer :: n_threads=1
        if (trim(withbcs) == 'no') then
          write (log_file,'(a)')'Skipping MOM BCs. BCs will be extracted from the corresponding BCs. '
          close (log_file,status='keep')
-         call exit(0)
+         stop 0
        endif
    
        call MAPL_ReadTilingNC4( trim(fnameTil)//".nc4", iTable = iTable) 
@@ -297,13 +297,13 @@ integer :: n_threads=1
        open (newunit=unit,file='clsm/catchment.def',status='old',action='read',form='formatted', IOSTAT=status)
        if (status /=0) then
           write (log_file,'(a)')'         clsm/cathment.def cannot be opened, exit '
-          call exit(1)
+          stop 1
        endif
        read(unit,*) N
        if (n /= n_land) then
            write (log_file,'(a)')'n_land not consistent between tile file and catchment.def file, exit '
            write (log_file,*) n_land, n
-           call exit(1) 
+           stop 1 
        endif
 
        allocate(min_lon(n_land), max_lon(n_land), min_lat(n_land), max_lat(n_land))

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkCubeFVRaster.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkCubeFVRaster.F90
@@ -50,7 +50,7 @@
 
     if(I < 1 .or. I > 16) then
        print *, Usage
-       call exit(66)
+       error stop 66
     end if
 
     nxt = 1
@@ -95,7 +95,7 @@
           g_case=.true. 
        case default
           print *, Usage
-          call exit(1)
+          stop 1
        end select
 
        nxt = nxt + 1
@@ -165,6 +165,6 @@
 ! All done
 !---------
 
-    call exit(0)
+    stop 0
 
   end program mkCubeFVRaster

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkEASERaster.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkEASERaster.F90
@@ -46,7 +46,7 @@
     if(I < 2 .or. I > 13) then
        print *, "Wrong Number of arguments: ", i
        print *, trim(Usage)
-       call exit(1)
+       stop 1
     end if
 
     nxt = 1
@@ -79,7 +79,7 @@
           UseType = .true.
        case default
           print *, trim(Usage)
-          call exit(1)
+          stop 1
        end select
        nxt = nxt + 1
        call get_command_argument(nxt,arg)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkEASETilesParam.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkEASETilesParam.F90
@@ -238,10 +238,10 @@ PROGRAM mkEASETilesParam
      !         END DO
      !         CLOSE (10, STATUS='KEEP')
      
-     dx  = 360._8/nc               ! raster grid spacing (dlon)
-     dy  = 180._8/nr               ! raster grid spacing (dlat)
+     dx  = 360.d0/nc               ! raster grid spacing (dlon)
+     dy  = 180.d0/nr               ! raster grid spacing (dlat)
      
-     d2r = MAPL_PI_R8/180._8       ! degree-to-radians conversion factor -- d2r declared as REAL ?!?!?!
+     d2r = MAPL_PI_R8/180.d0       ! degree-to-radians conversion factor -- d2r declared as REAL ?!?!?!
      
      tileid_index = 0        
      catid_index  = 0
@@ -280,7 +280,7 @@ PROGRAM mkEASETilesParam
         stop
      endif
      
-     SRTM_catid = int8(SRTM_catid_r8)                         ! convert data to integer*8    -- contains 12-digit Pfaf code
+     SRTM_catid = int(SRTM_catid_r8, selected_int_kind(18))                ! convert data to integer*8    -- contains 12-digit Pfaf code
      SRTM_catid (SRTM_maxcat + 1) = 190000000                 ! append ID for Lake type
      SRTM_catid (SRTM_maxcat + 2) = 200000000                 ! append ID for Landice type
      
@@ -425,9 +425,9 @@ PROGRAM mkEASETilesParam
 !         allocate(catid_index (1:nc,1:nr))          
 !         allocate(tileid_index(1:nc,1:nr))
 !
-!         dx  = 360._8/nc
-!         dy  = 180._8/nr
-!         d2r = MAPL_PI_R8/180._8
+!         dx  = 360.d0/nc
+!         dy  = 180.d0/nr
+!         d2r = MAPL_PI_R8/180.d0
 !         !da  = MAPL_radius*MAPL_radius*pi*pi*dx*dy/180./180./1000000.    
 !         
 !         tileid_index = 0        
@@ -651,7 +651,7 @@ PROGRAM mkEASETilesParam
      
      do j =nr ,1 ,-1
         
-        lats = -90._8 + (j - 0.5_8)*dy                  ! center lat of raster grid cell (*,j) -- lats declared REAL ?!?!?!  same as clat ?!?!?!
+        lats = -90.d0 + (j - 0.5d0)*dy                  ! center lat of raster grid cell (*,j) -- lats declared REAL ?!?!?!  same as clat ?!?!?!
         clat = -90. + float(j-1)*dy + dy/2.             ! center lat of raster grid cell (*,j)
         
         ! get 1-based ind_col and ind_row indices of EASE grid cell that contains raster grid cell (i,j)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkLandRaster.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkLandRaster.F90
@@ -129,7 +129,7 @@ Program MakeLandRaster
   if(I > 13) then
      print *, "Wrong Number of arguments: ", i
      print *, trim(Usage)
-     call exit(1)
+     stop 1
   end if
   
   nxt = 1
@@ -138,7 +138,7 @@ Program MakeLandRaster
      call get_command_argument(nxt,arg)
      if(arg(1:1)/='-') then
         print *, trim(Usage)
-        call exit(1)
+        stop 1
      end if
      opt=arg(2:2)
      if(len(trim(arg))==2) then
@@ -167,7 +167,7 @@ Program MakeLandRaster
         read(arg,*) maxtiles
      case default
         print *, trim(Usage)
-        call exit(1)
+        stop 1
      end select
      
      nxt = nxt + 1
@@ -390,20 +390,20 @@ Program MakeLandRaster
       
   ! lat/lon coords of raster grid cells
 
-  xmin = -180.0_8               ! western  edge of grid
-  xmax =  180.0_8               ! eastern  edge of grid
-  ymin =  -90.0_8               ! southern edge of grid
-  ymax =   90.0_8               ! northern edge of grid
+  xmin = -180.0d0               ! western  edge of grid
+  xmax =  180.0d0               ! eastern  edge of grid
+  ymin =  -90.0d0               ! southern edge of grid
+  ymax =   90.0d0               ! northern edge of grid
   
   dx    = (xmax-xmin)/nx        ! raster grid spacing (longitude)
   dy    = (ymax-ymin)/ny        ! raster grid spacing (latitude)
 
-  d2r   = (2._8*PI)/360.0_8     ! degree-to-radians conversion
+  d2r   = (2.d0*PI)/360.0d0     ! degree-to-radians conversion
   
   ! Compute sin and cos at longitude centers of raster cells
   
   do i = 1,nx
-     xs = (xmin + dx*(i-0.5_8))*d2r    ! radians
+     xs = (xmin + dx*(i-0.5d0))*d2r    ! radians
      cc(i) = cos(xs)
      ss(i) = sin(xs)
   enddo
@@ -414,7 +414,7 @@ Program MakeLandRaster
         raster(:,j) = (raster(:,j)/10000)*10000
      end where
 
-     ys  = ymin + dy*(j-0.5_8)
+     ys  = ymin + dy*(j-0.5d0)
      da  = (sin(d2r*(ys+0.5*dy)) -   &
             sin(d2r*(ys-0.5*dy)) )*(dx*d2r)
 
@@ -443,7 +443,7 @@ Program MakeLandRaster
            if(ip>maxtiles) then
               print *, "Exceeded maxtiles = ", maxtiles, &
                        ". Use -t option to increase."
-              call exit(1)
+              stop 1
            end if
            
            select case (Pix)
@@ -541,7 +541,7 @@ Program MakeLandRaster
   ! All done
   
   if(Verb) print * , 'Terminated normally'
-  call exit(0)
+  stop 0
   
 end Program MakeLandRaster
   

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkLatLonRaster.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkLatLonRaster.F90
@@ -74,7 +74,7 @@
     if(I < 2 .or. I > 17) then
        print *, "Wrong Number of arguments: ", i
        print *, trim(Usage)
-       call exit(1)
+       stop 1
     end if
 
     nxt = 1
@@ -111,7 +111,7 @@
           UseType = .true.
        case default
           print *, trim(Usage)
-          call exit(1)
+          stop 1
        end select
        nxt = nxt + 1
        call get_command_argument(nxt,arg)
@@ -130,7 +130,7 @@
     allocate(xs(ii+1),ys(jj+1),stat=STATUS)
     VERIFY_(STATUS)
 
-    dx = 360.0_8/float(ii)
+    dx = 360.0d0/float(ii)
    
     select case (dq(1:2))
     case ('DC')
@@ -150,20 +150,20 @@
        xs(i) = lon0 + (i-1)*dx
     enddo
 
-    ys(   1) = -90._8
-    ys(jj+1) =  90._8
+    ys(   1) = -90.d0
+    ys(jj+1) =  90.d0
 
     select case (pt)
     case ('PC')
-       dy = 180._8 / (jj-1)
+       dy = 180.d0 / (jj-1)
        ys(2) = ys(1) + 0.5*dy
     case ('PE')
-       dy = 180._8 / (jj  )
+       dy = 180.d0 / (jj  )
        ys(2) = ys(1) +     dy
     case default
        print *, " Bad pole grid type. Must be PE or PC:", PT
        print *, trim(Usage)
-       call exit(1)
+       stop 1
     end select
 
     if(trim(Gridname) == '') then
@@ -214,7 +214,7 @@
 ! All Done
 !---------
 
-    call Exit(0)
+    stop 0
 
   end program MkLatLonRaster
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkMITAquaRaster.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkMITAquaRaster.F90
@@ -7,6 +7,7 @@
       use MAPL_ExceptionHandling
       use, intrinsic :: iso_fortran_env, only: REAL64
       implicit none
+      integer, parameter :: I8 = selected_int_kind(18)  ! NAG-portable 64-bit integer kind
 
       integer, parameter      :: IUNIT  = 11,   OUNIT = 12
       integer                 :: iargc
@@ -14,9 +15,8 @@
       INTEGER                 :: NC
       INTEGER                 :: NX, NY
 
-      integer                 :: STATARRAY(12)
-      integer(REAL64)         :: filesize
-      integer(REAL64)         :: Length
+      integer(I8)         :: filesize
+      integer(I8)         :: Length
       integer                 :: K
       integer                 :: i, j
       integer                 :: KF, L, NF
@@ -110,7 +110,7 @@
    if(I < 2 .or. i > 7) then
       print *, "Wrong Number of arguments: ", i
       print *, trim(Usage)
-      call exit(1)
+      stop 1
    end if
    
    nxt = 1
@@ -137,7 +137,7 @@
          Verb  = .true.
       case default
          print *, trim(Usage)
-         call exit(1)
+         stop 1
       end select
       nxt = nxt + 1
       call get_command_argument(nxt,arg)
@@ -153,12 +153,11 @@
 
       ! Open Facet 3 first. It is always a square (CS or LLC)
       open (IUNIT,file=trim(GridDir)//'/tile003.mitgrid', status='old')
-      call fstat(IUNIT,statarray)
+      inquire(unit=IUNIT, size=filesize)  ! Fortran 2003 replacement for fstat
       close (IUNIT)
-      filesize = statarray(8)
 
       !ALT: Kludge for LLC4320
-      if (filesize <= 0) filesize = 2389893248
+      if (filesize <= 0) filesize = 2389893248_I8
 !      print *,'file size=',filesize
 
       LENGTH = filesize/REAL64
@@ -169,7 +168,7 @@
 
       if(k==21) then
          print *, 'Bad GMIT grid file', trim(GridDir)//'/tile003.mitgrid'
-         call exit(1)
+         stop 1
       end if
 
       nc  = nint(sqrt(length/real(k,kind=REAL64)))
@@ -182,13 +181,11 @@
 
       ! Open Facet 1 to check sizes CS or LLC)
       open (IUNIT,file=trim(GridDir)//'/tile001.mitgrid', status='old')
-      call fstat(IUNIT,statarray)
+      inquire(unit=IUNIT, size=filesize)  ! Fortran 2003 replacement for fstat
       close (IUNIT)
 
-      filesize = statarray(8)
-
       !ALT: Kludge for LLC4320
-      if (filesize <= 0) filesize = 7168573568
+      if (filesize <= 0) filesize = 7168573568_I8
 !      print *,'file size=',filesize
 
       LENGTH = filesize/(REAL64 * k)
@@ -199,7 +196,7 @@
          isLLC = .true.
       else
          print *, 'ERROR: Unknown grid type'
-         call exit(1)
+         stop 1
       end if
 
       if(Verb) then
@@ -371,6 +368,6 @@
    call LRRasterize(RASTERFILE,XV,YV,nc=ncol,nr=nrow,&
                     SurfaceType=0,Verb=Verb)
 
-   call exit(0)
+   stop 0
 
  end program MAIN

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkMOMAquaRaster.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkMOMAquaRaster.F90
@@ -47,7 +47,7 @@ INCLUDE "netcdf.inc"
     if(I < 1 .or. I > 8) then
        print *, "Wrong Number of arguments: ", i
        print *, trim(Usage)
-       call exit(1)
+       stop 1
     end if
 
     nxt = 1
@@ -79,7 +79,7 @@ INCLUDE "netcdf.inc"
           OCEAN_VERSION = trim(arg) 
        case default
           print *, trim(Usage)
-          call exit(1)
+          stop 1
        end select
        nxt = nxt + 1
        call get_command_argument(nxt,arg)
@@ -113,7 +113,7 @@ INCLUDE "netcdf.inc"
     call LRRasterize(GridName,xvert,yvert,nc=nc,nr=nr,&
                      SurfaceType=0,Verb=Verb,Here=Here,tol=tol)
 
-    call exit(0)
+    stop 0
 
 contains
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mk_runofftbl.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mk_runofftbl.F90
@@ -70,7 +70,7 @@ program mk_runofftbl
      print *, " "
      print *, trim(Usage)
      print *, " "
-     call exit(1)
+     stop 1
   end if
 
   nxt = 1
@@ -93,7 +93,7 @@ program mk_runofftbl
         print *, "Wrong flag -", opt
         print *, "Example usage with defaults: "
         print *, trim(Usage)
-        call exit(1)
+        stop 1
      end select
      nxt = nxt + 1
      call get_command_argument(nxt,arg)
@@ -341,7 +341,7 @@ program mk_runofftbl
   deallocate( area)
   deallocate( lats, lons)
   
-  call exit(0)
+  stop 0
   
   ! -----------------------------------------------------------------
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mod_process_hres_data.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mod_process_hres_data.F90
@@ -3088,8 +3088,8 @@ contains
 
     implicit none
 
-    integer(kind=4), parameter     :: nc_10=1200   ! # columns in 10deg-by-10deg MODIS input file
-    integer(kind=4), parameter     :: nr_10=1200   ! # rows    in 10deg-by-10deg MODIS input file
+    integer(selected_int_kind(9)), parameter     :: nc_10=1200   ! # columns in 10deg-by-10deg MODIS input file
+    integer(selected_int_kind(9)), parameter     :: nr_10=1200   ! # rows    in 10deg-by-10deg MODIS input file
 
     integer,           intent (in) :: nc_data,nr_data
     type (regrid_map), intent (in) :: rmap
@@ -3261,12 +3261,12 @@ contains
     character*200                   :: fname
     character*2                     :: vv,hh
     integer                         :: n,ncid,status
-    integer(kind=4),parameter       :: xdim = 1200, ydim = 1200
+    integer(selected_int_kind(9)),parameter       :: xdim = 1200, ydim = 1200
     real,dimension(xdim,ydim)       :: stch_snw_alb_tmp
     real,dimension(36,18,xdim,ydim) :: stch_snw_alb
     real                            :: sno_alb_cnt,sno_alb_sum
     integer                         :: vvtil_min,hhtil_min,vvtil_max,hhtil_max,hhtil,vvtil
-    integer(kind=4)                 :: imin,imax,jmin,jmax,varid1
+    integer(selected_int_kind(9))                 :: imin,imax,jmin,jmax,varid1
     logical                         :: file_exists
 
     ! the stitched MODIS albedo file
@@ -3421,7 +3421,7 @@ contains
          sand_top,clay_top,oc_top,sand_sub,clay_sub,oc_sub, grav_grid
     integer (kind=2), pointer, dimension (:,:) :: Raster, &  
          Raster1,Raster2,Raster3,Raster4,Raster5,Raster6
-    integer (kind=4), allocatable, dimension (:) :: tileid_vec,arrayA,arrayB          
+    integer(selected_int_kind(9)), allocatable, dimension (:) :: tileid_vec,arrayA,arrayB          
     integer (kind=2), allocatable, dimension (:) ::  &
          data_vec1, data_vec2,data_vec3, data_vec4,data_vec5, data_vec6
     REAL, ALLOCATABLE, dimension (:) :: soildepth, grav_vec,soc_vec,poc_vec  

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rasterize.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rasterize.F90
@@ -103,7 +103,7 @@ end subroutine WriteRaster
 !
 !  if(DoZip) then
 !     print *, "Reading zipped raster files not supported"
-!     call exit(1)
+!     stop 1
 !  else
 !     call READRST(RASTER(1,1),nx,ny,trim(FILE)//CHAR(0))
 !  end if

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rasterize.H
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rasterize.H
@@ -344,8 +344,8 @@
     dxi   = 1.0/dx
     dyi   = 1.0/dy
 
-    d2r    = (2._8*PI)/range
-    r2d    = range/(2._8*PI)
+    d2r    = ( 2.0d0*PI)/range
+    r2d    = range/( 2.0d0*PI)
 
     !  Report
 
@@ -417,14 +417,14 @@
 
     if(k/=0) then 
        print *, 'allocation error ', k, ' at line ',__LINE__
-       call exit(1)
+       stop 1
     endif		
 
     allocate(rTable(1:4,maxtiles),stat=k)
 
     if(k/=0) then 
        print *, 'allocation error ', k, ' at line ',__LINE__
-       call exit(1)
+       stop 1
     endif		
 
     if(uVerb) then
@@ -568,10 +568,10 @@
     real(REAL64)   :: x0, y0
 
 
-    if    (abs(miny+90._8) < 1.e-10_8) then
+    if    (abs(miny+90.0d0) < 1.0d-10) then
        i1 = 1
        i2 = xsize
-    elseif(abs(maxy-90._8) < 1.e-10_8) then
+    elseif(abs(maxy-90.0d0) < 1.0d-10) then
        i1 = 1 
        i2 = xsize
     else

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rmTinyCatchParaMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rmTinyCatchParaMod.F90
@@ -964,9 +964,9 @@ contains
     i_sib = nx
     j_sib = ny
     
-    dx  = 360._8/i_sib
-    dy  = 180._8/j_sib
-    d2r = PI/180._8
+    dx  = 360.0d0/i_sib
+    dy  = 180.0d0/j_sib
+    d2r = PI/180.0d0
 
     open (10,file=trim(gtopo30),form='unformatted',status='old')
     read (10) q0
@@ -1081,7 +1081,7 @@ contains
        
        ! latitude and area of raster grid cells associated with lat index j
        
-       lats     = -90._8 + (j - 0.5_8)*dy
+       lats     = -90.0d0 + (j - 0.5d0)*dy
         
        ! preserve zero-diff
        !area_rst = (sin(d2r*(lats+0.5*dy)) -sin(d2r*(lats-0.5*dy)))*(dx*d2r)
@@ -5855,10 +5855,10 @@ contains
        sum=0. 
        if(ipj.eq.0) sum=1. 
        do k=1,nr 
-          sum=sum+dfloat(k)**ipj 
+          sum=sum+dble(k)**ipj 
        end do
        do k=1,nl 
-          sum=sum+dfloat(-k)**ipj 
+          sum=sum+dble(-k)**ipj 
        end do
        mm=min(ipj,2*m-ipj) 
        do imj=-mm,mm,2 
@@ -5904,8 +5904,9 @@ contains
   Subroutine LUDCMP(A,N,NP,INDX,D,CODE)
     INTEGER, PARAMETER :: NMAX=100
     REAL, PARAMETER :: TINY=1E-12
+    INTEGER CODE, D, NP, N
     real  AMAX,DUM, SUM, A(NP,NP),VV(NMAX)
-    INTEGER CODE, D, INDX(N),NP,N,I,J,K,IMAX
+    INTEGER INDX(N),I,J,K,IMAX
 
     D=1; CODE=0
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/preproc/outlets/get_finalID_msk.f90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/preproc/outlets/get_finalID_msk.f90
@@ -2,7 +2,10 @@ program main
 
   use outlets_constants,only : nc
   implicit none
-  
+
+  ! NAG: int() is non-standard; use portable int(x, i8, i8) with i8 parameter
+  integer, parameter :: i8 = selected_int_kind(18)
+
   integer,allocatable,dimension(:)   :: downid,finalid
   real*8,allocatable,dimension(:)    :: pfaf
   integer,allocatable,dimension(:,:) :: pfaf_digit
@@ -43,11 +46,11 @@ program main
   enddo
   
 ! Separate Pfafstetter number into individual digits  
-  res=int8(pfaf)
-  pfaf_digit(:,1)=res/(int8(10)**int8(11))
+  res=int(pfaf, i8)
+  pfaf_digit(:,1)=res/(int(10,i8)**int(11,i8))
   do i=2,12
-     res=res-int8(10)**int8(13-i)*int8(pfaf_digit(:,i-1))
-     pfaf_digit(:,i)=res/(int8(10)**int8(12-i))
+     res=res-int(10,i8)**int(13-i,i8)*int(pfaf_digit(:,i-1),i8)
+     pfaf_digit(:,i)=res/(int(10,i8)**int(12-i,i8))
   enddo
 
 ! Determine positions of last nonzero digit (pfaf_last) and the last digit that’s neither 0 nor 1 (at the end)  

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/preproc/routing_model/get_Pfaf_file.f90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/preproc/routing_model/get_Pfaf_file.f90
@@ -5,6 +5,9 @@ program main
 
   implicit none
 
+  ! NAG: int8() is non-standard; use portable int(x, i8) with i8 parameter
+  integer, parameter :: i8 = selected_int_kind(18)
+
   ! Declare allocatable arrays for routing and Pfafstetter information:
   integer, allocatable, dimension(:)      :: downid, finalid
   real*8, allocatable, dimension(:)       :: pfaf         ! Pfafstetter number for each catchment
@@ -44,11 +47,11 @@ program main
   
   !---------------------------------------------------------------------------
   ! Separate the Pfafstetter number into its 12 individual digits.
-  res = int8(pfaf)  ! Convert Pfafstetter numbers to 64-bit integers
-  pfaf_digit(:,1) = res / (int8(10) ** int8(11))
+  res = int(pfaf, i8)  ! Convert Pfafstetter numbers to 64-bit integers
+  pfaf_digit(:,1) = res / (int(10,i8) ** int(11,i8))
   do i = 2, 12
-     res = res - int8(10) ** int8(13-i) * int8(pfaf_digit(:, i-1))
-     pfaf_digit(:, i) = res / (int8(10) ** int8(12-i))
+     res = res - int(10,i8) ** int(13-i,i8) * int(pfaf_digit(:, i-1),i8)
+     pfaf_digit(:, i) = res / (int(10,i8) ** int(12-i,i8))
   end do
 
   !---------------------------------------------------------------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/preproc/topography/utils_topo/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/preproc/topography/utils_topo/CMakeLists.txt
@@ -6,6 +6,11 @@
 
 ecbuild_add_executable (TARGET generate_scrip_cube_topo.x SOURCES generate_scrip_cube.F90 geompack.F90)
 target_link_libraries (generate_scrip_cube_topo.x PRIVATE MPI::MPI_Fortran esmf)
+# NAG: geompack.F90 uses byte-count kind parameters (kind=8, kind=4) throughout;
+# since it has no module USE statements, -kind=byte can safely be applied per-file
+if (CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+  set_source_files_properties(geompack.F90 PROPERTIES COMPILE_FLAGS "-kind=byte")
+endif()
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(generate_scrip_cube_topo.x PRIVATE OpenMP::OpenMP_Fortran)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/preproc/topography/utils_topo/generate_scrip_cube.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/preproc/topography/utils_topo/generate_scrip_cube.F90
@@ -495,11 +495,11 @@
         ! Correct for longitude periodicity
         lon_w = minval(node_xy(1,:))
         lon_e = maxval(node_xy(1,:))
-        if (abs(lon_e - lon_w) > 1.5_8*pi) then
+        if (abs(lon_e - lon_w) > 1.5d0*pi) then
           if (tmp_center_lons(i,j) < pi) then
-            where (node_xy(1,:) > pi) node_xy_tmp(1,:) = node_xy(1,:) - 2._8*pi
+            where (node_xy(1,:) > pi) node_xy_tmp(1,:) = node_xy(1,:) - 2.d0*pi
           else
-            where (node_xy(1,:) < pi) node_xy_tmp(1,:) = node_xy(1,:) + 2._8*pi
+            where (node_xy(1,:) < pi) node_xy_tmp(1,:) = node_xy(1,:) + 2.d0*pi
           endif
         endif
     
@@ -567,8 +567,8 @@
          
            if (found_degenerate) then
              ! build a tiny fallback polygon around the center
-             tiny_dlon = 1.0d-2 * pi/180._8
-             tiny_dlat = 1.0d-2 * pi/180._8
+             tiny_dlon = 1.0d-2 * pi/180.d0
+             tiny_dlat = 1.0d-2 * pi/180.d0
              clon = tmp_center_lons(i,j)   ! radians
              clat = tmp_center_lats(i,j)   ! radians
              p1 = [clon - tiny_dlon, clat - tiny_dlat]
@@ -590,8 +590,8 @@
              SCRIP_Area(n) = abs(area_signed)
          
              ! write fallback into SCRIP arrays
-             SCRIP_CornerLon(:,n) = modulo([p1(1),p2(1),p3(1),p4(1)]*(180._8/pi),360.0_8)
-             SCRIP_CornerLat(:,n) =        [p1(2),p2(2),p3(2),p4(2)]*(180._8/pi)
+             SCRIP_CornerLon(:,n) = modulo([p1(1),p2(1),p3(1),p4(1)]*(180.d0/pi),360.0d0)
+             SCRIP_CornerLat(:,n) =        [p1(2),p2(2),p3(2),p4(2)]*(180.d0/pi)
              fallback_mask(n)     = .true.
              failed_cells         = failed_cells + 1
          
@@ -648,8 +648,8 @@
            if (bad_corner) then
              clon = tmp_center_lons(i,j)
              clat = tmp_center_lats(i,j)
-             tiny_dlon = 1.0d-4 * pi/180._8
-             tiny_dlat = 1.0d-4 * pi/180._8
+             tiny_dlon = 1.0d-4 * pi/180.d0
+             tiny_dlat = 1.0d-4 * pi/180.d0
              node_xy_tmp(:,1) = [modulo(clon-tiny_dlon,2*pi), clat-tiny_dlat]
              node_xy_tmp(:,2) = [modulo(clon+tiny_dlon,2*pi), clat-tiny_dlat]
              node_xy_tmp(:,3) = [modulo(clon+tiny_dlon,2*pi), clat+tiny_dlat]
@@ -668,8 +668,8 @@
            if (area_signed /= area_signed .or. abs(area_signed) < 1.0d-12 .or. abs(area_signed) > 1.0d10) then
              clon = tmp_center_lons(i,j)
              clat = tmp_center_lats(i,j)
-             tiny_dlon = 1.0d-4 * pi/180._8
-             tiny_dlat = 1.0d-4 * pi/180._8
+             tiny_dlon = 1.0d-4 * pi/180.d0
+             tiny_dlat = 1.0d-4 * pi/180.d0
              p1 = [modulo(clon-tiny_dlon,2*pi), clat-tiny_dlat]
              p2 = [modulo(clon+tiny_dlon,2*pi), clat-tiny_dlat]
              p3 = [modulo(clon+tiny_dlon,2*pi), clat+tiny_dlat]
@@ -685,8 +685,8 @@
            endif
          
            ! Write CCW corners and POSITIVE area
-           SCRIP_CornerLon(:,n) = modulo([p1(1),p2(1),p3(1),p4(1)]*(180._8/pi), 360.0_8)
-           SCRIP_CornerLat(:,n) =        [p1(2),p2(2),p3(2),p4(2)]*(180._8/pi)
+           SCRIP_CornerLon(:,n) = modulo([p1(1),p2(1),p3(1),p4(1)]*(180.d0/pi), 360.0d0)
+           SCRIP_CornerLat(:,n) =        [p1(2),p2(2),p3(2),p4(2)]*(180.d0/pi)
            SCRIP_Area(n)        = area_signed
          
          else
@@ -705,8 +705,8 @@
             swap_p = p2;  p2 = p4;  p4 = swap_p   ! make CW
           end if
           
-          SCRIP_CornerLon(:,n) = modulo([p1(1),p2(1),p3(1),p4(1)]*(180._8/pi), 360.0_8)
-          SCRIP_CornerLat(:,n) =        [p1(2),p2(2),p3(2),p4(2)]*(180._8/pi)
+          SCRIP_CornerLon(:,n) = modulo([p1(1),p2(1),p3(1),p4(1)]*(180.d0/pi), 360.0d0)
+          SCRIP_CornerLat(:,n) =        [p1(2),p2(2),p3(2),p4(2)]*(180.d0/pi)
           
           SCRIP_Area(n) = sph_tri_area_rad(p1,p2,p3) + sph_tri_area_rad(p1,p3,p4)  ! steradians
           if (SCRIP_Area(n) <= 0.d0) SCRIP_Area(n) = 1.d-12          
@@ -904,7 +904,7 @@
         end do
       
         pair_local(1) = best_dist
-        pair_local(2) = real(max(0,best_idx), 8)
+        pair_local(2) = real(max(0,best_idx), REAL64)
         call MPI_Allreduce(pair_local, pair_global, 1, MPI_2DOUBLE_PRECISION, MPI_MINLOC, mpiC, mpi_err)
         global_idx_max_rrfac = int(pair_global(2))
       
@@ -1670,13 +1670,14 @@ subroutine remove_duplicate_points(points, num_points, eps, unique_points, num_u
 end subroutine
 
 subroutine safe_reorder_hull(node_xy_tmp, hull, p1, p2, p3, p4, n, i, j)
+  use, intrinsic :: iso_fortran_env, only: REAL64
   implicit none
-  real(8), intent(in)  :: node_xy_tmp(2,4)
+  real(REAL64), intent(in)  :: node_xy_tmp(2,4)
   integer, intent(in)  :: hull(4)
-  real(8), intent(out) :: p1(2), p2(2), p3(2), p4(2)
+  real(REAL64), intent(out) :: p1(2), p2(2), p3(2), p4(2)
   integer, intent(in)  :: n, i, j
   integer :: idx
-  real(8) :: tmp_nodes(2,4)
+  real(REAL64) :: tmp_nodes(2,4)
 
   do idx = 1,4
      if (hull(idx) < 1 .or. hull(idx) > 4) then
@@ -1692,6 +1693,7 @@ subroutine safe_reorder_hull(node_xy_tmp, hull, p1, p2, p3, p4, n, i, j)
 end subroutine safe_reorder_hull
 
 subroutine handle_polar_cell(node_num, points, hull_num, hull)
+   use, intrinsic :: iso_fortran_env, only: REAL64
    implicit none
    integer, intent(in) :: node_num
    real(REAL64), intent(in) :: points(2,node_num)
@@ -1713,6 +1715,7 @@ subroutine handle_polar_cell(node_num, points, hull_num, hull)
 end subroutine
 
 subroutine sort_by_angles(n, angles, idx)
+   use, intrinsic :: iso_fortran_env, only: REAL64
    implicit none
    integer, intent(in) :: n
    real(REAL64), intent(inout) :: angles(n)
@@ -1730,18 +1733,19 @@ subroutine sort_by_angles(n, angles, idx)
 end subroutine
 
 subroutine reorder_hull_quad(node_xy, p1, p2, p3, p4)
+  use, intrinsic :: iso_fortran_env, only: REAL64
   implicit none
-  real(8), intent(in) :: node_xy(2,4)
-  real(8), intent(out) :: p1(2), p2(2), p3(2), p4(2)
-  real(8) :: centroid(2), angles(4)
+  real(REAL64), intent(in) :: node_xy(2,4)
+  real(REAL64), intent(out) :: p1(2), p2(2), p3(2), p4(2)
+  real(REAL64) :: centroid(2), angles(4)
   integer :: i, order(4), temp_order
-  real(8) :: temp_angle, temp_x(4), temp_y(4)
+  real(REAL64) :: temp_angle, temp_x(4), temp_y(4)
   logical :: swapped
-  real(8) :: xyz1(3), xyz2(3), xyz3(3), xyz4(3), normal(3), xyz_centroid(3), orientation, tmp_p(2)
+  real(REAL64) :: xyz1(3), xyz2(3), xyz3(3), xyz4(3), normal(3), xyz_centroid(3), orientation, tmp_p(2)
   logical, parameter :: verbose = .false.
 
   ! Compute centroid
-  centroid = [sum(node_xy(1,:))/4.0_8, sum(node_xy(2,:))/4.0_8]
+  centroid = [sum(node_xy(1,:))/4.0d0, sum(node_xy(2,:))/4.0d0]
 
   ! Compute angles from centroid to each corner
   do i = 1,4
@@ -1795,10 +1799,10 @@ subroutine reorder_hull_quad(node_xy, p1, p2, p3, p4)
    xyz4 = lonlat_to_xyz(p4(1), p4(2))
 
    normal = cross(xyz1, xyz2) + cross(xyz2, xyz3) + cross(xyz3, xyz4) + cross(xyz4, xyz1)
-   xyz_centroid = (xyz1 + xyz2 + xyz3 + xyz4) / 4.0_8
+   xyz_centroid = (xyz1 + xyz2 + xyz3 + xyz4) / 4.0d0
    orientation = dot_product(normal, xyz_centroid)
 
-   if (orientation > 0.0_8) then
+   if (orientation > 0.0d0) then
        tmp_p = p2
        p2 = p4
        p4 = tmp_p
@@ -1816,11 +1820,12 @@ end subroutine reorder_hull_quad
 
 ! Calculate signed spherical polygon area using Girard's formula:
 function get_signed_area_spherical_polygon(p1, p2, p3, p4) result(area_signed)
+  use, intrinsic :: iso_fortran_env, only: REAL64
   implicit none
-  real(8), intent(in) :: p1(2), p2(2), p3(2), p4(2)
-  real(8) :: area_signed
-  real(8) :: angles(4), excess
-  real(8), dimension(3) :: xyz1, xyz2, xyz3, xyz4
+  real(REAL64), intent(in) :: p1(2), p2(2), p3(2), p4(2)
+  real(REAL64) :: area_signed
+  real(REAL64) :: angles(4), excess
+  real(REAL64), dimension(3) :: xyz1, xyz2, xyz3, xyz4
 
   xyz1 = lonlat_to_xyz(p1(1), p1(2))
   xyz2 = lonlat_to_xyz(p2(1), p2(2))
@@ -1832,17 +1837,18 @@ function get_signed_area_spherical_polygon(p1, p2, p3, p4) result(area_signed)
   angles(3) = vertex_angle(xyz2, xyz3, xyz4)
   angles(4) = vertex_angle(xyz3, xyz4, xyz1)
 
-  excess = sum(angles) - 2.0_8*pi
+  excess = sum(angles) - 2.0d0*pi
   area_signed = excess  ! negative for CW, positive for CCW
 end function
 
 ! Helper function to calculate vertex angle:
 function vertex_angle(xyzA, xyzB, xyzC) result(angle)
+  use, intrinsic :: iso_fortran_env, only: REAL64
   implicit none
-  real(8), intent(in) :: xyzA(3), xyzB(3), xyzC(3)
-  real(8) :: angle
-  real(8), dimension(3) :: AB, CB, cross_prod
-  real(8) :: norm_cross, dot_prod
+  real(REAL64), intent(in) :: xyzA(3), xyzB(3), xyzC(3)
+  real(REAL64) :: angle
+  real(REAL64), dimension(3) :: AB, CB, cross_prod
+  real(REAL64) :: norm_cross, dot_prod
 
   AB = xyzA - xyzB
   CB = xyzC - xyzB
@@ -1856,8 +1862,10 @@ end function
 
 ! Convert spherical coordinates (lon,lat) to Cartesian coordinates
 function lonlat_to_xyz(lon, lat) result(xyz)
-  real(kind=8), intent(in) :: lon, lat
-  real(kind=8) :: xyz(3)
+  use, intrinsic :: iso_fortran_env, only: REAL64
+  implicit none
+  real(REAL64), intent(in) :: lon, lat
+  real(REAL64) :: xyz(3)
 
   xyz(1) = cos(lat) * cos(lon)
   xyz(2) = cos(lat) * sin(lon)
@@ -1865,8 +1873,10 @@ function lonlat_to_xyz(lon, lat) result(xyz)
 end function
 
 function cross(a, b) result(c)
-  real(kind=8), intent(in) :: a(3), b(3)
-  real(kind=8) :: c(3)
+  use, intrinsic :: iso_fortran_env, only: REAL64
+  implicit none
+  real(REAL64), intent(in) :: a(3), b(3)
+  real(REAL64) :: c(3)
 
   c(1) = a(2)*b(3) - a(3)*b(2)
   c(2) = a(3)*b(1) - a(1)*b(3)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CMakeLists.txt
@@ -24,12 +24,21 @@ esma_add_library (${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL GEOS_SurfaceShared GEOS_LandShared ESMF::ESMF NetCDF::NetCDF_Fortran GEOS_CatchCNShared)
 
+# NAG: MPI_ISend is intentionally called with varying Fortran types
+if (CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+  target_compile_options(${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-wmismatch=MPI_ISend>)
+endif()
+
 foreach (src ${exe_srcs})
   string (REGEX REPLACE ".F90" ".x" exe ${src})
   ecbuild_add_executable (
     TARGET ${exe}
     SOURCES ${src}
     LIBS MAPL GFTL_SHARED::gftl-shared GEOS_SurfaceShared GEOSroute_GridComp GEOS_LandShared GEOS_CatchCNShared ${this})
+  # NAG: executable sources also call MPI_ISend with varying Fortran types
+  if (CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+    target_compile_options(${exe} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-wmismatch=MPI_ISend,NF_DEF_VAR>)
+  endif()
 endforeach ()
 
 install(PROGRAMS mk_Restarts DESTINATION bin)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentCNRst.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentCNRst.F90
@@ -11,6 +11,7 @@ module CatchmentCNRstMod
                                  VAR_COL_40, VAR_PFT_40, VAR_COL_45, VAR_PFT_45, &
                                  npft => numpft_CN
   use nanMod         , only : nan
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_nan
   
   implicit none
 
@@ -875,7 +876,7 @@ contains
            end do
         end do
 
-        where(isnan(var_off_pft))  var_off_pft = 0.
+        where(ieee_is_nan(var_off_pft))  var_off_pft = 0.
         where(var_off_pft /= var_off_pft)  var_off_pft = 0.
 
         print *, 'calculating regridded carbn'
@@ -958,7 +959,7 @@ contains
                  iv = nv                                     ! same type fraction (primary of secondary)                          
               else if(ityp_new == ityp_offl (offl_cell,nx) .and. fveg_offl (offl_cell,nx)> fmin) then
                  iv = nx                                     ! not same fraction
-              else if(iclass(ityp_new)==iclass(ityp_offl(offl_cell,nv)) .and. fveg_offl (offl_cell,nv)> fmin) then
+              else if(iclass(ityp_new)==iclass(int(ityp_offl(offl_cell,nv))) .and. fveg_offl (offl_cell,nv)> fmin) then
                  iv = nv                                     ! primary, other type (same class)
               else if(fveg_offl (offl_cell,nx)> fmin) then
                  iv = nx                                     ! secondary, other type (same class)
@@ -975,11 +976,11 @@ contains
               ! Check whether var_pft_out is realistic
               do nz = 1, nzone
                  do j = 1, VAR_PFT
-                    if (isnan(var_pft_out (n, nz,nv,j))) print *,j,nv,nz,n,var_pft_out (n, nz,nv,j),fveg_new
-                    !if(isnan(var_pft_out (n, nz,nv,69))) var_pft_out (n, nz,nv,69) = 1.e-6
-                    !if(isnan(var_pft_out (n, nz,nv,70))) var_pft_out (n, nz,nv,70) = 1.e-6   
-                    !if(isnan(var_pft_out (n, nz,nv,73))) var_pft_out (n, nz,nv,73) = 1.e-6
-                    !if(isnan(var_pft_out (n, nz,nv,74))) var_pft_out (n, nz,nv,74) = 1.e-6                 
+                    if (ieee_is_nan(var_pft_out (n, nz,nv,j))) print *,j,nv,nz,n,var_pft_out (n, nz,nv,j),fveg_new
+                    !if(ieee_is_nan(var_pft_out (n, nz,nv,69))) var_pft_out (n, nz,nv,69) = 1.e-6
+                    !if(ieee_is_nan(var_pft_out (n, nz,nv,70))) var_pft_out (n, nz,nv,70) = 1.e-6   
+                    !if(ieee_is_nan(var_pft_out (n, nz,nv,73))) var_pft_out (n, nz,nv,73) = 1.e-6
+                    !if(ieee_is_nan(var_pft_out (n, nz,nv,74))) var_pft_out (n, nz,nv,74) = 1.e-6                 
                  end do
               end do
            endif

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentRst.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/CatchmentRst.F90
@@ -20,8 +20,7 @@ module CatchmentRstMod
 
   implicit none
 #ifndef __GFORTRAN__
-  integer           :: ftell
-  external          :: ftell
+
 #endif
 
   type :: CatchmentRst
@@ -158,7 +157,7 @@ contains
        open(newunit=unit, file=filename,  form='unformatted', action = 'read')
        bpos=0
        read(unit)
-       epos = ftell(unit)          ! ending position of file pointer
+       inquire(unit=unit, pos=epos)  ! ending position of file pointer (Fortran 2003)
        close(unit)
        ntiles = (epos-bpos)/4-2    ! record size (in 4 byte words; 
        catch%ntiles = ntiles

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/SaltImpConverter.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/SaltImpConverter.F90
@@ -24,8 +24,6 @@ program SaltImpConverter
 
   integer, parameter   :: zoom=1
 #ifndef __GFORTRAN__
-  integer              :: ftell
-  external             :: ftell
 #endif
   integer              :: bpos, epos, ntot
   integer              :: foutID, status, TimID, TileID 
@@ -94,17 +92,17 @@ program SaltImpConverter
     'TS_FOUND'       &
       /
 
-  I = iargc()
+  I = command_argument_count()
 
   if(I /= 3) then
      print *, "Wrong Number of arguments: ", i
      print *, trim(Usage)
-     call exit(1)
+     stop 1
   end if
 
-  call getarg(1,InTileFile)
-  call getarg(2,InImpRestart)
-  call getarg(3,InIntRestart)
+  call get_command_argument(1,InTileFile)
+  call get_command_argument(2,InImpRestart)
+  call get_command_argument(3,InIntRestart)
 
   InRestart = trim(InImpRestart)
 
@@ -243,7 +241,7 @@ program SaltImpConverter
        read (50,iostat=rc)
        if( rc.eq.0 ) then
            ntot = ntot + 1
-           epos = ftell(50)          ! ending position of file pointer
+           inquire(unit=50, pos=epos) ! ftell replacement          ! ending position of file pointer
          nwords = (epos-bpos)/4-2    ! record size (in 4 byte words;
          write(6,100) ntot, nwords
          if( ntot.eq.1 ) then

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/SaltIntSplitter.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/SaltIntSplitter.F90
@@ -24,8 +24,6 @@ program SaltIntSplitter
 
   integer, parameter   :: zoom=1
 #ifndef __GFORTRAN__
-  integer              :: ftell
-  external             :: ftell
 #endif
   integer              :: bpos, epos, ntot
   integer, allocatable :: nrecs(:), mrecs(:)
@@ -53,16 +51,16 @@ program SaltIntSplitter
 
 !---------------------------------------------------------------------------
 
-  I = iargc()
+  I = command_argument_count()
 
   if(I /= 2) then
      print *, "Wrong Number of arguments: ", i
      print *, trim(Usage)
-     call exit(1)
+     stop 1
   end if
 
-  call getarg(1,InTileFile)
-  call getarg(2,InRestart)
+  call get_command_argument(1,InTileFile)
+  call get_command_argument(2,InRestart)
 
 
   call ReadTileFile_RealLatLon(InTileFile, itiles, mask=0)
@@ -298,7 +296,7 @@ program SaltIntSplitter
        read (50,iostat=rc)
        if( rc.eq.0 ) then
            ntot = ntot + 1
-           epos = ftell(50)          ! ending position of file pointer
+           inquire(unit=50, pos=epos) ! ftell replacement          ! ending position of file pointer
          nwords = (epos-bpos)/4-2    ! record size (in 4 byte words;
          write(6,100) ntot, nwords
          if( ntot.eq.1 ) then

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/Scale_Catch.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/Scale_Catch.F90
@@ -19,8 +19,6 @@ program Scale_Catch
 
   character(256)    :: fname1, fname2, fname3
 #ifndef __GFORTRAN__
-  integer           :: ftell
-  external          :: ftell
 #endif
   integer           :: bpos, epos, ntiles, n, nargs
   integer           :: old,  new,  sca
@@ -104,13 +102,13 @@ program Scale_Catch
  
 ! Usage
 ! -----
-  if (iargc() /= 6) then
+  if (command_argument_count() /= 6) then
      write(*,*) "Usage: Scale_Catch <Input_Catch> <Regridded_Catch> <Scaled_Catch> <SURFLAY> <WEMIN_IN> <WEMIN_OUT>"
-     call exit(2)
+     error stop 2
   end if
 
   do n=1,6
-  call getarg(n,arg(n))
+  call get_command_argument(n,arg(n))
   enddo
 
 ! Open INPUT and Regridded Catch Files
@@ -146,7 +144,7 @@ program Scale_Catch
      print *, "You must supply a valid SURFLAY value:"
      print *, "(Ganymed-3 and earlier) SURFLAY=20.0 for Old Soil Params"
      print *, "(Ganymed-4 and later  ) SURFLAY=50.0 for New Soil Params"
-     call exit(2)
+     error stop 2
   end if
   print *, 'SURFLAY: ',SURFLAY
 
@@ -160,7 +158,7 @@ program Scale_Catch
 !    ----------------
      bpos=0
      read(10)
-     epos = ftell(10)            ! ending position of file pointer
+     inquire(unit=10, pos=epos) ! ftell replacement            ! ending position of file pointer
      ntiles = (epos-bpos)/4-2    ! record size (in 4 byte words; 
      rewind 10
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/Scale_CatchCN.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/Scale_CatchCN.F90
@@ -132,13 +132,13 @@ program Scale_CatchCN
   
 ! Usage
 ! -----
-  if (iargc() /= 6) then
+  if (command_argument_count() /= 6) then
      write(*,*) "Usage: Scale_CatchCN <Input_Catch> <Regridded_Catch> <Scaled_Catch> <SURFLAY> <WEMIN_IN> <WEMIN_OUT>"
-     call exit(2)
+     error stop 2
   end if
 
   do n=1,6
-  call getarg(n,arg(n))
+  call get_command_argument(n,arg(n))
   enddo
 
 ! Open INPUT and Regridded Catch Files
@@ -174,7 +174,7 @@ program Scale_CatchCN
      print *, "You must supply a valid SURFLAY value:"
      print *, "(Ganymed-3 and earlier) SURFLAY=20.0 for Old Soil Params"
      print *, "(Ganymed-4 and later  ) SURFLAY=50.0 for New Soil Params"
-     call exit(2)
+     error stop 2
   end if
   print *, 'SURFLAY: ',SURFLAY
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/cv_SaltRestart.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/cv_SaltRestart.F90
@@ -68,7 +68,7 @@ program cv_SaltRestart
 
   source_is_coupled = .false.
 
-  I = iargc()
+  I = command_argument_count()
 
   print*, '# of arguments : ', I
 
@@ -76,25 +76,25 @@ program cv_SaltRestart
      print *, trim(Usage1)
      print *, ' ========= or ==========='
      print *, trim(Usage2)
-     call exit(1)
+     stop 1
   endif
 
   nxt = 1
 
   do while(nxt<=I)
-       call getarg(nxt,arg)
+       call get_command_argument(nxt,arg)
        if(arg(1:1)/='-') then
           print*, 'first letter /= -'
           print *, trim(Usage1)
           print *, ' ========= or ==========='
           print *, trim(Usage2)
-          call exit(1)
+          stop 1
        endif
        opt=arg(2:2)
        if(len(trim(arg))==2) then
           if(scan(opt,'AC')==0) then
              nxt = nxt + 1
-             call getarg(nxt,arg)
+             call get_command_argument(nxt,arg)
           end if
        else
           arg = arg(3:)
@@ -108,7 +108,7 @@ program cv_SaltRestart
           InFile1 = arg
           if(.not. source_is_coupled) then
              nxt = nxt + 1
-             call getarg(nxt,arg)
+             call get_command_argument(nxt,arg)
              InFile2 = arg
           endif  
        case ('t')
@@ -118,7 +118,7 @@ program cv_SaltRestart
           print *, trim(Usage1)
           print *, ' ========= or ==========='
           print *, trim(Usage2)
-          call exit(1)
+          stop 1
        end select
 
        nxt = nxt + 1
@@ -143,7 +143,7 @@ program cv_SaltRestart
 
   if(.not. source_is_coupled)  then
     print*, 'conversion from AMIP style restarts .NOT. implemented yet!!'
-    call exit(1)
+    stop 1
   else
 
   ilyr1(1) = 1                       ! if nilyr  = 4

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_CICERestart.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_CICERestart.F90
@@ -25,17 +25,17 @@ program mk_CiceRestart
 
 !---------------------------------------------------------------------------
 
-  I = iargc()
+  I = command_argument_count()
 
   if(I /= 3) then
      print *, "Wrong Number of arguments: ", i
      print *, trim(Usage)
-     call exit(1)
+     stop 1
   end if
 
-  call getarg(1,OutTileFile)
-  call getarg(2,InTileFile)
-  call getarg(3,InRestart)
+  call get_command_argument(1,OutTileFile)
+  call get_command_argument(2,InTileFile)
+  call get_command_argument(3,InRestart)
 
 ! Read Output Tile File .til file
 ! to get the index into the pfafsttater table

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_CatchCNRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_CatchCNRestarts.F90
@@ -212,7 +212,7 @@ program  mk_CatchCNRestarts
   integer  :: myid=0, numprocs=1, mpierr, mpistatus(MPI_STATUS_SIZE)  
   logical  :: root_proc=.true.
 
-  real, parameter :: nan = O'17760000000'
+  real, parameter :: nan = huge(1.0)
   real, parameter :: fmin= 1.e-4 ! ignore vegetation fractions at or below this value
   integer, parameter :: OutUnit = 40, InUnit = 50
 
@@ -286,7 +286,7 @@ program  mk_CatchCNRestarts
 
   call ESMF_Initialize(LogKindFlag=ESMF_LOGKIND_NONE) 
   
-  I = iargc()
+  I = command_argument_count()
   
   if( I /=5 ) then
      print *, "Wrong Number of arguments: ", i
@@ -295,7 +295,7 @@ program  mk_CatchCNRestarts
   end if
   
   do n=1,I
-     call getarg(n,arg(n))
+     call get_command_argument(n,arg(n))
   enddo
 
   read(arg(1),'(a)') OutTileFile
@@ -308,7 +308,7 @@ program  mk_CatchCNRestarts
      print *, "You must supply a valid SURFLAY value:"
      print *, "(Ganymed-3 and earlier) SURFLAY=20.0 for Old Soil Params"
      print *, "(Ganymed-4 and later  ) SURFLAY=50.0 for New Soil Params"
-     call exit(2)
+     error stop 2
   end if
 
   ! Are BCs data available? 
@@ -1388,7 +1388,7 @@ contains
            do nz = 1,nzone
               STATUS = NF_GET_VARA_REAL(NCFID,VarID(NCFID,'CNCOL'), (/1,i/), (/NTILES_CN,1 /),VAR_DUM2)
               do k = 1, NTILES_CN
-                 var_off_col(TILE_ID(K), nz,nv) = VAR_DUM2(K)
+                 var_off_col(int(TILE_ID(K)), nz,nv) = VAR_DUM2(K)
               end do
               i = i + 1
            end do
@@ -1400,7 +1400,7 @@ contains
               do nz = 1,nzone
                  STATUS = NF_GET_VARA_REAL(NCFID,VarID(NCFID,'CNPFT'), (/1,i/), (/NTILES_CN,1 /),VAR_DUM2)
                  do k = 1, NTILES_CN
-                    var_off_pft(TILE_ID(K), nz,nv,iv) = VAR_DUM2(K)
+                    var_off_pft(int(TILE_ID(K)), nz,nv,iv) = VAR_DUM2(K)
                  end do
                  i = i + 1
               end do
@@ -1442,7 +1442,7 @@ contains
                     iv = nv                                     ! same type fraction (primary of secondary)                          
                  else if(ityp_new == ityp_offl (offl_cell,nx) .and. fveg_offl (offl_cell,nx)> fmin) then
                     iv = nx                                     ! not same fraction
-                 else if(iclass(ityp_new)==iclass(ityp_offl(offl_cell,nv)) .and. fveg_offl (offl_cell,nv)> fmin) then
+                 else if(iclass(ityp_new)==iclass(int(ityp_offl(offl_cell,nv))) .and. fveg_offl (offl_cell,nv)> fmin) then
                     iv = nv                                     ! primary, other type (same class)
                  else if(fveg_offl (offl_cell,nx)> fmin) then
                     iv = nx                                     ! secondary, other type (same class)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_CatchRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_CatchRestarts.F90
@@ -40,16 +40,16 @@ program  mk_CatchRestarts
 
 !---------------------------------------------------------------------------
   
-  I = iargc()
+  I = command_argument_count()
 
   if( I<4 .or. I>5 ) then
      print *, "Wrong Number of arguments: ", i
      print *, trim(Usage)
-     call exit(1)
+     stop 1
   end if
  
   do n=1,I
-  call getarg(n,arg(n))
+  call get_command_argument(n,arg(n))
   enddo
   read(arg(1),'(a)') OutTileFile
   read(arg(2),'(a)')  InTileFile
@@ -57,7 +57,7 @@ program  mk_CatchRestarts
   read(arg(4),*)  SURFLAY
 
   if(I==5) then
-     call getarg(6,OutType)
+     call get_command_argument(6,OutType)
      OutIsOld = trim(OutType)=="OutIsOld"
   else
      OutIsOld = .false.
@@ -67,7 +67,7 @@ program  mk_CatchRestarts
      print *, "You must supply a valid SURFLAY value:"
      print *, "(Ganymed-3 and earlier) SURFLAY=20.0 for Old Soil Params"
      print *, "(Ganymed-4 and later  ) SURFLAY=50.0 for New Soil Params"
-     call exit(2)
+     error stop 2
   end if
 
   inquire(file=trim(DataDir)//"mosaic_veg_typs_fracs",exist=havedata)
@@ -354,7 +354,7 @@ contains
           enddo
        else
           print *, "Number of tiles in data, ",Ncatch," does not match number in til file ", size(Ido)
-          call exit(1)
+          stop 1
        endif
        
        allocate(ity(ncatch),rity(ncatch))

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_GEOSldasRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_GEOSldasRestarts.F90
@@ -54,7 +54,7 @@ PROGRAM mk_GEOSldasRestarts
   integer, parameter :: VAR_COL_CLM45 = 35 ! number of CN column restart variables
   integer, parameter :: VAR_PFT_CLM45 = 75 ! number of CN PFT variables per column
 
-  real,    parameter :: nan = O'17760000000'
+  real,    parameter :: nan = huge(1.0)
   real,    parameter :: fmin= 1.e-4 ! ignore vegetation fractions at or below this value
   integer, parameter :: OutUnit = 40, InUnit = 50
   character*256      :: arg, tmpstring, ESMADIR
@@ -131,17 +131,17 @@ PROGRAM mk_GEOSldasRestarts
   ! ----------------
 
   CALL get_command (cmd)
-  call getenv ("ESMADIR"        ,ESMADIR        )
+  call get_environment_variable("ESMADIR"        ,ESMADIR        )
   nxt = 1
   
-  call getarg(nxt,arg)
+  call get_command_argument(nxt,arg)
   rstfile = 'NONE'
   do while(arg(1:1)=='-')
 
      opt=arg(2:2)
      if(len(trim(arg))==2) then
         nxt = nxt + 1
-        call getarg(nxt,arg)
+        call get_command_argument(nxt,arg)
      else
         arg = arg(3:)
      end if
@@ -188,10 +188,10 @@ PROGRAM mk_GEOSldasRestarts
         RSTFILE   =  trim(arg)
      case default
         print *, trim(Usage)
-        call exit(1)
+        stop 1
      end select
      nxt = nxt + 1
-     call getarg(nxt,arg)
+     call get_command_argument(nxt,arg)
   end do
 
   if (index(model, 'catchcn') /=0 ) then
@@ -220,7 +220,7 @@ PROGRAM mk_GEOSldasRestarts
 
      call MPI_Barrier(MPI_COMM_WORLD, STATUS)
      call MPI_FINALIZE(mpierr)
-     call exit(0)     
+     stop 0     
 
   elseif (trim(REORDER) == 'R') then
 
@@ -230,7 +230,7 @@ PROGRAM mk_GEOSldasRestarts
  
      call MPI_Barrier(MPI_COMM_WORLD, STATUS)
      call MPI_FINALIZE(mpierr)
-     call exit(0)
+     stop 0
   
   else
 
@@ -238,13 +238,13 @@ PROGRAM mk_GEOSldasRestarts
 
      if(JOBFILE == 'N') then
 
-        call system('mkdir -p InData/  OutData/')
+        call execute_command_line('mkdir -p InData/  OutData/')
         tmpstring =  'cp '//trim(BCSDIR)//'/'//trim(TILFILE)//' InData/OutTileFile'
-        call system(tmpstring)
+        call execute_command_line(tmpstring)
         tmpstring =  'cp '//trim(BCSDIR)//'/'//trim(TILFILE)//' OutData/OutTileFile'
-        call system(tmpstring)
+        call execute_command_line(tmpstring)
         tmpstring =  'ln -s '//trim(BCSDIR)//'/clsm OutData/clsm'
-        call system(tmpstring)
+        call execute_command_line(tmpstring)
 
         open (10, file ='mkLDASsa.j', form = 'formatted', status ='unknown', action = 'write')
         write(10,'(a)')'#!/bin/csh -fx'
@@ -271,7 +271,7 @@ PROGRAM mk_GEOSldasRestarts
         write(10,'(a)')'bin/'//trim(catch_scaler)//' InData/'//model//'_internal_rst OutData/'//model//'_internal_rst '//model//'_internal_rst '//trim(SFL)
 
         close (10, status ='keep')
-        call system('chmod 755 mkLDASsa.j')
+        call execute_command_line('chmod 755 mkLDASsa.j')
         stop
      endif
   endif
@@ -2011,7 +2011,7 @@ contains
           do nz = 1,nzone
              STATUS = NF_GET_VARA_REAL(NCFID,VarID(NCFID,'CNCOL'), (/1,i/), (/NTILES_CN,1 /),VAR_DUM2)
              do k = 1, NTILES_CN
-                var_off_col(TILE_ID(K), nz,nv) = VAR_DUM2(K)
+                var_off_col(int(TILE_ID(K)), nz,nv) = VAR_DUM2(K)
              end do
              i = i + 1
           end do
@@ -2023,7 +2023,7 @@ contains
              do nz = 1,nzone
                 STATUS = NF_GET_VARA_REAL(NCFID,VarID(NCFID,'CNPFT'), (/1,i/), (/NTILES_CN,1 /),VAR_DUM2)
                 do k = 1, NTILES_CN
-                   var_off_pft(TILE_ID(K), nz,nv,iv) = VAR_DUM2(K)
+                   var_off_pft(int(TILE_ID(K)), nz,nv,iv) = VAR_DUM2(K)
                 end do
                 i = i + 1
              end do
@@ -2114,7 +2114,7 @@ contains
                  iv = nv                                     ! same type fraction (primary of secondary)                          
               else if(ityp_new == ityp_offl (offl_cell,nx) .and. fveg_offl (offl_cell,nx)> fmin) then
                  iv = nx                                     ! not same fraction
-              else if(iclass(ityp_new)==iclass(ityp_offl(offl_cell,nv)) .and. fveg_offl (offl_cell,nv)> fmin) then
+              else if(iclass(ityp_new)==iclass(int(ityp_offl(offl_cell,nv))) .and. fveg_offl (offl_cell,nv)> fmin) then
                  iv = nv                                     ! primary, other type (same class)
               else if(fveg_offl (offl_cell,nx)> fmin) then
                  iv = nx                                     ! secondary, other type (same class)
@@ -3910,7 +3910,7 @@ contains
 
     call OutFmt%close()
 
-    call system('/bin/cp InData/catch_internal_rst OutData/catch_internal_rst')
+    call execute_command_line('/bin/cp InData/catch_internal_rst OutData/catch_internal_rst')
 
   END SUBROUTINE read_ldas_restarts
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_LakeLandiceSaltRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_LakeLandiceSaltRestarts.F90
@@ -27,8 +27,6 @@ program mk_LakeLandiceSaltRestarts
 
   integer           :: zoom
 #ifndef __GFORTRAN__
-  integer              :: ftell
-  external             :: ftell
 #endif
   integer              :: bpos, epos, ntot
   integer, allocatable :: nrecs(:), mrecs(:)
@@ -48,20 +46,20 @@ program mk_LakeLandiceSaltRestarts
   integer :: status
 !---------------------------------------------------------------------------
 
-  I = iargc()
+  I = command_argument_count()
 
   if(I /= 5) then
      print *, "Wrong Number of arguments: ", i
      print *, trim(Usage)
-     call exit(1)
+     stop 1
   end if
 
-  call getarg(1,OutTileFile)
-  call getarg(2,InTileFile)
-  call getarg(3,InRestart)
-  call getarg(4,arg)
+  call get_command_argument(1,OutTileFile)
+  call get_command_argument(2,InTileFile)
+  call get_command_argument(3,InRestart)
+  call get_command_argument(4,arg)
   read(arg,*) mask
-  call getarg(5,arg)
+  call get_command_argument(5,arg)
   read(arg,*) zoom
 
 ! Read Output Tile File .til file
@@ -200,7 +198,7 @@ program mk_LakeLandiceSaltRestarts
        read (50,iostat=rc)
        if( rc.eq.0 ) then
            ntot = ntot + 1
-           epos = ftell(50)          ! ending position of file pointer
+           inquire(unit=50, pos=epos) ! ftell replacement          ! ending position of file pointer
          nwords = (epos-bpos)/4-2    ! record size (in 4 byte words;
          write(6,100) ntot, nwords
          if( ntot.eq.1 ) then

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_catchANDcnRestarts.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/mk_restarts/mk_catchANDcnRestarts.F90
@@ -51,65 +51,65 @@ PROGRAM mk_catchANDcnRestarts
        integer :: nxt
        character(len=256) :: arg
        nxt = 1
-       call getarg(nxt,arg)
+       call get_command_argument(nxt,arg)
 
        do while(trim(arg) /= '')
           select case (trim(arg))
           case ('-h')
               call print_usage()
-              call exit(0)
+              stop 0
           case ('-out_bcs')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             out_bcsdir = trim(arg)
           case ('-time')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             YYYYMMDDHHMM = trim(arg)
           case ('-out_dir')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             out_dir = trim(arg)
           case ('-model')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             model = trim(arg)
           case ('-surflay')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             read(arg,*)  surflay
           case ('-in_tilefile')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             in_tilefile =  trim(arg)
           case ('-out_tilefile')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             out_tilefile =  trim(arg)
           case ('-in_rst')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             in_rstfile   =  trim(arg)
           case ('-out_rst')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             out_rstfile   =  trim(arg)
           case ('-in_wemin')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             read(arg,*)  wemin_in
           case ('-out_wemin')
             nxt = nxt + 1
-            call getarg(nxt,arg)
+            call get_command_argument(nxt,arg)
             read(arg,*)  wemin_out
           case default
             print*, trim(arg)
             call print_usage()
             print*, "wong command line"
-            call exit(1)
+            stop 1
           end select
           nxt = nxt + 1
-          call getarg(nxt,arg)
+          call get_command_argument(nxt,arg)
        end do
        if (index(model, 'catchcn') /=0 ) then
          if((INDEX(out_bcsdir, '/ICA/') /= 0) .or. (INDEX(out_bcsdir, '/GM4/') /= 0)) then


### PR DESCRIPTION
…nents

- nanMod.F90, clm_varcon.F90, CN_DriverMod.F90: fix NaN/kind handling for NAG
- lsm_routines.F90, StieglitzSnow.F90: fix type/kind issues
- GEOS_IgniGridComp.F90, GEOS_RouteGridComp.F90: NAG compatibility fixes
- makebcs/: fix scalar-vs-array, type mismatch, and OPEN CONVERT issues; add NAG CMake flags
- mk_restarts/: fix NF_DEF_VAR dimids array, kind literals, type mismatches; add NAG CMake flags
- generate_scrip_cube.F90, utils_topo/CMakeLists.txt: NAG fixes for topo utilities
- get_finalID_msk.f90, get_Pfaf_file.f90: fix free-form source and type issues