### PR TITLE
Migrate MAPL_AllocateCoupling caller in GEOSgigatraj to MAPL_FieldEmptyComplete

### DIFF
--- a/GEOSgigatraj_GridComp/GEOS_GigatrajGridComp.F90
+++ b/GEOSgigatraj_GridComp/GEOS_GigatrajGridComp.F90
@@ -379,7 +379,7 @@ contains
             endif
             call ESMF_FieldBundleGet(bdle, trim(FieldNames(i)), field=tmp_field, _RC)
          endif
-         call MAPL_AllocateCoupling(tmp_field, _RC)
+         call MAPL_FieldEmptyComplete(tmp_field, _RC)
          call ESMF_AttributeGet(tmp_field, NAME='LONG_NAME', VALUE=LONG_NAME, _RC)
          call ESMF_AttributeGet(tmp_field, NAME='UNITS', VALUE=UNITS, _RC)
     


### PR DESCRIPTION
## Summary

- Replaces `call MAPL_AllocateCoupling(...)` with `call MAPL_FieldEmptyComplete(...)` in:
  - `GEOSgigatraj_GridComp/GEOS_GigatrajGridComp.F90`

## Context

`MAPL_AllocateCoupling` is a legacy MAPL2 Base symbol being removed as part of the MAPL3 migration (GEOS-ESM/MAPL#4820). `MAPL_FieldEmptyComplete` is the MAPL3 replacement with identical behavior — it reads all field metadata from `ESMF_Info` and allocates accordingly. It is now available transitively via `use MAPL` following GEOS-ESM/MAPL#4823.

Closes #1401.
