### PR TITLE
Replace MAPL_DecomposeDim with mapl_GetPartition in RouteGridComp

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOSroute_GridComp/GEOS_RouteGridComp.F90
@@ -25,6 +25,7 @@ module GEOS_RouteGridCompMod
 
   use ESMF
   use MAPL_Mod
+  use mapl_Partition, only: mapl_GetPartition
   use MAPL_Constants
   use ROUTING_MODEL,          ONLY:     &
        river_routing, ROUTE_DT
@@ -400,7 +401,7 @@ contains
     route%mype = mype
     
     ! define minCatch, maxCatch
-    call MAPL_DecomposeDim ( n_catg,ims,ndes ) ! ims(mype+1) gives the size of my partition
+    ims = mapl_GetPartition(n_catg, k=ndes) ! ims(mype+1) gives the size of my partition
     ! myPE is 0-based!
     beforeMe = sum(ims(1:mype))
     minCatch = beforeMe + 1


### PR DESCRIPTION
## Summary

- Replace legacy `MAPL_DecomposeDim` with v3 `mapl_GetPartition` in `GEOS_RouteGridComp.F90`
- Add `use mapl_Partition, only: mapl_GetPartition` to the module use list

## Notes

- This was the only call site of `MAPL_DecomposeDim` in GEOSgcm, enabling its removal in a follow-on MAPL PR.
- `mapl_GetPartition` returns a 1-based integer array of local sizes, fully compatible with the existing `ims(mype+1)` indexing.

Closes GEOS-ESM/GEOSgcm#1080