### PR TITLE
Migrate MAPL_BaseMod to MAPL_Constants in surface/land components

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/cloudnew.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/cloudnew.F90
@@ -21,7 +21,7 @@ module cloudnew
                                 MAPL_PI   , MAPL_R8   , &
                                 MAPL_R4   , MAPL_AVOGAD
 
-   use MAPL_BaseMod,      only: MAPL_UNDEF
+   use MAPL_Constants,    only: MAPL_UNDEF
    use Aer_Actv_Single_Moment,only: USE_BERGERON, USE_AEROSOL_NN
    use GEOSmoist_Process_Library
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatchCN_GridComp/Shared/catchmentCN.F90
@@ -64,7 +64,7 @@
 
 MODULE CATCHMENT_CN_MODEL
   
-  USE MAPL_BaseMod,      ONLY: MAPL_Land
+  USE MAPL_Constants,    ONLY: MAPL_Land
   
   USE MAPL_Constants, ONLY:           &
        PIE               => MAPL_PI,     &  ! -                       

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catch_incr.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catch_incr.F90
@@ -6,7 +6,7 @@ module catch_incr
   ! reichle+csdraper,  3 Apr 2012
   ! reichle,          29 Sep 2023 - added snow checks 
 
-  use MAPL_BaseMod,      ONLY:               &
+  use MAPL_Constants,    ONLY:               &
        MAPL_Land
 
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/catchment.F90
@@ -62,7 +62,7 @@
 
       MODULE CATCHMENT_MODEL
 
-      USE MAPL_BaseMod,      ONLY:               &
+      USE MAPL_Constants,    ONLY:               &
            NTYPS             => MAPL_NumVegTypes, &
            MAPL_Land,                             &
            MAPL_UNDEF

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/StieglitzSnow.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Shared/StieglitzSnow.F90
@@ -22,7 +22,7 @@ module StieglitzSnow
        TF   => MAPL_TICE,       &  ! K          
        RHOW => MAPL_RHOWTR         ! kg/m^3     
   
-  USE MAPL_BaseMod,      ONLY: MAPL_LANDICE
+  USE MAPL_Constants,    ONLY: MAPL_LANDICE
  
   USE SurfParams,        ONLY: WEMIN, AICEV, AICEN
   


### PR DESCRIPTION
## Summary

Replaces `use MAPL_BaseMod` with `use MAPL_Constants` in 5 land/surface component files, as `MAPL_BaseMod` is being deleted in GEOS-ESM/MAPL#4857.

## Files changed

- `GEOSmoist_GridComp/cloudnew.F90` — `MAPL_UNDEF`
- `GEOSsurface_GridComp/Shared/StieglitzSnow.F90` — `MAPL_LANDICE`
- `GEOScatch_GridComp/catchment.F90` — `MAPL_NumVegTypes`, `MAPL_Land`, `MAPL_UNDEF`
- `GEOScatch_GridComp/catch_incr.F90` — `MAPL_Land`
- `GEOScatchCN_GridComp/Shared/catchmentCN.F90` — `MAPL_Land`

Closes #1408
Part of GEOS-ESM/MAPL#4857