### PR TITLE
Replace MAPL2 dependency with MAPL in GEOSgwd_GridComp

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
@@ -31,7 +31,7 @@ esma_add_library (
   SRCS ${srcs}
   # GEOS_Shared removed: no GWD source file actually uses it (leftover dependency)
   # not yet ported to MAPL3 - restore GEOS_Shared when ported
-  DEPENDENCIES MAPL2 MAPL MAPL.generic3g MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
+  DEPENDENCIES MAPL MAPL.generic3g MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
   )
 
 mapl_acg (


### PR DESCRIPTION
## Summary

- Removes `MAPL2` from `DEPENDENCIES` in `GEOSgwd_GridComp/CMakeLists.txt`, replacing with `MAPL`

## Motivation

Part of the MAPL2 retirement sequence. Contingent on GEOS-ESM/MAPL#4889 (PR1) being merged.

## Related Issues

Closes #1415