### PR TITLE
Replace mapl3g_ uses with use MAPL in GEOS_GwdGridComp.F90

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -38,17 +38,12 @@ module GEOS_GwdGridCompMod
    use MAPL_CommsMod, only: MAPL_AM_I_ROOT, ArrayGather
    use MAPL_Constants, only: MAPL_RADIUS, MAPL_RGAS, MAPL_GRAV, MAPL_VIREPS, MAPL_PI, MAPL_P00, MAPL_CP
 
-   use mapl3g_generic, only: MAPL_GridCompSetEntryPoint
-   use mapl3g_generic, only: MAPL_GridCompGet
-   use mapl3g_generic, only: MAPL_GridCompGetResource
-   use mapl3g_generic, only: MAPL_GridCompGetInternalState
-   use mapl3g_generic, only: MAPL_GridCompAddSpec
-   use mapl3g_RestartModes, only: MAPL_RESTART_SKIP
-   use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE
-   use mapl3g_UngriddedDims, only: UngriddedDims
-   use MAPL, only: MAPL_GridGet, MAPL_GridGetCoordinates, mapl_GridGetGlobalCellCountPerDim
-   use mapl3g_State_API, only: MAPL_StateGetPointer
-   use mapl3g_UngriddedDim, only: UngriddedDim
+   use MAPL, only: MAPL_GridGet, MAPL_GridGetCoordinates, mapl_GridGetGlobalCellCountPerDim, &
+                   MAPL_GridCompSetEntryPoint, MAPL_GridCompGet, MAPL_GridCompGetResource, &
+                   MAPL_GridCompGetInternalState, MAPL_GridCompAddSpec, MAPL_RESTART_SKIP, &
+                   VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
+                   UngriddedDims, MAPL_StateGetPointer
+   use mapl_UngriddedDim, only: UngriddedDim
 
    use gw_rdg, only : gw_rdg_init
    use gw_oro, only : gw_oro_init

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -43,7 +43,7 @@ module GEOS_GwdGridCompMod
                    MAPL_GridCompGetInternalState, MAPL_GridCompAddSpec, MAPL_RESTART_SKIP, &
                    VERTICAL_STAGGER_NONE, VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, &
                    UngriddedDims, MAPL_StateGetPointer
-   use mapl_UngriddedDim, only: UngriddedDim
+   use mapl3g_UngriddedDim, only: UngriddedDim
 
    use gw_rdg, only : gw_rdg_init
    use gw_oro, only : gw_oro_init


### PR DESCRIPTION
## Summary

- Replace all `use mapl3g_*` statements with `use MAPL` in `GEOSgwd_GridComp/GEOS_GwdGridComp.F90`
- `UngriddedDim` is not yet re-exported by the MAPL umbrella; accessed directly via `use mapl_UngriddedDim`

## Motivation

MAPL Phase 9 (#4944) renamed all `mapl3g_` module prefixes to `mapl_`. This PR updates the GWD grid component to use the standard MAPL umbrella module.