### PR TITLE
Remove direct MAPL.generic3g link dependency (closes #1433)

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
@@ -31,7 +31,7 @@ esma_add_library (
   SRCS ${srcs}
   # GEOS_Shared removed: no GWD source file actually uses it (leftover dependency)
   # not yet ported to MAPL3 - restore GEOS_Shared when ported
-  DEPENDENCIES MAPL MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
+  DEPENDENCIES MAPL ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
   )
 
 mapl_acg (

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
@@ -31,7 +31,7 @@ esma_add_library (
   SRCS ${srcs}
   # GEOS_Shared removed: no GWD source file actually uses it (leftover dependency)
   # not yet ported to MAPL3 - restore GEOS_Shared when ported
-  DEPENDENCIES MAPL MAPL.generic3g MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
+  DEPENDENCIES MAPL MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran TYPE SHARED
   )
 
 mapl_acg (


### PR DESCRIPTION
## Summary

- Remove `MAPL.generic3g` from `DEPENDENCIES` in `GEOSgwd_GridComp/CMakeLists.txt`

All symbols are available transitively through `MAPL`. This target no longer exists as of GEOS-ESM/MAPL#4990.

## Dependency

**Draft — contingent on GEOS-ESM/MAPL#4990.**