### PR TITLE
Make consistency btw default values of SS_FOUND in OpenWater and SeaiceInterface

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_OpenWaterGridComp.F90
@@ -1298,7 +1298,7 @@ module GEOS_OpenwaterGridCompMod
           UNITS              = 'PSU',                             &
           DIMS               = MAPL_DimsTileOnly,                 &
           VLOCATION          = MAPL_VLocationNone,                &
-          DEFAULT            = 30.0,                              &
+          DEFAULT            = 33.3333,                           &  !SK - Match the SS_FOUND in OpenWater and SeaiceInterface
           _RC)
 
      call MAPL_AddImportSpec(GC,                                  &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSsaltwater_GridComp/GEOS_SimpleSeaiceGridComp.F90
@@ -1071,7 +1071,7 @@ module GEOS_SimpleSeaiceGridCompMod
         UNITS              = 'psu',                               &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
-        DEFAULT            = 30.0,                                &
+        DEFAULT            = 33.3333,                             &     !SK - Match the SS_FOUND inSimpleSeaice with that from OpenWater and SeaiceInterface
         _RC  )
 
    call MAPL_AddImportSpec(GC,                                  &


### PR DESCRIPTION
## Notes:
- Default values of SS_FOUND were different in ImportSpec from OpenWater and SeaiceInterface
- This makes inconsistency in MAPLE initialDefault
- This PR fixes this inconsistency