### PR TITLE
GEOSgwd_GridComp: drop 3g argument from mapl_acg() call

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/CMakeLists.txt
@@ -37,7 +37,6 @@ esma_add_library (
 mapl_acg (
   ${this} GWD_StateSpecs.rc
   IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS GET_POINTERS DECLARE_POINTERS
-  3g
   )
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280


### PR DESCRIPTION
Remove the `3g` argument from the `mapl_acg()` call in `GEOSgwd_GridComp/CMakeLists.txt`.