### PR TITLE
bugfix: Replace non-standard fstat with standard Fortran INQUIRE in mkMITAquaRaster.F90

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkMITAquaRaster.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkMITAquaRaster.F90
@@ -5,7 +5,7 @@
 
       use LogRectRasterizeMod,     ONLY: LRRasterize
       use MAPL_ExceptionHandling
-      use, intrinsic :: iso_fortran_env, only: REAL64
+      use, intrinsic :: iso_fortran_env, only: REAL64, INT64
       implicit none
 
       integer, parameter      :: IUNIT  = 11,   OUNIT = 12
@@ -14,9 +14,9 @@
       INTEGER                 :: NC
       INTEGER                 :: NX, NY
 
-      integer                 :: STATARRAY(12)
-      integer(REAL64)         :: filesize
-      integer(REAL64)         :: Length
+      integer                 :: ios
+      integer(INT64)          :: filesize
+      integer(INT64)          :: Length
       integer                 :: K
       integer                 :: i, j
       integer                 :: KF, L, NF
@@ -84,7 +84,7 @@
 !            161,162,179,180,197,198,215,216,233,234]
 !#15x15   nprocs = 360
 !#  blankList(1:108)
-! [1,2,3,4,5,6,7,8,9,10,11,12,14,15,16,17,18,21,22,23,24,& 
+! [1,2,3,4,5,6,7,8,9,10,11,12,14,15,16,17,18,21,22,23,24,&
 !  65,71,75,76,90,95,96,101,102,109,110,111,112,113,114,115,116,117,118,119,&
 !  120,121,122,123,124,125,126,127,128,129,130,131,132,&
 !  188,189,190,193,194,195,196,199,&
@@ -112,7 +112,7 @@
       print *, trim(Usage)
       call exit(1)
    end if
-   
+
    nxt = 1
    call get_command_argument(nxt,arg)
    do while(arg(1:1)=='-')
@@ -152,10 +152,11 @@
    BLNKSZ =  count(blanklist /= 0)
 
       ! Open Facet 3 first. It is always a square (CS or LLC)
-      open (IUNIT,file=trim(GridDir)//'/tile003.mitgrid', status='old')
-      call fstat(IUNIT,statarray)
-      close (IUNIT)
-      filesize = statarray(8)
+      inquire(file=trim(GridDir)//'/tile003.mitgrid', size=filesize, iostat=ios)
+      if (ios /= 0) then
+         print *, 'Error opening file: ', trim(GridDir)//'/tile003.mitgrid'
+         call exit(1)
+      end if
 
       !ALT: Kludge for LLC4320
       if (filesize <= 0) filesize = 2389893248
@@ -181,11 +182,11 @@
       LENGTH = nx*ny*REAL64
 
       ! Open Facet 1 to check sizes CS or LLC)
-      open (IUNIT,file=trim(GridDir)//'/tile001.mitgrid', status='old')
-      call fstat(IUNIT,statarray)
-      close (IUNIT)
-
-      filesize = statarray(8)
+      inquire(file=trim(GridDir)//'/tile001.mitgrid', size=filesize, iostat=ios)
+      if (ios /= 0) then
+         print *, 'Error opening file: ', trim(GridDir)//'/tile001.mitgrid'
+         call exit(1)
+      end if
 
       !ALT: Kludge for LLC4320
       if (filesize <= 0) filesize = 7168573568
@@ -303,7 +304,7 @@
       open (IUNIT, FILE=trim(GridDir)//trim(FACEFILE), &
             ACCESS='DIRECT', RECL=LENGTH, STATUS='OLD',convert='big_endian')
 
-!      read (IUNIT,REC=5) rA 
+!      read (IUNIT,REC=5) rA
       read (IUNIT,REC=6) XG
       read (IUNIT,REC=7) YG
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkMITAquaRaster.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkMITAquaRaster.F90
@@ -158,8 +158,6 @@
          call exit(1)
       end if
 
-      !ALT: Kludge for LLC4320
-      if (filesize <= 0) filesize = 2389893248
 !      print *,'file size=',filesize
 
       LENGTH = filesize/REAL64
@@ -188,8 +186,6 @@
          call exit(1)
       end if
 
-      !ALT: Kludge for LLC4320
-      if (filesize <= 0) filesize = 7168573568
 !      print *,'file size=',filesize
 
       LENGTH = filesize/(REAL64 * k)


### PR DESCRIPTION
## NOTE

I had to close #1445 and reopen this PR with a different branch name. Something very weird was happening with CI/mepo.

---

GCC 16 tightened enforcement of the `fstat` intrinsic signature, requiring a 13-element array but the code declared only 12, causing a compile error:

```
Error: Size of 'values' argument of 'fstat' intrinsic at (1) too small (12/13)
```

`fstat` is a non-standard GNU extension. This fix replaces both calls with the standard Fortran 2003 `INQUIRE(file=..., size=...)` intrinsic, which directly returns the file size without needing an intermediate status array. This is portable across compilers and was already applied in the Flang fixes in #1175.

Additional cleanup:
- `integer(REAL64)` → `integer(INT64)` for `filesize` and `Length` — using `REAL64` as a kind parameter for an integer variable was technically accidental (both happen to be kind=8 on most platforms); `INT64` is semantically correct.
- `STATARRAY(12)` declaration removed as it is no longer needed.
- `INT64` added to the `iso_fortran_env` import.

All my testing shows this is zero-diff but then, the model doesn't run this code. This is part of the makebcs code...

(Replaces #1445, which was closed due to a branch rename to avoid a CI issue with `mepo checkout-if-exists`.)