### PR TITLE
ISSM Continuation Across Segments

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1011,7 +1011,6 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME = "NSTEPS_ISSM",                               &
         LONG_NAME  = "steps_since_issm",                          &
         UNITS      = "none",                                      &
-        PRECISION  = ESMF_KIND_I4,                                &
         DIMS       = MAPL_DimsNone,                               &
         UNGRIDDED_DIMS = (/1/),                                   &
         VLOCATION  = MAPL_VlocationNone,                          &
@@ -1748,7 +1747,7 @@ module GEOS_LandiceGridCompMod
        integer, optional,   intent(  out) :: RC     ! Error code
 
        type (ESMF_State)                  :: INTERNAL
-       integer, pointer                   :: NSTEPS_ISSM(:)
+       real, pointer                   :: NSTEPS_ISSM(:)
    
    ! !DESCRIPTION: The Initialize method of the Landice Gridded Component.
    
@@ -1824,7 +1823,7 @@ module GEOS_LandiceGridCompMod
              allocate(issm_tile_state%ICETHICK_TILE(nt_local))
              allocate(issm_tile_state%ICEVEL_TILE(nt_local))
              allocate(issm_tile_state%ICESMB_TILE(nt_local))
-             issm_tile_state%NSTEPS_INIT = NSTEPS_ISSM(:)
+             issm_tile_state%NSTEPS_INIT = nint(NSTEPS_ISSM(1))
              issm_tile_wrap%ptr => issm_tile_state
              call ESMF_UserCompSetInternalState(GCS(I), 'ISSM_TILES', issm_tile_wrap, status)
              VERIFY_(STATUS)
@@ -2880,7 +2879,7 @@ contains
         ! initialize from restart 
         ! (defaults to zero; i.e. ISSM has not run yet)
         ICESMB_ISSM(:) = ICESMB_ISSM_IN(:) 
-        NSTEPS_ISSM = NSTEPS_ISSM_IN(:) ! steps since last ISSM run
+        NSTEPS_ISSM = nint(NSTEPS_ISSM_IN(1)) ! steps since last ISSM run
     end if 
 
     allocate(MLT (NT), STAT=STATUS)
@@ -3508,7 +3507,7 @@ contains
 
         ! update internal states
         if(associated(ICESMB_ISSM_IN)) ICESMB_ISSM_IN = ICESMB_ISSM
-        if(associated(NSTEPS_ISSM_IN)) NSTEPS_ISSM_IN(:) = NSTEPS_ISSM
+        if(associated(NSTEPS_ISSM_IN)) NSTEPS_ISSM_IN(1) = real(NSTEPS_ISSM)
 
     end if 
 ! Update snow and landice albedos to anticipate
@@ -3681,7 +3680,7 @@ contains
 
                ! update internal states after refresh
                if(associated(ICESMB_ISSM_IN)) ICESMB_ISSM_IN = ICESMB_ISSM
-               if(associated(NSTEPS_ISSM_IN)) NSTEPS_ISSM_IN(:) = NSTEPS_ISSM
+               if(associated(NSTEPS_ISSM_IN)) NSTEPS_ISSM_IN(1) = real(NSTEPS_ISSM)
             end if 
          endif
       enddo

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1008,27 +1008,14 @@ module GEOS_LandiceGridCompMod
 !  !Internal state:
 #ifdef HAVE_ISSM  
      call MAPL_AddInternalSpec(GC,                                &
-        SHORT_NAME = "NSTEPS_ISSM",                               &
-        LONG_NAME  = "steps_since_issm",                          &
-        UNITS      = "none",                                      &
-        DIMS       = MAPL_DimsNone,                               &
-        UNGRIDDED_DIMS = (/1/),                                   &
-        VLOCATION  = MAPL_VlocationNone,                          &
-        RESTART    = MAPL_RestartOptional,                        & 
-        DEFAULT    = 0,                                           &
-        RC         = STATUS                                       &
-      )
-     VERIFY_(STATUS)
-
-     call MAPL_AddInternalSpec(GC,                                &
         SHORT_NAME         = 'ICESMB_ISSM',                       &
         LONG_NAME          = 'issm_surface_mass_balance',         &
         UNITS              = 'kg m-2 s-1',                        &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
+		RESTART            = MAPL_RestartOptional,                & 
         DEFAULT            = 0.0 ,                                &
                                                     RC=STATUS  )
-
 #endif
 
      call MAPL_AddInternalSpec(GC,                           &
@@ -1747,7 +1734,6 @@ module GEOS_LandiceGridCompMod
        integer, optional,   intent(  out) :: RC     ! Error code
 
        type (ESMF_State)                  :: INTERNAL
-       real, pointer                   :: NSTEPS_ISSM(:)
    
    ! !DESCRIPTION: The Initialize method of the Landice Gridded Component.
    
@@ -1809,8 +1795,6 @@ module GEOS_LandiceGridCompMod
        call MAPL_Get(MAPL, INTERNAL_ESMF_STATE = INTERNAL, RC=STATUS) 
        VERIFY_(STATUS)   
 
-       call MAPL_GetPointer(INTERNAL,NSTEPS_ISSM,'NSTEPS_ISSM', RC=STATUS); VERIFY_(STATUS)
-
        do I = 1, SIZE(GCS)
           call MAPL_GetObjectFromGC( GCS(I), CHILD_MAPL, RC=STATUS )
           VERIFY_(STATUS)
@@ -1822,8 +1806,8 @@ module GEOS_LandiceGridCompMod
              allocate(issm_tile_state%ICESURF_TILE(nt_local))
              allocate(issm_tile_state%ICETHICK_TILE(nt_local))
              allocate(issm_tile_state%ICEVEL_TILE(nt_local))
-             allocate(issm_tile_state%ICESMB_TILE(nt_local))
-             issm_tile_state%NSTEPS_INIT = nint(NSTEPS_ISSM(1))
+             allocate(issm_tile_state%ICESMB_ISSM(nt_local))
+			 issm_tile_state%NSTEPS_ISSM = 0
              issm_tile_wrap%ptr => issm_tile_state
              call ESMF_UserCompSetInternalState(GCS(I), 'ISSM_TILES', issm_tile_wrap, status)
              VERIFY_(STATUS)
@@ -2368,8 +2352,6 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
 #ifdef HAVE_ISSM    
   type(T_ISSM_TILE_STATE), pointer    :: issm_tile_state
   type(ISSM_TILE_WRAP)                :: issm_tile_wrap
-  real, pointer                       :: ICESMB_ISSM_IN(:) ! pointer to internal for time-averaged SMB
-  integer, pointer                    :: NSTEPS_ISSM_IN(:) ! pointer to internal for steps since last ISSM run
 #endif
 !=============================================================================
 
@@ -2522,7 +2504,7 @@ contains
    real, pointer, dimension(:)   :: RMELTOC002
 
 ! pointers to internal
-
+   real, pointer, dimension(:)    :: ICESMB_IN
    real, pointer, dimension(:,:)  :: TS
    real, pointer, dimension(:,:)  :: QS
    real, pointer, dimension(:,:)  :: FR
@@ -2691,6 +2673,8 @@ contains
    real, parameter :: LANDICEDEPTH_ = 0.07 ! water equiv depth of top layer
    real, parameter :: LANDICECOND_  = 1.2  ! ice conductivity divided by depth of bottom layer
    real, parameter :: LANDICETDEEP_ = 230. ! deep ice temperature
+
+   integer :: u, ios      ! read ISSM_NSTEPS txt file
 !  Begin...
 !----------
 
@@ -2746,12 +2730,9 @@ contains
 
 ! Pointers to internals
 !----------------------
-   
 #ifdef HAVE_ISSM
-   call MAPL_GetPointer(INTERNAL,ICESMB_ISSM_IN,'ICESMB_ISSM', RC=STATUS); VERIFY_(STATUS)
-   call MAPL_GetPointer(INTERNAL,NSTEPS_ISSM_IN,'NSTEPS_ISSM', RC=STATUS); VERIFY_(STATUS)
+   call MAPL_GetPointer(INTERNAL,ICESMB_IN , 'ICESMB_ISSM',alloc=.true., RC=STATUS); VERIFY_(STATUS)
 #endif
-
    call MAPL_GetPointer(INTERNAL,TS   , 'TS'     , RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(INTERNAL,QS   , 'QS'     , RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(INTERNAL,FR   , 'FR'     , RC=STATUS); VERIFY_(STATUS)
@@ -2871,17 +2852,30 @@ contains
 
     NT = size(ALW)
 
-   
-    if (.not. associated(ICESMB_ISSM)) then
-        allocate(ICESMB_ISSM(NT),STAT=STATUS)
-        VERIFY_(STATUS)
-       
-        ! initialize from restart 
-        ! (defaults to zero; i.e. ISSM has not run yet)
-        ICESMB_ISSM(:) = ICESMB_ISSM_IN(:) 
-        NSTEPS_ISSM = nint(NSTEPS_ISSM_IN(1)) ! steps since last ISSM run
-    end if 
-
+    ! initialize running mean for ICESMB and 
+	! number of steps since last ISSM solve
+    if(DO_ISSM==1) then
+        if (.not. associated(ICESMB_ISSM)) then
+	        ! initialize running-mean ICESMB for ISSM (ICESMB_ISSM)  
+            allocate(ICESMB_ISSM(NT),STAT=STATUS)
+            VERIFY_(STATUS)
+		    if (associated(ICESMB_IN)) then 
+		        ICESMB_ISSM(:) = ICESMB_IN(:) 
+		    else
+                ICESMB_ISSM(:) = 0
+		    end if 
+		
+		    ! initialize steos since last ISSM run
+	        NSTEPS_ISSM = 0    
+	        open(newunit=u, file="ISSM_NSTEPS.txt", status="old", iostat=ios)
+	        if (ios == 0) then
+		        read(u, *) NSTEPS_ISSM
+		        close(u)
+	        end if
+			
+	    end if 	
+	end if 
+        
     allocate(MLT (NT), STAT=STATUS)
     VERIFY_(STATUS)                
     allocate(DTS (NT), STAT=STATUS)
@@ -3505,10 +3499,8 @@ contains
         if(associated(ICESMB_ISSM)) ICESMB_ISSM = ICESMB_ISSM + (ICESMB-ICESMB_ISSM)/(NSTEPS_ISSM+1)
         NSTEPS_ISSM = NSTEPS_ISSM + 1 ! accumulated timesteps since last ISSM run
 
-        ! update internal states
-        if(associated(ICESMB_ISSM_IN)) ICESMB_ISSM_IN = ICESMB_ISSM
-        if(associated(NSTEPS_ISSM_IN)) NSTEPS_ISSM_IN(1) = real(NSTEPS_ISSM)
-
+		!update internal state
+		ICESMB_IN(:) = ICESMB_ISSM(:)
     end if 
 ! Update snow and landice albedos to anticipate
 !   next radiation calculation
@@ -3651,17 +3643,14 @@ contains
          if (index(GCNAMES(N), 'ISSM') /=0 ) then ! check if issm alarm is ringing too
             call MAPL_GetObjectFromGC(GCS(N), CHILD_MAPL, RC=STATUS); VERIFY_(STATUS)
             call MAPL_Get(CHILD_MAPL, RUNALARM = ISSM_ALARM, RC=STATUS); VERIFY_(STATUS)
-            VERIFY_(STATUS)
-          
-            if (ESMF_AlarmIsRinging (ISSM_ALARM, RC=STATUS)) then
-               call ESMF_UserCompGetInternalState(GCS(N), 'ISSM_TILES', issm_tile_wrap, status)
-               VERIFY_(STATUS)
-               issm_tile_state =>issm_tile_wrap%ptr
+            VERIFY_(STATUS) 
 
-               ! send ICESMB that has been averaged over time steps since last ISSM run
-               if(associated(ICESMB_ISSM)) issm_tile_state%ICESMB_TILE = ICESMB_ISSM
-
-            end if 
+			! update private internal states to send to ISSM
+			call ESMF_UserCompGetInternalState(GCS(N), 'ISSM_TILES', issm_tile_wrap, status)
+		    VERIFY_(STATUS)
+		    issm_tile_state =>issm_tile_wrap%ptr
+	        issm_tile_state%ICESMB_ISSM   = ICESMB_ISSM
+	        issm_tile_state%NSTEPS_ISSM = NSTEPS_ISSM
 
             ! call ISSM run method every time landice runs so that restarts will persist
             ! ISSM Run method only calls the ISSM C++ solvers at ISSM_DT intervals
@@ -3678,12 +3667,16 @@ contains
                NSTEPS_ISSM = 0    ! set ISSM time step accumulation back to zero
                ICESMB_ISSM(:) = 0 ! zero out ICESMB running average
 
-               ! update internal states after refresh
-               if(associated(ICESMB_ISSM_IN)) ICESMB_ISSM_IN = ICESMB_ISSM
-               if(associated(NSTEPS_ISSM_IN)) NSTEPS_ISSM_IN(1) = real(NSTEPS_ISSM)
+			   ! update private internal state
+			   issm_tile_state%ICESMB_ISSM   = ICESMB_ISSM
+               issm_tile_state%NSTEPS_ISSM = NSTEPS_ISSM
+
+			   ! update internal state for running-mean ICESMB
+			   ICESMB_IN(:) = ICESMB_ISSM(:)
+
             end if 
-         endif
-      enddo
+         end if
+      end do
     end if 
 #endif
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1756,7 +1756,7 @@ module GEOS_LandiceGridCompMod
 #ifdef HAVE_ISSM
        type(T_ISSM_TILE_STATE), pointer :: issm_tile_state
        type(ISSM_TILE_WRAP)             :: issm_tile_wrap
-	   real, pointer, dimension(:)      :: ICESURF
+	   real, pointer, dimension(:)       :: ICESURF
        real, pointer, dimension(:)      :: ICETHICK
        real, pointer, dimension(:)      :: ICEVEL
 #endif
@@ -1806,7 +1806,6 @@ module GEOS_LandiceGridCompMod
              allocate(issm_tile_state%ICETHICK_TILE(nt_local))
              allocate(issm_tile_state%ICEVEL_TILE(nt_local))
              allocate(issm_tile_state%ICESMB_ISSM(nt_local))
-             issm_tile_state%ISSM_NSTEPS = 0 ! initialize to zero
              issm_tile_wrap%ptr => issm_tile_state
              call ESMF_UserCompSetInternalState(GCS(I), 'ISSM_TILES', issm_tile_wrap, status)
              VERIFY_(STATUS)
@@ -2872,16 +2871,19 @@ contains
             else
                ICESMB_ISSM(:) = 0
             end if 
-		
-            ! initialize steps since last ISSM run:
-            ISSM_NSTEPS = 0    
-            open(newunit=u, file="ISSM_NSTEPS.txt", status="old", iostat=ios)
-            if (ios == 0) then
-               read(u, *) ISSM_NSTEPS
-               close(u)
-            end if
-	    end if 	
-	end if 
+	     end if 	
+        
+        ! get number of timesteps from issm tile internal state
+        call MAPL_Get (MAPL, GCS=GCS, GCNAMES=GCNAMES, RC=STATUS )
+        do N=1, size(GCS)
+          if (index(GCNAMES(N), 'ISSM') /=0 ) then
+             call ESMF_UserCompGetInternalState(GCS(N), 'ISSM_TILES', issm_tile_wrap, status)
+             VERIFY_(STATUS)
+             issm_tile_state =>issm_tile_wrap%ptr
+             ISSM_NSTEPS = issm_tile_state%ISSM_NSTEPS 
+          end if
+        end do         
+	 end if 
         
     allocate(MLT (NT), STAT=STATUS)
     VERIFY_(STATUS)                
@@ -3651,11 +3653,6 @@ contains
             call MAPL_GetObjectFromGC(GCS(N), CHILD_MAPL, RC=STATUS); VERIFY_(STATUS)
             call MAPL_Get(CHILD_MAPL, RUNALARM = ISSM_ALARM, RC=STATUS); VERIFY_(STATUS)
 
-            ! update private internal states to send to ISSM
-            call ESMF_UserCompGetInternalState(GCS(N), 'ISSM_TILES', issm_tile_wrap, status)
-            VERIFY_(STATUS)
-            
-            issm_tile_state =>issm_tile_wrap%ptr
             issm_tile_state%ICESMB_ISSM   = ICESMB_ISSM
             issm_tile_state%ISSM_NSTEPS = ISSM_NSTEPS
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1756,6 +1756,9 @@ module GEOS_LandiceGridCompMod
 #ifdef HAVE_ISSM
        type(T_ISSM_TILE_STATE), pointer :: issm_tile_state
        type(ISSM_TILE_WRAP)             :: issm_tile_wrap
+	   real, pointer, dimension(:)      :: ICESURF
+       real, pointer, dimension(:)      :: ICETHICK
+       real, pointer, dimension(:)      :: ICEVEL
 #endif
        integer :: nt_local
         
@@ -1790,6 +1793,7 @@ module GEOS_LandiceGridCompMod
    !---------------------------------------------------------------------
 
 #ifdef HAVE_ISSM
+   ! Get Landice timestep to send to ISSM
        do I = 1, SIZE(GCS)
           call MAPL_GetObjectFromGC( GCS(I), CHILD_MAPL, RC=STATUS )
           VERIFY_(STATUS)
@@ -1802,7 +1806,7 @@ module GEOS_LandiceGridCompMod
              allocate(issm_tile_state%ICETHICK_TILE(nt_local))
              allocate(issm_tile_state%ICEVEL_TILE(nt_local))
              allocate(issm_tile_state%ICESMB_ISSM(nt_local))
-			    issm_tile_state%ISSM_NSTEPS = 0 ! initialize to zero
+             issm_tile_state%ISSM_NSTEPS = 0 ! initialize to zero
              issm_tile_wrap%ptr => issm_tile_state
              call ESMF_UserCompSetInternalState(GCS(I), 'ISSM_TILES', issm_tile_wrap, status)
              VERIFY_(STATUS)
@@ -1813,10 +1817,19 @@ module GEOS_LandiceGridCompMod
    
    ! Call Initialize for every Child
    !--------------------------------
-   
        call MAPL_GenericInitialize ( GC, IMPORT, EXPORT, CLOCK,  RC=STATUS)
        VERIFY_(STATUS)
-   
+
+#ifdef HAVE_ISSM
+       ! initialize exports to restart values set by ISSM GridComp's Initialize, 
+	   ! because ISSM typically has a multi-day timestep and exports will remain empty otherwise
+       call MAPL_GetPointer(EXPORT,ICESURF , 'ICESURF',alloc=.true., RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT,ICETHICK ,'ICETHICK',alloc=.true., RC=STATUS); VERIFY_(STATUS)
+       call MAPL_GetPointer(EXPORT,ICEVEL ,'ICEVEL',alloc=.true., RC=STATUS); VERIFY_(STATUS)
+       if(associated(ICESURF))  ICESURF = issm_tile_state%ICESURF_TILE
+       if(associated(ICETHICK)) ICETHICK = issm_tile_state%ICETHICK_TILE
+       if(associated(ICEVEL))   ICEVEL = issm_tile_state%ICEVEL_TILE
+#endif   
        call MAPL_TimerOff(MAPL,"INITIALIZE", RC=STATUS ); VERIFY_(STATUS)
    
        RETURN_(ESMF_SUCCESS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1755,7 +1755,7 @@ module GEOS_LandiceGridCompMod
        integer                                 :: I
 #ifdef HAVE_ISSM
        type(T_ISSM_TILE_STATE), pointer :: issm_tile_state
-       type(ISSM_TILE_WRAP) :: issm_tile_wrap
+       type(ISSM_TILE_WRAP)             :: issm_tile_wrap
 #endif
        integer :: nt_local
         
@@ -1802,7 +1802,7 @@ module GEOS_LandiceGridCompMod
              allocate(issm_tile_state%ICETHICK_TILE(nt_local))
              allocate(issm_tile_state%ICEVEL_TILE(nt_local))
              allocate(issm_tile_state%ICESMB_ISSM(nt_local))
-			 issm_tile_state%NSTEPS_ISSM = 0
+			    issm_tile_state%NSTEPS_ISSM = 0 ! initialize to zero
              issm_tile_wrap%ptr => issm_tile_state
              call ESMF_UserCompSetInternalState(GCS(I), 'ISSM_TILES', issm_tile_wrap, status)
              VERIFY_(STATUS)
@@ -2847,27 +2847,26 @@ contains
 
     NT = size(ALW)
 
-    ! initialize running mean for ICESMB and 
-	! number of steps since last ISSM solve
+    ! initialize running mean ICESMB and number of steps since last ISSM solve
     if(DO_ISSM==1) then
         if (.not. associated(ICESMB_ISSM)) then
-	        ! initialize running-mean ICESMB for ISSM (ICESMB_ISSM)  
             allocate(ICESMB_ISSM(NT),STAT=STATUS)
             VERIFY_(STATUS)
-		    if (associated(ICESMB_IN)) then 
-		        ICESMB_ISSM(:) = ICESMB_IN(:) 
-		    else
-                ICESMB_ISSM(:) = 0
-		    end if 
+
+            ! initialize from restart:
+            if (associated(ICESMB_IN)) then 
+               ICESMB_ISSM(:) = ICESMB_IN(:) 
+            else
+               ICESMB_ISSM(:) = 0
+            end if 
 		
-		    ! initialize steos since last ISSM run
-	        NSTEPS_ISSM = 0    
-	        open(newunit=u, file="ISSM_NSTEPS.txt", status="old", iostat=ios)
-	        if (ios == 0) then
-		        read(u, *) NSTEPS_ISSM
-		        close(u)
-	        end if
-			
+            ! initialize steps since last ISSM run:
+            NSTEPS_ISSM = 0    
+            open(newunit=u, file="ISSM_NSTEPS.txt", status="old", iostat=ios)
+            if (ios == 0) then
+               read(u, *) NSTEPS_ISSM
+               close(u)
+            end if
 	    end if 	
 	end if 
         
@@ -3494,7 +3493,7 @@ contains
         if(associated(ICESMB_ISSM)) ICESMB_ISSM = ICESMB_ISSM + (ICESMB-ICESMB_ISSM)/(NSTEPS_ISSM+1)
         NSTEPS_ISSM = NSTEPS_ISSM + 1 ! accumulated timesteps since last ISSM run
 
-		!update internal state
+		! update internal state
 		ICESMB_IN(:) = ICESMB_ISSM(:)
     end if 
 ! Update snow and landice albedos to anticipate
@@ -3638,14 +3637,14 @@ contains
          if (index(GCNAMES(N), 'ISSM') /=0 ) then ! check if issm alarm is ringing too
             call MAPL_GetObjectFromGC(GCS(N), CHILD_MAPL, RC=STATUS); VERIFY_(STATUS)
             call MAPL_Get(CHILD_MAPL, RUNALARM = ISSM_ALARM, RC=STATUS); VERIFY_(STATUS)
-            VERIFY_(STATUS) 
 
-			! update private internal states to send to ISSM
-			call ESMF_UserCompGetInternalState(GCS(N), 'ISSM_TILES', issm_tile_wrap, status)
-		    VERIFY_(STATUS)
-		    issm_tile_state =>issm_tile_wrap%ptr
-	        issm_tile_state%ICESMB_ISSM   = ICESMB_ISSM
-	        issm_tile_state%NSTEPS_ISSM = NSTEPS_ISSM
+            ! update private internal states to send to ISSM
+            call ESMF_UserCompGetInternalState(GCS(N), 'ISSM_TILES', issm_tile_wrap, status)
+            VERIFY_(STATUS)
+            
+            issm_tile_state =>issm_tile_wrap%ptr
+            issm_tile_state%ICESMB_ISSM   = ICESMB_ISSM
+            issm_tile_state%NSTEPS_ISSM = NSTEPS_ISSM
 
             ! call ISSM run method every time landice runs so that restarts will persist
             ! ISSM Run method only calls the ISSM C++ solvers at ISSM_DT intervals
@@ -3662,12 +3661,12 @@ contains
                NSTEPS_ISSM = 0    ! set ISSM time step accumulation back to zero
                ICESMB_ISSM(:) = 0 ! zero out ICESMB running average
 
-			   ! update private internal state
-			   issm_tile_state%ICESMB_ISSM   = ICESMB_ISSM
+               ! update private internal state
+               issm_tile_state%ICESMB_ISSM   = ICESMB_ISSM
                issm_tile_state%NSTEPS_ISSM = NSTEPS_ISSM
 
-			   ! update internal state for running-mean ICESMB
-			   ICESMB_IN(:) = ICESMB_ISSM(:)
+               ! update internal state for running-mean ICESMB
+               ICESMB_IN(:) = ICESMB_ISSM(:)
 
             end if 
          end if

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1761,7 +1761,8 @@ module GEOS_LandiceGridCompMod
        real, pointer, dimension(:)             :: ICEVEL
 #endif
        integer                                 :: nt_local
-	   integer                                 :: DO_ISSM	   
+       integer                                 :: DO_ISSM
+       real                                    :: LANDICE_DT                     
         
    !=============================================================================
    
@@ -1793,6 +1794,11 @@ module GEOS_LandiceGridCompMod
    ! Place the land tilegrid in the generic state of each child component
    !---------------------------------------------------------------------
 
+       ! get model timestep, overwrite with component-specific timestep if found
+       call MAPL_GetResource (MAPL, LANDICE_DT, label='RUN_DT:',_RC)
+       call MAPL_GetResource (MAPL, LANDICE_DT, label='DT:',default=LANDICE_DT,_RC)
+       
+       ! get ISSM flag
        call MAPL_GetResource (MAPL, DO_ISSM, label='DO_ISSM:', DEFAULT=0, __RC__ )
    
 #ifndef HAVE_ISSM

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1819,6 +1819,7 @@ module GEOS_LandiceGridCompMod
              allocate(issm_tile_state%ICETHICK_TILE(nt_local))
              allocate(issm_tile_state%ICEVEL_TILE(nt_local))
              allocate(issm_tile_state%ICESMB_ISSM(nt_local))
+             issm_tile_state%LANDICE_DT = LANDICE_DT
              issm_tile_wrap%ptr => issm_tile_state
              call ESMF_UserCompSetInternalState(GCS(I), 'ISSM_TILES', issm_tile_wrap, status)
              VERIFY_(STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1006,6 +1006,31 @@ module GEOS_LandiceGridCompMod
   VERIFY_(STATUS)
 
 !  !Internal state:
+#ifdef HAVE_ISSM  
+     call MAPL_AddInternalSpec(GC,                                &
+        SHORT_NAME = "NSTEPS_ISSM",                               &
+        LONG_NAME  = "steps_since_issm",                          &
+        UNITS      = "none",                                      &
+        PRECISION  = ESMF_KIND_I4,                                &
+        DIMS       = MAPL_DimsNone,                               &
+        UNGRIDDED_DIMS = (/1/),                                   &
+        VLOCATION  = MAPL_VlocationNone,                          &
+        RESTART    = MAPL_RestartOptional,                        & 
+        DEFAULT    = 0,                                           &
+        RC         = STATUS                                       &
+      )
+     VERIFY_(STATUS)
+
+     call MAPL_AddInternalSpec(GC,                                &
+        SHORT_NAME         = 'ICESMB_ISSM',                       &
+        LONG_NAME          = 'issm_surface_mass_balance',         &
+        UNITS              = 'kg m-2 s-1',                        &
+        DIMS               = MAPL_DimsTileOnly,                   &
+        VLOCATION          = MAPL_VLocationNone,                  &
+        DEFAULT            = 0.0 ,                                &
+                                                    RC=STATUS  )
+
+#endif
 
      call MAPL_AddInternalSpec(GC,                           &
         SHORT_NAME         = 'TS',                                &
@@ -1721,6 +1746,9 @@ module GEOS_LandiceGridCompMod
        type(ESMF_State),    intent(inout) :: EXPORT ! Export state
        type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
        integer, optional,   intent(  out) :: RC     ! Error code
+
+       type (ESMF_State)                  :: INTERNAL
+       integer, pointer                   :: NSTEPS_ISSM(:)
    
    ! !DESCRIPTION: The Initialize method of the Landice Gridded Component.
    
@@ -1773,11 +1801,17 @@ module GEOS_LandiceGridCompMod
    
        call MAPL_Get (MAPL, LOCSTREAM=LOCSTREAM, GCS=GCS, GCNAMES=gcnames, RC=STATUS )
        VERIFY_(STATUS)
-       call MAPL_LocStreamGet(locstream, NT_LOCAL=nt_local, rc=status)
-       VERIFY_(status)
+       call MAPL_LocStreamGet(locstream, NT_LOCAL=nt_local, rc=STATUS)
+       VERIFY_(STATUS)
    ! Place the land tilegrid in the generic state of each child component
    !---------------------------------------------------------------------
+
 #ifdef HAVE_ISSM
+       call MAPL_Get(MAPL, INTERNAL_ESMF_STATE = INTERNAL, RC=STATUS) 
+       VERIFY_(STATUS)   
+
+       call MAPL_GetPointer(INTERNAL,NSTEPS_ISSM,'NSTEPS_ISSM', RC=STATUS); VERIFY_(STATUS)
+
        do I = 1, SIZE(GCS)
           call MAPL_GetObjectFromGC( GCS(I), CHILD_MAPL, RC=STATUS )
           VERIFY_(STATUS)
@@ -1790,6 +1824,7 @@ module GEOS_LandiceGridCompMod
              allocate(issm_tile_state%ICETHICK_TILE(nt_local))
              allocate(issm_tile_state%ICEVEL_TILE(nt_local))
              allocate(issm_tile_state%ICESMB_TILE(nt_local))
+             issm_tile_state%NSTEPS_INIT = NSTEPS_ISSM(:)
              issm_tile_wrap%ptr => issm_tile_state
              call ESMF_UserCompSetInternalState(GCS(I), 'ISSM_TILES', issm_tile_wrap, status)
              VERIFY_(STATUS)
@@ -2334,6 +2369,8 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
 #ifdef HAVE_ISSM    
   type(T_ISSM_TILE_STATE), pointer    :: issm_tile_state
   type(ISSM_TILE_WRAP)                :: issm_tile_wrap
+  real, pointer                       :: ICESMB_ISSM_IN(:) ! pointer to internal for time-averaged SMB
+  integer, pointer                    :: NSTEPS_ISSM_IN(:) ! pointer to internal for steps since last ISSM run
 #endif
 !=============================================================================
 
@@ -2417,7 +2454,7 @@ contains
 ! pointer to ISSM import via private internal state
 ! accumulate over time steps for averaging
    real, pointer, dimension(:), save :: ICESMB_ISSM=>null()
-   integer, save                     :: NSTEPS_ISSM = 0 ! time steps since last ISSM
+   integer, save                     :: NSTEPS_ISSM = 0 ! time steps since last ISSM run
 
 ! pointers to export
    real, pointer, dimension(:  )  :: ICESMB
@@ -2710,6 +2747,11 @@ contains
 
 ! Pointers to internals
 !----------------------
+   
+#ifdef HAVE_ISSM
+   call MAPL_GetPointer(INTERNAL,ICESMB_ISSM_IN,'ICESMB_ISSM', RC=STATUS); VERIFY_(STATUS)
+   call MAPL_GetPointer(INTERNAL,NSTEPS_ISSM_IN,'NSTEPS_ISSM', RC=STATUS); VERIFY_(STATUS)
+#endif
 
    call MAPL_GetPointer(INTERNAL,TS   , 'TS'     , RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(INTERNAL,QS   , 'QS'     , RC=STATUS); VERIFY_(STATUS)
@@ -2830,11 +2872,15 @@ contains
 
     NT = size(ALW)
 
+   
     if (.not. associated(ICESMB_ISSM)) then
-    allocate(ICESMB_ISSM(NT),STAT=STATUS)
-    VERIFY_(STATUS)
-    ! accumulated between timesteps, so init to zero:
-    ICESMB_ISSM(:) = 0 
+        allocate(ICESMB_ISSM(NT),STAT=STATUS)
+        VERIFY_(STATUS)
+       
+        ! initialize from restart 
+        ! (defaults to zero; i.e. ISSM has not run yet)
+        ICESMB_ISSM(:) = ICESMB_ISSM_IN(:) 
+        NSTEPS_ISSM = NSTEPS_ISSM_IN(:) ! steps since last ISSM run
     end if 
 
     allocate(MLT (NT), STAT=STATUS)
@@ -3455,10 +3501,15 @@ contains
     ! Calculate surface mass balance (SMB) for ISSM
     if(associated(ICESMB)) ICESMB    = ACCUM - RUNOFF
     
-    ! accumulate ICESMB over time steps between ISSM runs
+    ! average ICESMB over time steps between ISSM runs
     if(DO_ISSM==1) then
-    if(associated(ICESMB_ISSM)) ICESMB_ISSM = ICESMB_ISSM+ICESMB
-    NSTEPS_ISSM = NSTEPS_ISSM + 1 ! accumulate timesteps since last ISSM run
+        if(associated(ICESMB_ISSM)) ICESMB_ISSM = ICESMB_ISSM + (ICESMB-ICESMB_ISSM)/(NSTEPS_ISSM+1)
+        NSTEPS_ISSM = NSTEPS_ISSM + 1 ! accumulated timesteps since last ISSM run
+
+        ! update internal states
+        if(associated(ICESMB_ISSM_IN)) ICESMB_ISSM_IN = ICESMB_ISSM
+        if(associated(NSTEPS_ISSM_IN)) NSTEPS_ISSM_IN(:) = NSTEPS_ISSM
+
     end if 
 ! Update snow and landice albedos to anticipate
 !   next radiation calculation
@@ -3593,7 +3644,7 @@ contains
        WEBOT =  WESNBOT / DT
     end if
 
-    ! Run ISSM (checks if ISSM_ALARM is ringing)
+! Run ISSM 
 #ifdef HAVE_ISSM
     if (DO_ISSM==1) then
       call MAPL_Get (MAPL, GCS=GCS, GCNAMES=GCNAMES, RC=STATUS )
@@ -3609,19 +3660,28 @@ contains
                issm_tile_state =>issm_tile_wrap%ptr
 
                ! send ICESMB that has been averaged over time steps since last ISSM run
-               if(associated(ICESMB_ISSM)) issm_tile_state%ICESMB_TILE = ICESMB_ISSM/NSTEPS_ISSM
+               if(associated(ICESMB_ISSM)) issm_tile_state%ICESMB_TILE = ICESMB_ISSM
 
-               call MAPL_GenericRunChildren(GC, IMPORT, EXPORT, CLOCK, RC=STATUS)
-               VERIFY_(STATUS)
+            end if 
 
-               ! get exports on tile space
+            ! call ISSM run method every time landice runs so that restarts will persist
+            ! ISSM Run method only calls the ISSM C++ solvers at ISSM_DT intervals
+            call MAPL_GenericRunChildren(GC, IMPORT, EXPORT, CLOCK, RC=STATUS)
+            VERIFY_(STATUS)
+
+            if (ESMF_AlarmIsRinging (ISSM_ALARM, RC=STATUS)) then   
+               ! if ISSM solvers were called, get exports on tile space
                if(associated(ICESURF))  ICESURF = issm_tile_state%ICESURF_TILE
                if(associated(ICETHICK)) ICETHICK = issm_tile_state%ICETHICK_TILE
                if(associated(ICEVEL))   ICEVEL = issm_tile_state%ICEVEL_TILE
 
                ! refresh ICESMB accumulator
                NSTEPS_ISSM = 0    ! set ISSM time step accumulation back to zero
-               ICESMB_ISSM(:) = 0 ! zero out ICESMB accumulator
+               ICESMB_ISSM(:) = 0 ! zero out ICESMB running average
+
+               ! update internal states after refresh
+               if(associated(ICESMB_ISSM_IN)) ICESMB_ISSM_IN = ICESMB_ISSM
+               if(associated(NSTEPS_ISSM_IN)) NSTEPS_ISSM_IN(:) = NSTEPS_ISSM
             end if 
          endif
       enddo

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1013,7 +1013,7 @@ module GEOS_LandiceGridCompMod
         UNITS              = 'kg m-2 s-1',                        &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
-		RESTART            = MAPL_RestartOptional,                & 
+		  RESTART            = MAPL_RestartOptional,                & 
         DEFAULT            = 0.0 ,                                &
                                                     RC=STATUS  )
 #endif
@@ -1756,7 +1756,7 @@ module GEOS_LandiceGridCompMod
 #ifdef HAVE_ISSM
        type(T_ISSM_TILE_STATE), pointer :: issm_tile_state
        type(ISSM_TILE_WRAP)             :: issm_tile_wrap
-	   real, pointer, dimension(:)       :: ICESURF
+	    real, pointer, dimension(:)      :: ICESURF
        real, pointer, dimension(:)      :: ICETHICK
        real, pointer, dimension(:)      :: ICEVEL
 #endif
@@ -1821,7 +1821,7 @@ module GEOS_LandiceGridCompMod
 
 #ifdef HAVE_ISSM
        ! initialize exports to restart values set by ISSM GridComp's Initialize, 
-	   ! because ISSM typically has a multi-day timestep and exports will remain empty otherwise
+       ! because ISSM typically has a multi-day timestep and exports will remain empty otherwise
        call MAPL_GetPointer(EXPORT,ICESURF , 'ICESURF',alloc=.true., RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(EXPORT,ICETHICK ,'ICETHICK',alloc=.true., RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(EXPORT,ICEVEL ,'ICEVEL',alloc=.true., RC=STATUS); VERIFY_(STATUS)
@@ -2681,7 +2681,6 @@ contains
    real, parameter :: LANDICECOND_  = 1.2  ! ice conductivity divided by depth of bottom layer
    real, parameter :: LANDICETDEEP_ = 230. ! deep ice temperature
 
-   integer :: u, ios      ! read ISSM_NSTEPS txt file
 !  Begin...
 !----------
 
@@ -3649,7 +3648,7 @@ contains
     if (DO_ISSM==1) then
       call MAPL_Get (MAPL, GCS=GCS, GCNAMES=GCNAMES, RC=STATUS )
       do N=1, size(GCS)
-         if (index(GCNAMES(N), 'ISSM') /=0 ) then ! check if issm alarm is ringing too
+         if (index(GCNAMES(N), 'ISSM') /=0 ) then 
             call MAPL_GetObjectFromGC(GCS(N), CHILD_MAPL, RC=STATUS); VERIFY_(STATUS)
             call MAPL_Get(CHILD_MAPL, RUNALARM = ISSM_ALARM, RC=STATUS); VERIFY_(STATUS)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1739,9 +1739,9 @@ module GEOS_LandiceGridCompMod
    
    ! ErrLog Variables
    
-       character(len=ESMF_MAXSTR)           :: IAm 
-       integer                              :: STATUS
-       character(len=ESMF_MAXSTR)           :: COMP_NAME
+       character(len=ESMF_MAXSTR)              :: IAm 
+       integer                                 :: STATUS
+       character(len=ESMF_MAXSTR)              :: COMP_NAME
        
    ! Local derived type aliases
    
@@ -1754,13 +1754,14 @@ module GEOS_LandiceGridCompMod
      
        integer                                 :: I
 #ifdef HAVE_ISSM
-       type(T_ISSM_TILE_STATE), pointer :: issm_tile_state
-       type(ISSM_TILE_WRAP)             :: issm_tile_wrap
-	    real, pointer, dimension(:)      :: ICESURF
-       real, pointer, dimension(:)      :: ICETHICK
-       real, pointer, dimension(:)      :: ICEVEL
+       type(T_ISSM_TILE_STATE), pointer        :: issm_tile_state
+       type(ISSM_TILE_WRAP)                    :: issm_tile_wrap
+	    real, pointer, dimension(:)            :: ICESURF
+       real, pointer, dimension(:)             :: ICETHICK
+       real, pointer, dimension(:)             :: ICEVEL
 #endif
-       integer :: nt_local
+       integer                                 :: nt_local
+	   integer                                 :: DO_ISSM	   
         
    !=============================================================================
    
@@ -1791,6 +1792,12 @@ module GEOS_LandiceGridCompMod
        VERIFY_(STATUS)
    ! Place the land tilegrid in the generic state of each child component
    !---------------------------------------------------------------------
+
+       call MAPL_GetResource (MAPL, DO_ISSM, label='DO_ISSM:', DEFAULT=0, __RC__ )
+   
+#ifndef HAVE_ISSM
+       DO_ISSM=0
+#endif
 
 #ifdef HAVE_ISSM
    ! Get Landice timestep to send to ISSM
@@ -1825,9 +1832,11 @@ module GEOS_LandiceGridCompMod
        call MAPL_GetPointer(EXPORT,ICESURF , 'ICESURF',alloc=.true., RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(EXPORT,ICETHICK ,'ICETHICK',alloc=.true., RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(EXPORT,ICEVEL ,'ICEVEL',alloc=.true., RC=STATUS); VERIFY_(STATUS)
-       if(associated(ICESURF))  ICESURF = issm_tile_state%ICESURF_TILE
-       if(associated(ICETHICK)) ICETHICK = issm_tile_state%ICETHICK_TILE
-       if(associated(ICEVEL))   ICEVEL = issm_tile_state%ICEVEL_TILE
+	   if (DO_ISSM==1) then
+          if(associated(ICESURF))  ICESURF = issm_tile_state%ICESURF_TILE
+          if(associated(ICETHICK)) ICETHICK = issm_tile_state%ICETHICK_TILE
+          if(associated(ICEVEL))   ICEVEL = issm_tile_state%ICEVEL_TILE
+	   end if 
 #endif   
        call MAPL_TimerOff(MAPL,"INITIALIZE", RC=STATUS ); VERIFY_(STATUS)
    

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1802,7 +1802,7 @@ module GEOS_LandiceGridCompMod
              allocate(issm_tile_state%ICETHICK_TILE(nt_local))
              allocate(issm_tile_state%ICEVEL_TILE(nt_local))
              allocate(issm_tile_state%ICESMB_ISSM(nt_local))
-			    issm_tile_state%NSTEPS_ISSM = 0 ! initialize to zero
+			    issm_tile_state%ISSM_NSTEPS = 0 ! initialize to zero
              issm_tile_wrap%ptr => issm_tile_state
              call ESMF_UserCompSetInternalState(GCS(I), 'ISSM_TILES', issm_tile_wrap, status)
              VERIFY_(STATUS)
@@ -2430,7 +2430,7 @@ contains
 ! pointer to ISSM import via private internal state
 ! accumulate over time steps for averaging
    real, pointer, dimension(:), save :: ICESMB_ISSM=>null()
-   integer, save                     :: NSTEPS_ISSM = 0 ! time steps since last ISSM run
+   integer, save                     :: ISSM_NSTEPS = 0 ! time steps since last ISSM run
 
 ! pointers to export
    real, pointer, dimension(:  )  :: ICESMB
@@ -2861,10 +2861,10 @@ contains
             end if 
 		
             ! initialize steps since last ISSM run:
-            NSTEPS_ISSM = 0    
+            ISSM_NSTEPS = 0    
             open(newunit=u, file="ISSM_NSTEPS.txt", status="old", iostat=ios)
             if (ios == 0) then
-               read(u, *) NSTEPS_ISSM
+               read(u, *) ISSM_NSTEPS
                close(u)
             end if
 	    end if 	
@@ -3490,8 +3490,8 @@ contains
     
     ! average ICESMB over time steps between ISSM runs
     if(DO_ISSM==1) then
-        if(associated(ICESMB_ISSM)) ICESMB_ISSM = ICESMB_ISSM + (ICESMB-ICESMB_ISSM)/(NSTEPS_ISSM+1)
-        NSTEPS_ISSM = NSTEPS_ISSM + 1 ! accumulated timesteps since last ISSM run
+        if(associated(ICESMB_ISSM)) ICESMB_ISSM = ICESMB_ISSM + (ICESMB-ICESMB_ISSM)/(ISSM_NSTEPS+1)
+        ISSM_NSTEPS = ISSM_NSTEPS + 1 ! accumulated timesteps since last ISSM run
 
 		! update internal state
 		ICESMB_IN(:) = ICESMB_ISSM(:)
@@ -3644,7 +3644,7 @@ contains
             
             issm_tile_state =>issm_tile_wrap%ptr
             issm_tile_state%ICESMB_ISSM   = ICESMB_ISSM
-            issm_tile_state%NSTEPS_ISSM = NSTEPS_ISSM
+            issm_tile_state%ISSM_NSTEPS = ISSM_NSTEPS
 
             ! call ISSM run method every time landice runs so that restarts will persist
             ! ISSM Run method only calls the ISSM C++ solvers at ISSM_DT intervals
@@ -3658,12 +3658,12 @@ contains
                if(associated(ICEVEL))   ICEVEL = issm_tile_state%ICEVEL_TILE
 
                ! refresh ICESMB accumulator
-               NSTEPS_ISSM = 0    ! set ISSM time step accumulation back to zero
+               ISSM_NSTEPS = 0    ! set ISSM time step accumulation back to zero
                ICESMB_ISSM(:) = 0 ! zero out ICESMB running average
 
                ! update private internal state
                issm_tile_state%ICESMB_ISSM   = ICESMB_ISSM
-               issm_tile_state%NSTEPS_ISSM = NSTEPS_ISSM
+               issm_tile_state%ISSM_NSTEPS = ISSM_NSTEPS
 
                ! update internal state for running-mean ICESMB
                ICESMB_IN(:) = ICESMB_ISSM(:)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1756,7 +1756,7 @@ module GEOS_LandiceGridCompMod
 #ifdef HAVE_ISSM
        type(T_ISSM_TILE_STATE), pointer        :: issm_tile_state
        type(ISSM_TILE_WRAP)                    :: issm_tile_wrap
-	    real, pointer, dimension(:)            :: ICESURF
+       real, pointer, dimension(:)             :: ICESURF 
        real, pointer, dimension(:)             :: ICETHICK
        real, pointer, dimension(:)             :: ICEVEL
 #endif
@@ -2868,6 +2868,7 @@ contains
     NT = size(ALW)
 
     ! initialize running mean ICESMB and number of steps since last ISSM solve
+#ifdef HAVE_ISSM	
     if(DO_ISSM==1) then
         if (.not. associated(ICESMB_ISSM)) then
             allocate(ICESMB_ISSM(NT),STAT=STATUS)
@@ -2883,6 +2884,7 @@ contains
         
         ! get number of timesteps from issm tile internal state
         call MAPL_Get (MAPL, GCS=GCS, GCNAMES=GCNAMES, RC=STATUS )
+		VERIFY_(STATUS)
         do N=1, size(GCS)
           if (index(GCNAMES(N), 'ISSM') /=0 ) then
              call ESMF_UserCompGetInternalState(GCS(N), 'ISSM_TILES', issm_tile_wrap, status)
@@ -2892,7 +2894,8 @@ contains
           end if
         end do         
 	 end if 
-        
+#endif
+		
     allocate(MLT (NT), STAT=STATUS)
     VERIFY_(STATUS)                
     allocate(DTS (NT), STAT=STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -1732,8 +1732,6 @@ module GEOS_LandiceGridCompMod
        type(ESMF_State),    intent(inout) :: EXPORT ! Export state
        type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
        integer, optional,   intent(  out) :: RC     ! Error code
-
-       type (ESMF_State)                  :: INTERNAL
    
    ! !DESCRIPTION: The Initialize method of the Landice Gridded Component.
    
@@ -1792,9 +1790,6 @@ module GEOS_LandiceGridCompMod
    !---------------------------------------------------------------------
 
 #ifdef HAVE_ISSM
-       call MAPL_Get(MAPL, INTERNAL_ESMF_STATE = INTERNAL, RC=STATUS) 
-       VERIFY_(STATUS)   
-
        do I = 1, SIZE(GCS)
           call MAPL_GetObjectFromGC( GCS(I), CHILD_MAPL, RC=STATUS )
           VERIFY_(STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -385,7 +385,12 @@ subroutine SetServices ( GC, RC )
     type(ESMF_Field)                       :: meshField               ! field on mesh
     type(ESMF_Field)                       :: gridField               ! field on grid
     type(ISSM_WRAP)                        :: wrap                    ! wrapper for internal state
+
+    ! tile information
     integer                                :: NT                      ! local number of landice tiles
+    type(T_ISSM_TILE_STATE), pointer       :: issm_tile_state
+    type(ISSM_TILE_WRAP)                   :: issm_tile_wrap
+
 
     ! field halo
     integer                                :: num_halo_nodes          ! num_nodes minus num_owned_nodes
@@ -786,13 +791,16 @@ subroutine SetServices ( GC, RC )
     ! calculate ice flow speed
     ICEVEL_HALO = sqrt(ICEVX_HALO**2 + ICEVY_HALO**2)
 
-    call mesh_to_tile(ICESURF_HALO,ICESURF_TILE)
+    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
+    issm_tile_state => issm_tile_wrap%ptr
+
+    call mesh_to_tile(ICESURF_HALO,ICESURF_TILE,rc=STATUS); VERIFY_(STATUS)
     issm_tile_state%ICESURF_TILE = ICESURF_TILE
 
-    call mesh_to_tile(ICETHICK_HALO,ICETHICK_TILE)
+    call mesh_to_tile(ICETHICK_HALO,ICETHICK_TILE,rc=STATUS); VERIFY_(STATUS)
     issm_tile_state%ICETHICK_TILE = ICETHICK_TILE
 
-    call mesh_to_tile(ICEVEL_HALO,ICEVEL_TILE)
+    call mesh_to_tile(ICEVEL_HALO,ICEVEL_TILE,rc=STATUS); VERIFY_(STATUS)
     issm_tile_state%ICEVEL_TILE = ICEVEL_TILE
 
 
@@ -951,7 +959,6 @@ subroutine SetServices ( GC, RC )
 
     ! tile information
     integer                              :: NT                      ! number of landice tiles
-
     type(T_ISSM_TILE_STATE), pointer     :: issm_tile_state
     type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
 
@@ -1036,7 +1043,7 @@ subroutine SetServices ( GC, RC )
       VERIFY_(STATUS)
 
       ! get number of mesh elements
-      call ESMF_MeshGet(mesh,elementCount=num_elements,nodeCount=num_nodes)
+      call ESMF_MeshGet(mesh,nodeCount=num_nodes)
 
       ! allocate ice-elevation output (export from ISSM)
       allocate(ISSM_OUTPUTS(num_outputs*num_nodes))  
@@ -1085,7 +1092,7 @@ subroutine SetServices ( GC, RC )
       ! *************************************************************************** !
       ! TRANSFORM ICESMB FROM TILES TO MESH 
       ! *************************************************************************** !
-      call tile_to_mesh(ICESMB_TILE,ICESMB_MESH)
+      call tile_to_mesh(ICESMB_TILE,ICESMB_MESH,rc=STATUS); VERIFY_(STATUS)
 
       ! save ICESMB on mesh elements 
       call MAPL_GetPointer(EXPORT  , ICESMB_EX , 'ICESMB' , RC=STATUS); VERIFY_(STATUS)
@@ -1152,13 +1159,13 @@ subroutine SetServices ( GC, RC )
       ! REGRID MESH FIELDS ONTO LANDICE TILES AND EXPORT VIA INTERNAL STATE
       ! *************************************************************************** !
       ! transform from mesh to tiles
-      call mesh_to_tile(ICESURF_MESH,ICESURF_TILE)
+      call mesh_to_tile(ICESURF_MESH,ICESURF_TILE,rc=STATUS); VERIFY_(STATUS)
       issm_tile_state%ICESURF_TILE = ICESURF_TILE
 
-      call mesh_to_tile(ICETHICK_MESH,ICETHICK_TILE)
+      call mesh_to_tile(ICETHICK_MESH,ICETHICK_TILE,rc=STATUS); VERIFY_(STATUS)
       issm_tile_state%ICETHICK_TILE = ICETHICK_TILE
 
-      call mesh_to_tile(ICEVEL_MESH,ICEVEL_TILE)
+      call mesh_to_tile(ICEVEL_MESH,ICEVEL_TILE,rc=STATUS); VERIFY_(STATUS)
       issm_tile_state%ICEVEL_TILE = ICEVEL_TILE
 
     end if 
@@ -1255,10 +1262,11 @@ subroutine SetServices ( GC, RC )
   end subroutine Finalize
 
 
-  subroutine mesh_to_tile(VAR_MESH,VAR_TILE)
+  subroutine mesh_to_tile(VAR_MESH,VAR_TILE,RC)
     ! regrid from mesh to grid, then transform from grid to landice tiles
     real(dp),    pointer, dimension(:), intent(inout)   :: VAR_MESH           ! var on mesh nodes
     real, pointer, dimension(:), intent(inout)          :: VAR_TILE           ! var on landice tiles
+    integer, optional,       intent(OUT)                :: RC                 ! Error code
 
     real, pointer, dimension(:,:)                       :: VAR_GRID => null() ! var on attached grid
     real(dp),    pointer, dimension(:)                  :: VAR_MESH_OWN       ! var on owned mesh nodes
@@ -1270,7 +1278,8 @@ subroutine SetServices ( GC, RC )
   
     num_owned_nodes = size(internal_state%owned_idx)
 
-    call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
+    call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, rc=STATUS)
+    VERIFY_(STATUS)
 
     allocate(VAR_MESH_OWN(num_owned_nodes))
 
@@ -1308,10 +1317,11 @@ subroutine SetServices ( GC, RC )
 
   end subroutine mesh_to_tile
 
-  subroutine tile_to_mesh(VAR_TILE,VAR_MESH)
+  subroutine tile_to_mesh(VAR_TILE,VAR_MESH,RC)
     ! transform from landice tile to grid, then regrid onto mesh
     real, pointer, dimension(:), intent(inout)     :: VAR_TILE           ! var on landice tiles
     real(dp), pointer, dimension(:), intent(inout) :: VAR_MESH           ! var on mesh elements
+    integer, optional,       intent(OUT)           :: RC                 ! Error code
 
     real, pointer, dimension(:,:)                  :: VAR_GRID => null() ! var on attached grid
     real(dp), pointer, dimension(:)                :: MESH_PTR           ! pointer for ESMF_FieldGet 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -91,7 +91,7 @@ type T_ISSM_TILE_STATE
     real, pointer :: ICETHICK_TILE(:)
     real, pointer :: ICEVEL_TILE(:)
     real, pointer :: ICESMB_ISSM(:)
-	integer       :: NSTEPS_ISSM
+	integer       :: ISSM_NSTEPS
 end type T_ISSM_TILE_STATE
 
 type ISSM_TILE_WRAP
@@ -1268,7 +1268,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     issm_tile_state => issm_tile_wrap%ptr
 	
 	  open(newunit=u, file="ISSM_NSTEPS.txt", status="replace")
-	  write(u, *) issm_tile_state%NSTEPS_ISSM
+	  write(u, *) issm_tile_state%ISSM_NSTEPS
 	  close(u)
 
     ! call ISSM finalize (saves binary output .outbin file)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -935,7 +935,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
   call ESMF_VMGet(vm,localPET=localPET,rc=STATUS); VERIFY_(STATUS)
 
   ! run ISSM at specified time steps, 
-  ! if bootstrapping restart and issm has not by final time step, run anyways
+  ! if bootstrapping restart and issm has run not by final time step, run anyways
   ! with timestep of zero, which just gets restart values
   if ( ESMF_AlarmIsRinging(ALARM, RC=STATUS) .or. NEED_RST ) then
 
@@ -947,9 +947,10 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
     VERIFY_(STATUS)
 
+    ! if just getting restart, set timestep to zero
     if (NEED_RST) then
         ISSM_DT = 0.0_dp
-	end if 
+	  end if 
 
     ! get number of mesh elements
     call ESMF_MeshGet(mesh,elementCount=num_elements,nodeCount=num_nodes,numOwnedNodes=num_owned_nodes)
@@ -1044,7 +1045,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
 
     ! update ISSM run flag (for C++ library calls)
-	ISSM_RAN = .true.
+	  ISSM_RAN = .true.
 
     ! *************************************************************************** !
     ! UNPACK AND EXPORT ISSM OUTPUTS ON MESH TILES
@@ -1249,9 +1250,9 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     integer			                   :: STATUS
     character(len=ESMF_MAXSTR)         :: COMP_NAME
 
-    ! testing
-	integer :: u
-	type(T_ISSM_TILE_STATE), pointer     :: issm_tile_state
+    ! variables for writing out timesteps since ISSM (via ISSM_NSTEPS.txt)
+	  integer :: u
+	  type(T_ISSM_TILE_STATE), pointer     :: issm_tile_state
     type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
 
     ! Get the target components name and set-up traceback handle.
@@ -1262,26 +1263,25 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     Iam = trim(comp_name) // Iam
 
 
-	! save number of steps since last issm run as a little txt file
-	call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
+	! save number of steps since last ISSM run as a little txt file
+	  call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
 	
-	open(newunit=u, file="ISSM_NSTEPS.txt", status="replace")
-	write(u, *) issm_tile_state%NSTEPS_ISSM
-	close(u)
+	  open(newunit=u, file="ISSM_NSTEPS.txt", status="replace")
+	  write(u, *) issm_tile_state%NSTEPS_ISSM
+	  close(u)
 
     ! call ISSM finalize (saves binary output .outbin file)
-	if (ISSM_RAN) then
-	! NOTE: only call if ISSM C++ solvers were called, because OutputResultsx
-	! in C++ source throws error if 'results' is empty... 
-	! not actually a problem, but this case won't call FemModel destructors,
-	! should really just remove OutputResultsx from FinalizeISSM()....
+	  if (ISSM_RAN) then
+	  ! NOTE: only call if ISSM C++ solvers were called, because OutputResultsx
+	  ! in C++ source throws error if 'results' is empty... 
+	  ! not actually a problem, but this case won't call FemModel destructors,
+	  ! should probably just remove OutputResultsx from FinalizeISSM()....
         call FinalizeISSM()
-	end if 
+	  end if 
 
 ! Generic Finalize
 ! ------------------
-    
     call MAPL_GenericFinalize( GC, IMPORT, EXPORT, CLOCK, RC=status )
     VERIFY_(STATUS)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -12,7 +12,7 @@ module GEOS_IssmGridCompMod
 !
 !   {\tt GEOS\_ISSM} is a wrapper that calls ISSM (C++) IRF methods
 !   Imports: ICESMB (defined on landice tiles)  [private internal state]
-!   Exports: ICESURF, ICETHICK, ICESMB, ICEVX, ICEVY (defined on mesh) [true export state]
+!   Exports: ICESURF, ICETHICK, ICESMB_ISSM, ICEVX, ICEVY (defined on mesh) [true export state]
 !   Exports: ICESURF, ICETHICK, ICEVEL (defined on landice tiles) [private internal state]
 !   Internals: ICESURF, ICETHICK, IMLS, OMLS (defined on mesh) [true internal state]
 ! *** NOTES: 
@@ -74,9 +74,7 @@ end subroutine FinalizeISSM
 
 end interface
 
-
 private
-
 
 public SetServices
 
@@ -158,8 +156,6 @@ subroutine SetServices ( GC, RC )
 !=============================================================================
 
     type(MAPL_MetaComp), pointer       :: MAPL
-    type (ESMF_Config)                 :: CF
-    real                               :: ISSM_DT     ! time step [s] (ISSM_DT set in AGCM.rc)
 
     ! Get my internal MAPL_Generic state
 
@@ -175,20 +171,12 @@ subroutine SetServices ( GC, RC )
 !-----------------------------------
 
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE,   Initialize, _RC)
-
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,          Run,        _RC)
-    
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_FINALIZE,     Finalize,   _RC)
     
-
 !-----------------------------------
 
     call MAPL_GetObjectFromGC (GC, MAPL, _RC)
-    
-    call ESMF_GridCompGet(GC, CONFIG = CF, _RC)
-
-    ! get timestep for ISSM
-    call ESMF_ConfigGetAttribute(CF, ISSM_DT, Label=trim(COMP_NAME)//"_DT:", DEFAULT=302400.0, _RC)
     
 ! Set the state variable specs.
 !-----------------------------------
@@ -227,14 +215,14 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
          _RC  )
-    
+		 
     call MAPL_AddExportSpec(GC,                    &
-         SHORT_NAME = 'ICESMB',                    &
-         LONG_NAME  = 'ice_surface_mass_balance',  &
+         SHORT_NAME = 'ICESMB_ISSM',               &
+         LONG_NAME  = 'issm_surface_mass_balance', &
          UNITS      = 'kg m-2 s-1',                &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         _RC  )
+         _RC  )	 
     
     !   Internal states:
     call MAPL_AddInternalSpec(GC,                  &
@@ -243,7 +231,7 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'm',                         &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-		     RESTART    = MAPL_RestartOptional,        &   
+         RESTART    = MAPL_RestartOptional,        &   
          _RC  )
     
     call MAPL_AddInternalSpec(GC,                  &
@@ -252,7 +240,7 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'm',                         &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-		     RESTART    = MAPL_RestartOptional,        & 
+         RESTART    = MAPL_RestartOptional,        & 
          _RC  )
     
     call MAPL_AddInternalSpec(GC,                  &
@@ -261,7 +249,7 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'none',                      &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-		     RESTART    = MAPL_RestartOptional,        & 
+         RESTART    = MAPL_RestartOptional,        & 
          _RC  )
     
     call MAPL_AddInternalSpec(GC,                  &
@@ -270,7 +258,7 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'none',                      &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-		     RESTART    = MAPL_RestartOptional,        & 
+         RESTART    = MAPL_RestartOptional,        & 
          _RC  )
     
     call MAPL_AddInternalSpec(GC,                  &
@@ -290,8 +278,17 @@ subroutine SetServices ( GC, RC )
          VLOCATION  = MAPL_VLocationNone,          &
          RESTART    = MAPL_RestartOptional,        &
          _RC  )
-    
-
+! ! want to track steps since last ISSM run via internal state checkpoints
+!    call MAPL_AddInternalSpec(GC,                  &
+!         SHORT_NAME = 'ISSM_NSTEPS',               &
+!         LONG_NAME  = 'steps_since_issm',          &
+!         UNITS      = 'none',                      &
+!         DIMS       = MAPL_DimsNone,               &
+!		 PRECISION  = ESMF_KIND_R8,                &
+!		 UNGRIDDED_DIMS = (/1/),                   &
+!         VLOCATION  = MAPL_VLocationNone,          &
+!		 RESTART    = MAPL_RestartSkipInitial,     &
+!         _RC  )
 
 ! Set the Profiling timers
 ! ------------------------
@@ -325,11 +322,13 @@ subroutine SetServices ( GC, RC )
     type(ESMF_Time)                        :: ringTime                ! time of first ring
     type(ESMF_TimeInterval)                :: ringInterval            ! ring time interval (ISSM_DT)
     real                                   :: ISSM_DT                 ! ISSM time step [s] (ISSM_DT set in AGCM.rc)
-    real                                   :: HEARTBEAT_DT            ! landice time step [s] (ISSM_DT set in AGCM.rc)
+    real                                   :: LANDICE_DT              ! landice time step [s] 
     integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
     integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
-	  integer                                :: ios, u                  ! for reading ISSM_NSTEPS.txt file
-
+    integer                                :: ios, u                  ! for reading ISSM_NSTEPS.txt file
+	real(dp), pointer, dimension(:)        :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
+    integer                                :: ATTR                    ! internal state attribute
+	
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)             :: IAm
     integer                                :: STATUS
@@ -394,7 +393,6 @@ subroutine SetServices ( GC, RC )
     ! (needed for elements,this is not needed for regridding fields defined on nodes)
     real(dp)                               :: dlon,lon1,lon2,lon3
     integer, pointer, dimension(:)         :: elementMask => null()
-    integer, pointer, dimension(:)         :: nodeMask => null()
     integer                                :: n1,n2,n3
 
     ! pointers to internal state for restart
@@ -469,7 +467,6 @@ subroutine SetServices ( GC, RC )
     allocate(elementConn(3*num_elements))
     allocate(elementCoords(2*num_elements))
     allocate(elementMask(num_elements))
-    allocate(nodeMask(num_nodes))
     allocate(nodeOwners(num_nodes))
 
     ! get information about nodes and elements
@@ -479,13 +476,13 @@ subroutine SetServices ( GC, RC )
 
     elementTypes(:) = ESMF_MESHELEMTYPE_TRI ! triangular elements
 
-    ! mask triangles that cross the seam (longitude +/- 180)
-    ! possibly mask nodes... (note: you don't have to 'activate' these
-    ! masks, they can just be associated with the mesh)
-    ! note: this is only relevant in regridding when fields are
-    !       defined on esmf_meshloc_element (rather than esmf_meshloc_node)
+    ! mask for triangles that cross the seam (longitude +/- 180)
+    ! (you don't have to 'activate' this mask, it can just be 'associated' with the mesh)
+	!
+    ! NOTE: This is only relevant in regridding when fields are defined
+    !       on ESMF_MESHLOC_ELEMENT (rather than ESMF_MESHLOC_NODE)
+	!       so is NOT CURRENTLY USED, but retained for possible future developments 
     elementMask(:) = 0
-    nodeMask(:) = 0
     do j=1,num_elements
       n1 = elementConn(3*(j-1)+1)
       n2 = elementConn(3*(j-1)+2)
@@ -496,18 +493,14 @@ subroutine SetServices ( GC, RC )
       dlon = maxval((/lon1,lon2,lon3/)) - minval((/lon1,lon2,lon3/))
       if ( dlon>180.0 ) then
         elementMask(j) = 1
-        nodeMask(n1) = 1
-        nodeMask(n2) = 1
-        nodeMask(n3) = 1
       end if
     end do
 
     ! create the ESMF mesh from ISSM mesh properties
     mesh = ESMF_MeshCreate(parametricDim=2, spatialDim=2, nodeIds=nodeIds, nodeCoords=nodeCoords, &
             elementIds=elementIds, elementTypes=elementTypes, elementConn=elementConn,elementMask=elementMask,& 
-            nodeMask=nodeMask,elementCoords=elementCoords,coordSys=ESMF_COORDSYS_SPH_DEG, _RC)
+            elementCoords=elementCoords,coordSys=ESMF_COORDSYS_SPH_DEG, _RC)
     
-
     ! associate ESMF_Mesh representation of ISSM mesh with GC for regridding imports/exports in Run method       
     call ESMF_GridCompSet(GC,mesh=mesh,_RC)
     
@@ -604,8 +597,20 @@ subroutine SetServices ( GC, RC )
 
     ! Generic initialize
     !-----------------------------------
+
     call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, _RC )
-    
+
+	! ! Modify the internal state to only have MAPL_AttrTile attribute because 
+	! ! ISSM_NSTEPS has DIMS=MAPL_DimsNone, which adds a MAPL_AttrGrid attribute.... 
+	! ! NOTE: this hack works only for *writing* checkpoints; the code will still crash 
+	! !       if you try to read back in for the same reason     
+	! ! get internal state
+	! call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+	! ! Following MAPL_StateCreateFromVarSpecNew:
+	! ATTR = 0
+	! ATTR = IOR(ATTR, MAPL_AttrTile)
+	! call ESMF_AttributeSet(INTERNAL, NAME = "MAPL_GridTypeBits", VALUE=ATTR, RC=status)   
+
 	  ! Create Custom ISSM Run Alarm 
     !-----------------------------------
 
@@ -617,18 +622,19 @@ subroutine SetServices ( GC, RC )
       close(u)
     end if
 
-    ! get timestep for landice (heartbeat)
-    call MAPL_Get(MAPL, HEARTBEAT=HEARTBEAT_DT,_RC)
+    ! get timestep for landice 
+    call MAPL_Get(MAPL, HEARTBEAT=LANDICE_DT,_RC)
+    call MAPL_GetResource (MAPL, LANDICE_DT, Label="DT:", DEFAULT=LANDICE_DT, RC=STATUS)	
     
     ! get timestep for ISSM
     call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
     
     ! total landice time steps between ISSM runs
-    NSTEPS_RING = nint(ISSM_DT/HEARTBEAT_DT)
+    NSTEPS_RING = nint(ISSM_DT/LANDICE_DT)
     
     ! calculate initial ring time from initial time and remaining timesteps
     call ESMF_ClockGet(CLOCK,currTime=startTime)
-    sec_to_ring = (NSTEPS_RING-NSTEPS_INIT)*nint(HEARTBEAT_DT)
+    sec_to_ring = (NSTEPS_RING-NSTEPS_INIT)*nint(LANDICE_DT)
     call ESMF_TimeIntervalSet(startInterval,s = sec_to_ring )
     ringTime = startTime + startInterval
 
@@ -654,15 +660,20 @@ subroutine SetServices ( GC, RC )
     allocate(OMLS_HALO(num_nodes))
     allocate(ZEROS(num_nodes))
 
-    call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+    ! get internal state
+	call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
     
     ! get pointers to restarts
     call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', _RC)
-    call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', _RC)
-    call MAPL_GetPointer(INTERNAL, ICEVX_IN, 'ICEVX', _RC)
-    call MAPL_GetPointer(INTERNAL, ICEVY_IN, 'ICEVY', _RC)
+    call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK',_RC)
+    call MAPL_GetPointer(INTERNAL, ICEVX_IN, 'ICEVX',_RC)
+    call MAPL_GetPointer(INTERNAL, ICEVY_IN, 'ICEVY',_RC)
     call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', _RC)
-    call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', _RC)
+    call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS',_RC)
+    
+	! ! tracking NSTEPS via internal state not functional yet... 
+	! call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',alloc=.true.,_RC)
+	! ISSM_NSTEPS(:) = 19.0 ! test value
 
     ! if restart has been read, apply halo operation and send pointers to ISSM
     ! else, ISSM will just use default initial values in ISSM*.bin input files
@@ -673,10 +684,10 @@ subroutine SetServices ( GC, RC )
     
     if (ISSM_RST_FOUND) then
       ! apply halo operation to all restart variables
-      call apply_halo(ICESURF_IN,ICESURF_HALO)
-      call apply_halo(ICETHICK_IN,ICETHICK_HALO)
-      call apply_halo(IMLS_IN,IMLS_HALO)
-      call apply_halo(OMLS_IN,OMLS_HALO)
+      call apply_halo(ICESURF_IN,ICESURF_HALO,_RC)
+      call apply_halo(ICETHICK_IN,ICETHICK_HALO,_RC)
+      call apply_halo(IMLS_IN,IMLS_HALO,_RC)
+      call apply_halo(OMLS_IN,OMLS_HALO,_RC)
 
       ! package restarts into one pointer
       GEOS_RESTARTS(:) = 0.0_dp
@@ -694,11 +705,10 @@ subroutine SetServices ( GC, RC )
 
     else
       ! bootstrap restart values from ISSM input files (ISSM*.bin)
-      ! by running with zero time step and zero forcing
-      ZEROS = 0.0_dp
+      ! by running with near-zero time step and zero forcing
 
       call ESMF_VMBarrier(vm, _RC)
-      call RunISSM(0.0_dp, c_loc(ZEROS), c_loc(GEOS_RESTARTS))
+      call RunISSM(1.0_dp, c_loc(ZEROS), c_loc(GEOS_RESTARTS))
       call ESMF_VMBarrier(vm, _RC)
 
       ! update ISSM run flag (for C++ library calls)
@@ -715,6 +725,8 @@ subroutine SetServices ( GC, RC )
       ! filter out halo points (keep the owned indices) for restarts
       if(associated(ICESURF_IN)) ICESURF_IN = ICESURF_HALO(owned_idx)
       if(associated(ICETHICK_IN)) ICETHICK_IN = ICETHICK_HALO(owned_idx)
+	  if(associated(ICEVX_IN)) ICEVX_IN = ICEVX_HALO(owned_idx)
+      if(associated(ICEVY_IN)) ICEVY_IN = ICEVY_HALO(owned_idx)
       if(associated(OMLS_IN)) OMLS_IN = OMLS_HALO(owned_idx)
       if(associated(IMLS_IN)) IMLS_IN = IMLS_HALO(owned_idx)
 
@@ -723,20 +735,23 @@ subroutine SetServices ( GC, RC )
     ! Initialize Export pointers on mesh tile space so history has something to write
     !-----------------------------------
 
-    call MAPL_GetPointer(EXPORT, ICESURF_EX, 'ICESURF', _RC)
+    call MAPL_GetPointer(EXPORT, ICESURF_EX, 'ICESURF',alloc=.true., _RC)
     if(associated(ICESURF_EX)) ICESURF_EX = ICESURF_HALO(owned_idx)
 
-    call MAPL_GetPointer(EXPORT, ICETHICK_EX, 'ICETHICK', _RC)
+    call MAPL_GetPointer(EXPORT, ICETHICK_EX, 'ICETHICK',alloc=.true., _RC)
     if(associated(ICETHICK_EX)) ICETHICK_EX = ICETHICK_HALO(owned_idx)
 
-    call MAPL_GetPointer(EXPORT, ICEVX_EX, 'ICEVX', _RC)
+    call MAPL_GetPointer(EXPORT, ICEVX_EX, 'ICEVX',alloc=.true.,_RC)
     if(associated(ICEVX_EX)) ICEVX_EX = ICEVX_HALO(owned_idx)
 
-    call MAPL_GetPointer(EXPORT, ICEVY_EX, 'ICEVY', _RC)
+    call MAPL_GetPointer(EXPORT, ICEVY_EX, 'ICEVY',alloc=.true.,_RC)
     if(associated(ICEVY_EX)) ICEVY_EX = ICEVY_HALO(owned_idx)
 
     ! Finally, set the tile export state so landice can access values before ISSM runs
     !-----------------------------------
+	call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
+    issm_tile_state => issm_tile_wrap%ptr
+	
     ! Regrid from mesh to tile
     call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
 
@@ -748,9 +763,6 @@ subroutine SetServices ( GC, RC )
     ! calculate ice flow speed
     ICEVEL_HALO = sqrt(ICEVX_HALO**2 + ICEVY_HALO**2)
 
-    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
-    issm_tile_state => issm_tile_wrap%ptr
-
     call mesh_to_tile(ICESURF_HALO,ICESURF_TILE,_RC)
     issm_tile_state%ICESURF_TILE = ICESURF_TILE
 
@@ -759,7 +771,6 @@ subroutine SetServices ( GC, RC )
 
     call mesh_to_tile(ICEVEL_HALO,ICEVEL_TILE,_RC)
     issm_tile_state%ICEVEL_TILE = ICEVEL_TILE
-
 
     call ESMF_VMBarrier(vm, _RC)
 
@@ -772,7 +783,6 @@ subroutine SetServices ( GC, RC )
     if(associated(elementCoords))   deallocate(elementCoords)
     if(associated(glacIds))         deallocate(glacIds)
     if(associated(elementMask))     deallocate(elementMask)
-    if(associated(nodeMask))        deallocate(nodeMask)
     if(associated(halo_idx))        deallocate(halo_idx)
     if(associated(owned_idx))       deallocate(owned_idx)
     if(associated(halolist))        deallocate(halolist)
@@ -799,10 +809,14 @@ subroutine SetServices ( GC, RC )
     _RETURN(_SUCCESS)
 
     contains
-       subroutine apply_halo(VAR_IN,VAR_HALO)
+       subroutine apply_halo(VAR_IN,VAR_HALO,RC)
           ! apply halo operation to a restart variable
+		  ! arguments:
           real, pointer, dimension(:), intent(inout)     :: VAR_IN            ! var on owned_nodes
           real(dp), pointer, dimension(:), intent(inout) :: VAR_HALO          ! var on all nodes
+		  integer, optional, intent(out)                 :: RC
+
+		  ! local variables:
           real(dp), pointer, dimension(:)                :: VAR_DP            ! double version of VAR_IN
           real(dp), pointer, dimension(:)                :: MESH_PTR          ! pointer for ESMF_FieldGet
           real(dp), pointer, dimension(:)                :: ARRAY_PTR         ! pointer for ESMF_FieldGet 
@@ -822,7 +836,6 @@ subroutine SetServices ( GC, RC )
           ! create field on ISSM mesh 
           meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, _RC)
           
-
           ! append halo values to end of "owned" array
           call ESMF_FieldHalo(meshField, routehandle=halohandle, _RC)
       
@@ -837,12 +850,13 @@ subroutine SetServices ( GC, RC )
           call ESMF_FieldDestroy(meshField,_RC)  
           call ESMF_ArrayDestroy(meshArray,_RC)  
           deallocate(VAR_DP)
-        
+
+		  _RETURN(_SUCCESS)
        end subroutine apply_halo
 
        function create_mesh_grid(rc) result(mesh_grid)
           type (ESMF_Grid) :: mesh_grid
-          integer, optional, intent(out) :: rc
+          integer, optional, intent(out) :: RC
           integer :: status, nDEs, num(1)
           real(kind=8), pointer :: centers(:,:)
           integer, allocatable  :: IMs(:)
@@ -920,9 +934,10 @@ subroutine SetServices ( GC, RC )
     type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
 
     ! surface mass balance on mesh and landice tiles
+	! note: SMB has been time-averaged between ISSM runs
     real(dp), pointer, dimension(:)      :: ICESMB_MESH   => null() ! surface mass balce on mesh elements
     real, pointer, dimension(:)          :: ICESMB_TILE   => null() ! surface mass balance on landice tiles
-    real, pointer, dimension(:)          :: ICESMB_EX     => null() ! pointer to SMB export (mesh)
+	real, pointer, dimension(:)          :: ICESMB_EX     => null() ! pointer to export state (mesh tiles)
 
     ! ISSM Outputs
     real(dp),    pointer, dimension(:)   :: ISSM_OUTPUTS  => null() ! pointer containing all outputs
@@ -942,10 +957,13 @@ subroutine SetServices ( GC, RC )
     ! ice-flow velocity in x direction (in projection coordinates)
     real(dp),    pointer, dimension(:)   :: ICEVX_MESH   => null() ! ice x-velocity on mesh
     real, pointer, dimension(:)          :: ICEVX_EX     => null() ! pointer to export state (mesh tiles)
+    real, pointer, dimension(:)          :: ICEVX_IN     => null() ! pointer to internal state (mesh tiles)
+	
 
     ! ice-flow velocity in y direction (in projection coordinates)
     real(dp),    pointer, dimension(:)   :: ICEVY_MESH   => null() ! ice y-velocity on mesh
     real, pointer, dimension(:)          :: ICEVY_EX     => null() ! pointer to export state (mesh tiles)
+    real, pointer, dimension(:)          :: ICEVY_IN     => null() ! pointer to export state (mesh tiles)
 
     ! ice mask level set (tracks glacier terminus)
     real(dp),    pointer, dimension(:)   :: IMLS_MESH    => null() ! ice mask level set
@@ -998,7 +1016,6 @@ subroutine SetServices ( GC, RC )
       ! get timestep for ISSM
       call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
       
-
       ! get number of mesh elements
       call ESMF_MeshGet(mesh,nodeCount=num_nodes)
 
@@ -1035,7 +1052,10 @@ subroutine SetServices ( GC, RC )
       
       ! *************************************************************************** !
       ! GET ICESMB IMPORT (surface mass balance)
-      ! *************************************************************************** !    
+      ! *************************************************************************** ! 
+	  ! NOTE: ICESMB (from landice) has been time-averaged between ISSM runs
+	  !       hence the name ICESMB_ISSM
+	  
       ! allocate tiles for ICESMB 
       if(.not.associated(ICESMB_TILE)) then
         allocate(ICESMB_TILE(NT), STAT=STATUS)
@@ -1046,13 +1066,11 @@ subroutine SetServices ( GC, RC )
       ! copy import values into tile array 
       ICESMB_TILE = issm_tile_state%ICESMB_ISSM
 
-      ! *************************************************************************** !
-      ! TRANSFORM ICESMB FROM TILES TO MESH 
-      ! *************************************************************************** !
+	  ! transform ICESMB from landice tiles to mesh 
       call tile_to_mesh(ICESMB_TILE,ICESMB_MESH,_RC)
 
       ! save ICESMB on mesh elements 
-      call MAPL_GetPointer(EXPORT  , ICESMB_EX , 'ICESMB' , _RC)
+      call MAPL_GetPointer(EXPORT  , ICESMB_EX , 'ICESMB_ISSM' , _RC)
 
       if(associated(ICESMB_EX)) ICESMB_EX = ICESMB_MESH(internal_state%owned_idx)
 
@@ -1106,6 +1124,12 @@ subroutine SetServices ( GC, RC )
       call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', _RC)
       if(associated(ICETHICK_IN)) ICETHICK_IN = ICETHICK_MESH(internal_state%owned_idx)
 
+	  call MAPL_GetPointer(INTERNAL, ICEVX_IN, 'ICEVX', _RC)
+      if(associated(ICEVX_IN)) ICEVX_IN = ICEVX_MESH(internal_state%owned_idx)
+
+	  call MAPL_GetPointer(INTERNAL, ICEVY_IN, 'ICEVY', _RC)
+      if(associated(ICEVY_IN)) ICEVY_IN = ICEVY_MESH(internal_state%owned_idx)
+
       call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', _RC)
       if(associated(OMLS_IN)) OMLS_IN = OMLS_MESH(internal_state%owned_idx)
 
@@ -1130,7 +1154,6 @@ subroutine SetServices ( GC, RC )
     ! barrier to ensure regridding completes before any deallocates
     call ESMF_VMBarrier(vm,_RC)
     
-
     ! deallocates
     if(associated(ICESURF_MESH))  deallocate(ICESURF_MESH)
     if(associated(ICETHICK_MESH)) deallocate(ICETHICK_MESH)
@@ -1174,13 +1197,13 @@ subroutine SetServices ( GC, RC )
     
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)	       :: IAm
-    integer			                       :: STATUS
+    integer			                   :: STATUS
     character(len=ESMF_MAXSTR)         :: COMP_NAME
 
     ! variables for writing out timesteps since ISSM (via ISSM_NSTEPS.txt)
-	  integer :: u
-	  type(T_ISSM_TILE_STATE), pointer     :: issm_tile_state
-    type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
+    integer :: u
+    type(T_ISSM_TILE_STATE), pointer   :: issm_tile_state
+    type(ISSM_TILE_WRAP)               :: issm_tile_wrap
 
     ! Get the target components name and set-up traceback handle.
     ! -----------------------------------------------------------
@@ -1191,21 +1214,21 @@ subroutine SetServices ( GC, RC )
 
 
 	! save number of steps since last ISSM run as a little txt file
-	  call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, STATUS); _VERIFY(STATUS)
+    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, STATUS); _VERIFY(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
 	
-	  open(newunit=u, file="ISSM_NSTEPS.txt", status="replace")
-	  write(u, *) issm_tile_state%ISSM_NSTEPS
-	  close(u)
+    open(newunit=u, file="ISSM_NSTEPS.txt", status="replace")
+    write(u, *) issm_tile_state%ISSM_NSTEPS
+    close(u)
 
     ! call ISSM finalize (saves binary output .outbin file)
-	  if (ISSM_RAN) then
+    if (ISSM_RAN) then
 	  ! NOTE: only call if ISSM C++ solvers were called, because OutputResultsx
 	  ! in C++ source throws error if 'results' is empty... 
 	  ! not actually a problem, but this case won't call FemModel destructors,
 	  ! should probably just remove OutputResultsx from FinalizeISSM()....
-        call FinalizeISSM()
-	  end if 
+       call FinalizeISSM()
+    end if 
 
     ! Generic Finalize
     ! ------------------
@@ -1221,10 +1244,12 @@ subroutine SetServices ( GC, RC )
 
   subroutine mesh_to_tile(VAR_MESH,VAR_TILE,RC)
     ! regrid from mesh to grid, then transform from grid to landice tiles
+	! arguments:
     real(dp),    pointer, dimension(:), intent(inout)   :: VAR_MESH           ! var on mesh nodes
     real, pointer, dimension(:), intent(inout)          :: VAR_TILE           ! var on landice tiles
     integer, optional,       intent(OUT)                :: RC                 ! Error code
 
+    ! local variables:
     real, pointer, dimension(:,:)                       :: VAR_GRID => null() ! var on attached grid
     real(dp),    pointer, dimension(:)                  :: VAR_MESH_OWN       ! var on owned mesh nodes
     type(ESMF_Field)                                    :: srcField
@@ -1237,7 +1262,6 @@ subroutine SetServices ( GC, RC )
 
     call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
     
-
     allocate(VAR_MESH_OWN(num_owned_nodes))
 
     VAR_MESH_OWN = VAR_MESH(internal_state%owned_idx)
@@ -1252,11 +1276,9 @@ subroutine SetServices ( GC, RC )
     srcField = ESMF_FieldCreate(mesh=internal_state%mesh,farrayPtr=VAR_MESH_OWN,meshloc=ESMF_MESHLOC_NODE, & 
     datacopyflag=ESMF_DATACOPY_VALUE,_RC)
     
-    
     ! create destination field: field on grid
     dstField = ESMF_FieldCreate(grid=internal_state%grid,typekind=ESMF_TYPEKIND_R4,_RC)
     
-
     ! regrid field from mesh to grid
     call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_m2g, _RC)
 
@@ -1266,7 +1288,6 @@ subroutine SetServices ( GC, RC )
     ! transform from grid to tiles  
     call MAPL_LocStreamTransform(internal_state%locstream,VAR_TILE,VAR_GRID, _RC)
     
-
     ! destroy regridding fields so they can be reused
     call ESMF_FieldDestroy(srcField,_RC)
     call ESMF_FieldDestroy(dstField,_RC)
@@ -1277,10 +1298,12 @@ subroutine SetServices ( GC, RC )
 
   subroutine tile_to_mesh(VAR_TILE,VAR_MESH,RC)
     ! transform from landice tile to grid, then regrid onto mesh
+	! arguments:
     real, pointer, dimension(:), intent(inout)     :: VAR_TILE           ! var on landice tiles
     real(dp), pointer, dimension(:), intent(inout) :: VAR_MESH           ! var on mesh elements
     integer, optional,       intent(OUT)           :: RC                 ! Error code
 
+    ! local variables:
     real, pointer, dimension(:,:)                  :: VAR_GRID => null() ! var on attached grid
     real(dp), pointer, dimension(:)                :: MESH_PTR           ! pointer for ESMF_FieldGet 
     type(ESMF_Field)                               :: srcField
@@ -1294,7 +1317,6 @@ subroutine SetServices ( GC, RC )
     ! get number of ndoes
     call ESMF_MeshGet(internal_state%mesh,nodeCount=num_nodes,numOwnedNodes=num_owned_nodes,_RC)
     
-
     ! get grid dimensions
     call MAPL_GridGet(internal_state%grid, localCellCountPerDim=local_dims, _RC)
     IM = local_dims(1)
@@ -1309,19 +1331,15 @@ subroutine SetServices ( GC, RC )
     ! (rather than MAPL_UNDEF, which leads to errors when regridding onto mesh)
     call MAPL_LocStreamTransform(internal_state%locstream, VAR_TILE, VAR_GRID, TRANSPOSE=.true., _RC)
     
-
     ! create source field on grid
     srcField = ESMF_FieldCreate(grid=internal_state%grid,farrayPtr=VAR_GRID, datacopyflag=ESMF_DATACOPY_VALUE,_RC)
     
-
     ! create destination field on mesh elements
     meshArray=ESMF_ArrayCreate(internal_state%nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=internal_state%halolist,_RC)
     
-
     ! create field on ISSM mesh
     dstField=ESMF_FieldCreate(internal_state%mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, _RC)
     
-
     ! regrid from grid to mesh
     call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_g2m, _RC)
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -98,7 +98,7 @@ type T_ISSM_TILE_STATE
     real, pointer :: ICEVEL_TILE(:)
     real, pointer :: ICESMB_ISSM(:)
     integer       :: ISSM_NSTEPS
-	real          :: LANDICE_DT
+	  real          :: LANDICE_DT
 end type T_ISSM_TILE_STATE
 
 type ISSM_TILE_WRAP

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -171,33 +171,33 @@ subroutine SetServices ( GC, RC )
 ! Get my name and set-up traceback handle
 ! ---------------------------------------
 
-    call ESMF_GridCompGet( GC, NAME=COMP_NAME, RC=STATUS )
-    VERIFY_(STATUS)
+    call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC )
+    
     Iam = trim(COMP_NAME) // 'SetServices'
 
 ! Set the Initialize, Run, and Finalize entry points
 !-----------------------------------
 
-    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE,   Initialize, RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE,   Initialize, _RC)
+    
 
-    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,          Run,        RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,          Run,        _RC)
+    
 
-    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_FINALIZE,     Finalize,   RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_FINALIZE,     Finalize,   _RC)
+    
 
 !-----------------------------------
 
-    call MAPL_GetObjectFromGC (GC, MAPL, RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_GetObjectFromGC (GC, MAPL, _RC)
+    
 
-    call ESMF_GridCompGet(GC, CONFIG = CF, RC=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_GridCompGet(GC, CONFIG = CF, _RC)
+    
 
     ! get timestep for ISSM
-    call ESMF_ConfigGetAttribute(CF, ISSM_DT, Label=trim(COMP_NAME)//"_DT:", DEFAULT=302400.0, RC=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_ConfigGetAttribute(CF, ISSM_DT, Label=trim(COMP_NAME)//"_DT:", DEFAULT=302400.0, _RC)
+    
 
 
     ! Set the state variable specs.
@@ -212,8 +212,8 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'm',                         &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
 
     call MAPL_AddExportSpec(GC,                    &
          SHORT_NAME = 'ICEVX',                     &
@@ -221,8 +221,8 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'm s-1',                     &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
 
     call MAPL_AddExportSpec(GC,                    &
         SHORT_NAME = 'ICEVY',                      &
@@ -230,8 +230,8 @@ subroutine SetServices ( GC, RC )
         UNITS      = 'm s-1',                      &
         DIMS       = MAPL_DimsTileOnly,            &
         VLOCATION  = MAPL_VLocationNone,           &
-        RC=STATUS  )
-    VERIFY_(STATUS)
+        _RC  )
+    
 
     call MAPL_AddExportSpec(GC,                    &
          SHORT_NAME = 'ICETHICK',                  &
@@ -239,8 +239,8 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'm',                         &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
 
     call MAPL_AddExportSpec(GC,                    &
          SHORT_NAME = 'ICESMB',                    &
@@ -248,8 +248,8 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'kg m-2 s-1',                &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
 
     !   Internal states:
     call MAPL_AddInternalSpec(GC,                  &
@@ -259,8 +259,8 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
 		     RESTART    = MAPL_RestartOptional,        &   
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
 
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICETHICK',                  &
@@ -269,8 +269,8 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
 		     RESTART    = MAPL_RestartOptional,        & 
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
     
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'IMLS',                      &
@@ -279,8 +279,8 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
 		     RESTART    = MAPL_RestartOptional,        & 
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
 
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'OMLS',                      &
@@ -289,8 +289,8 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
 		     RESTART    = MAPL_RestartOptional,        & 
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
 
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICEVX',                     &
@@ -299,8 +299,8 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
          RESTART    = MAPL_RestartOptional,        &
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
 
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICEVY',                     &
@@ -309,20 +309,20 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
          RESTART    = MAPL_RestartOptional,        &
-         RC=STATUS  )
-    VERIFY_(STATUS)
+         _RC  )
+    
 
 
 ! Set the Profiling timers
 ! ------------------------
 
-    call MAPL_TimerAdd(GC,    name="RUN"   ,RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_TimerAdd(GC,    name="RUN"   ,_RC)
+    
 
    
 ! ----------------------------------
-    call MAPL_GenericSetServices    ( GC, RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_GenericSetServices    ( GC, _RC)
+    
 
 
     RETURN_(ESMF_SUCCESS)
@@ -460,28 +460,28 @@ subroutine SetServices ( GC, RC )
     ! -----------------------------------------------------------
 
     Iam = "Initialize"
-    call ESMF_GridCompGet( GC, NAME=COMP_NAME, RC=status )
-    VERIFY_(STATUS)
+    call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC )
+    
     Iam = trim(COMP_NAME) // trim(Iam)
 
     ! Get my internal MAPL_Generic state
     !-----------------------------------
 
-    call MAPL_GetObjectFromGC ( GC, MAPL, RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_GetObjectFromGC ( GC, MAPL, _RC)
+    
 
-    call ESMF_VMGetCurrent(vm, rc=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_VMGetCurrent(vm, _RC)
+    
 
-    call ESMF_VMGet(vm,mpiCommunicator=comm,localPet=localPET,rc=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_VMGet(vm,mpiCommunicator=comm,localPet=localPET,_RC)
+    
 
     ! ****************************************************
     ! call ISSM initialize C++ code so we can set up mesh
 
     ! get directory with ISSM binary input files (can modify if needed)
-    call GET_ENVIRONMENT_VARIABLE("SCRDIR",ISSM_EXPDIR,STATUS=STATUS)
-    VERIFY_(STATUS)
+    call GET_ENVIRONMENT_VARIABLE("SCRDIR",ISSM_EXPDIR,STATUS=STATUS); _VERIFY(STATUS)
+    
 
     EXPDIR = trim(ISSM_EXPDIR)//"/"//c_null_char ! create string for C++
     
@@ -534,12 +534,12 @@ subroutine SetServices ( GC, RC )
     ! create the ESMF mesh from ISSM mesh properties
     mesh = ESMF_MeshCreate(parametricDim=2, spatialDim=2, nodeIds=nodeIds, nodeCoords=nodeCoords, &
             elementIds=elementIds, elementTypes=elementTypes, elementConn=elementConn,elementMask=elementMask,& 
-            nodeMask=nodeMask,elementCoords=elementCoords,coordSys=ESMF_COORDSYS_SPH_DEG, rc=STATUS)
-    VERIFY_(STATUS)
+            nodeMask=nodeMask,elementCoords=elementCoords,coordSys=ESMF_COORDSYS_SPH_DEG, _RC)
+    
 
     ! associate ESMF_Mesh representation of ISSM mesh with GC for regridding imports/exports in Run method       
-    call ESMF_GridCompSet(GC,mesh=mesh,rc=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_GridCompSet(GC,mesh=mesh,_RC)
+    
 
     ! set up field halos
     !-----------------------------------
@@ -570,40 +570,40 @@ subroutine SetServices ( GC, RC )
     end do
 
     ! create array with halo information
-    meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,rc=STATUS)
-    VERIFY_(STATUS)
+    meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,_RC)
+    
 
     ! create field on ISSM mesh 
-    meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, rc=STATUS)
-    VERIFY_(STATUS)
+    meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, _RC)
+    
 
     ! store the halo operation in a routehandle
-    call ESMF_FieldHaloStore(meshField, routehandle=halohandle, rc=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_FieldHaloStore(meshField, routehandle=halohandle, _RC)
+    
 
     ! Set up regridding next
     !-----------------------------------
     ! get atmospheric (attached) grid 
-    call ESMF_GridCompGet( GC, GRID=grid, RC=status ); VERIFY_(STATUS)
+    call ESMF_GridCompGet( GC, GRID=grid, _RC )
     
     ! create field on atmospheric grid
-    gridField = ESMF_FieldCreate(grid=grid,typekind=ESMF_TYPEKIND_R4,rc=STATUS); VERIFY_(STATUS)
+    gridField = ESMF_FieldCreate(grid=grid,typekind=ESMF_TYPEKIND_R4,_RC)
     
     ! create routehandle for mesh-to-grid regridding (set srcMaskValues to 1 if needed... )
     call ESMF_FieldRegridStore(srcField=meshField, dstField=gridField,routehandle=routehandle_m2g,& 
     unmappedaction=ESMF_UNMAPPEDACTION_IGNORE,extrapmethod=ESMF_EXTRAPMETHOD_CREEP,&
-    extrapNumLevels=1,rc=STATUS)
-    VERIFY_(STATUS)
+    extrapNumLevels=1,_RC)
+    
 
     ! create routehandle for grid-to-mesh regridding (set dstMaskValues to 1 if needed... )
     call ESMF_FieldRegridStore(srcField=gridField, dstField=meshField,routehandle=routehandle_g2m,& 
-    unmappedaction=ESMF_UNMAPPEDACTION_IGNORE,extrapmethod=ESMF_EXTRAPMETHOD_NEAREST_D,rc=STATUS)
-    VERIFY_(STATUS)
+    unmappedaction=ESMF_UNMAPPEDACTION_IGNORE,extrapmethod=ESMF_EXTRAPMETHOD_NEAREST_D,_RC)
+    
     
     ! create component's private internal state
     ! stores everything needed for regrid and halo operations during run method
-    allocate(internal_state, stat=STATUS)
-    VERIFY_(STATUS)
+    allocate(internal_state, stat=STATUS); _VERIFY(STATUS)
+    
     allocate(internal_state%halo_idx(num_halo_nodes))
     allocate(internal_state%owned_idx(num_owned_nodes))
     allocate(internal_state%halolist(num_halo_nodes))
@@ -620,8 +620,8 @@ subroutine SetServices ( GC, RC )
 
     ! wrap the private internal state
     wrap%ptr => internal_state
-    call ESMF_UserCompSetInternalState ( GC, 'ISSM_WRAP', wrap, status )
-    VERIFY_(STATUS)
+    call ESMF_UserCompSetInternalState ( GC, 'ISSM_WRAP', wrap, STATUS ); _VERIFY(STATUS)
+    
 
     ! Create losctream that match mesh element id, then set it to this GC and MAPL
     ! note: original attached/atmospheric grid and landice tile locstream have
@@ -640,8 +640,8 @@ subroutine SetServices ( GC, RC )
 
     ! Generic initialize
     !-----------------------------------
-    call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
-    VERIFY_(STATUS)
+    call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, _RC )
+    
 
 	  ! Create Custom ISSM Run Alarm 
     !-----------------------------------
@@ -655,12 +655,12 @@ subroutine SetServices ( GC, RC )
     end if
 
     ! get timestep for landice (heartbeat)
-    call MAPL_Get(MAPL, HEARTBEAT=HEARTBEAT_DT,RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_Get(MAPL, HEARTBEAT=HEARTBEAT_DT,_RC)
+    
 
     ! get timestep for ISSM
-    call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
+    
     
     ! total landice time steps between ISSM runs
     NSTEPS_RING = nint(ISSM_DT/HEARTBEAT_DT)
@@ -672,12 +672,12 @@ subroutine SetServices ( GC, RC )
     ringTime = startTime + startInterval
 
     ! set ring interval to ISSM time step
-    call ESMF_TimeIntervalSet(ringInterval,s=nint(ISSM_DT),RC=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_TimeIntervalSet(ringInterval,s=nint(ISSM_DT),_RC)
+    
 
     ! create new ISSM_ALARM
-    ISSM_ALARM = ESMF_AlarmCreate(CLOCK,ringTime=ringTime,ringInterval=ringInterval,sticky=.false.,rc=STATUS)
-	  VERIFY_(STATUS)
+    ISSM_ALARM = ESMF_AlarmCreate(CLOCK,ringTime=ringTime,ringInterval=ringInterval,sticky=.false.,_RC)
+	  
 
 	! set run alarm
     call MAPL_Set(MAPL, RUNALARM = ISSM_ALARM, _RC)
@@ -696,16 +696,16 @@ subroutine SetServices ( GC, RC )
     allocate(OMLS_HALO(num_nodes))
     allocate(ZEROS(num_nodes))
 
-    call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+    
 
     ! get pointers to restarts
-    call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
-    call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
-    call MAPL_GetPointer(INTERNAL, ICEVX_IN, 'ICEVX', RC=STATUS); VERIFY_(STATUS)
-    call MAPL_GetPointer(INTERNAL, ICEVY_IN, 'ICEVY', RC=STATUS); VERIFY_(STATUS)
-    call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', RC=STATUS); VERIFY_(STATUS)
-    call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', _RC)
+    call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', _RC)
+    call MAPL_GetPointer(INTERNAL, ICEVX_IN, 'ICEVX', _RC)
+    call MAPL_GetPointer(INTERNAL, ICEVY_IN, 'ICEVY', _RC)
+    call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', _RC)
+    call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', _RC)
 
     ! if restart has been read, apply halo operation and send pointers to ISSM
     ! else, ISSM will just use default initial values in ISSM*.bin input files
@@ -731,18 +731,18 @@ subroutine SetServices ( GC, RC )
       GEOS_RESTARTS(5*num_nodes+1:6*num_nodes) = IMLS_HALO(:) 
 
       ! set restarts on the ISSM side
-      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)      
+      call ESMF_VMBarrier(vm, _RC)      
       call InputFromRestarts(c_loc(GEOS_RESTARTS))
-      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+      call ESMF_VMBarrier(vm, _RC)
 
     else
       ! bootstrap restart values from ISSM input files (ISSM*.bin)
       ! by running with zero time step and zero forcing
       ZEROS = 0.0_dp
 
-      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+      call ESMF_VMBarrier(vm, _RC)
       call RunISSM(epsilon(ISSM_DT), c_loc(ZEROS), c_loc(GEOS_RESTARTS))
-      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+      call ESMF_VMBarrier(vm, _RC)
 
       ! update ISSM run flag (for C++ library calls)
       ISSM_RAN = .true.
@@ -766,16 +766,16 @@ subroutine SetServices ( GC, RC )
     ! Initialize Export pointers on mesh tile space so history has something to write
     !-----------------------------------
 
-    call MAPL_GetPointer(EXPORT, ICESURF_EX, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(EXPORT, ICESURF_EX, 'ICESURF', _RC)
     if(associated(ICESURF_EX)) ICESURF_EX = ICESURF_HALO(owned_idx)
 
-    call MAPL_GetPointer(EXPORT, ICETHICK_EX, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(EXPORT, ICETHICK_EX, 'ICETHICK', _RC)
     if(associated(ICETHICK_EX)) ICETHICK_EX = ICETHICK_HALO(owned_idx)
 
-    call MAPL_GetPointer(EXPORT, ICEVX_EX, 'ICEVX', RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(EXPORT, ICEVX_EX, 'ICEVX', _RC)
     if(associated(ICEVX_EX)) ICEVX_EX = ICEVX_HALO(owned_idx)
 
-    call MAPL_GetPointer(EXPORT, ICEVY_EX, 'ICEVY', RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(EXPORT, ICEVY_EX, 'ICEVY', _RC)
     if(associated(ICEVY_EX)) ICEVY_EX = ICEVY_HALO(owned_idx)
 
     ! Finally, set the tile export state so landice can access values before ISSM runs
@@ -791,20 +791,20 @@ subroutine SetServices ( GC, RC )
     ! calculate ice flow speed
     ICEVEL_HALO = sqrt(ICEVX_HALO**2 + ICEVY_HALO**2)
 
-    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
+    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
 
-    call mesh_to_tile(ICESURF_HALO,ICESURF_TILE,rc=STATUS); VERIFY_(STATUS)
+    call mesh_to_tile(ICESURF_HALO,ICESURF_TILE,_RC)
     issm_tile_state%ICESURF_TILE = ICESURF_TILE
 
-    call mesh_to_tile(ICETHICK_HALO,ICETHICK_TILE,rc=STATUS); VERIFY_(STATUS)
+    call mesh_to_tile(ICETHICK_HALO,ICETHICK_TILE,_RC)
     issm_tile_state%ICETHICK_TILE = ICETHICK_TILE
 
-    call mesh_to_tile(ICEVEL_HALO,ICEVEL_TILE,rc=STATUS); VERIFY_(STATUS)
+    call mesh_to_tile(ICEVEL_HALO,ICEVEL_TILE,_RC)
     issm_tile_state%ICEVEL_TILE = ICEVEL_TILE
 
 
-    call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+    call ESMF_VMBarrier(vm, _RC)
 
     ! deallocate pointers
     if(associated(nodeCoords))      deallocate(nodeCoords)
@@ -835,9 +835,9 @@ subroutine SetServices ( GC, RC )
     if(associated(ICEVEL_TILE))     deallocate(ICEVEL_TILE)
 
     ! destroy fields and arrays
-    call ESMF_FieldDestroy(gridField, rc=STATUS); VERIFY_(STATUS)
-    call ESMF_FieldDestroy(meshField, rc=STATUS); VERIFY_(STATUS)
-    call ESMF_ArrayDestroy(meshArray, rc=STATUS); VERIFY_(STATUS)
+    call ESMF_FieldDestroy(gridField, _RC)
+    call ESMF_FieldDestroy(meshField, _RC)
+    call ESMF_ArrayDestroy(meshArray, _RC)
     
     RETURN_(ESMF_SUCCESS)
 
@@ -857,28 +857,28 @@ subroutine SetServices ( GC, RC )
           VAR_DP(1:num_owned_nodes) = REAL(VAR_IN,kind=dp)
       
           ! create array with halo information
-          meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,rc=STATUS)
+          meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,_RC)
 
           call ESMF_ArrayGet(array=meshArray,farrayPtr=ARRAY_PTR)
           ARRAY_PTR(:) = VAR_DP(:)
 
           ! create field on ISSM mesh 
-          meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, rc=STATUS)
-          VERIFY_(STATUS)
+          meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, _RC)
+          
 
           ! append halo values to end of "owned" array
-          call ESMF_FieldHalo(meshField, routehandle=halohandle, rc=STATUS); VERIFY_(STATUS)
+          call ESMF_FieldHalo(meshField, routehandle=halohandle, _RC)
       
           ! get pointer to field on mesh
-          call ESMF_FieldGet(meshField,farrayPtr=MESH_PTR,RC=STATUS); VERIFY_(STATUS)
+          call ESMF_FieldGet(meshField,farrayPtr=MESH_PTR,_RC)
 
           ! copy values into VAR_HALO, interleave according to owned and halo indices
           VAR_HALO(owned_idx) = MESH_PTR(1:num_owned_nodes)          ! owned nodes
           VAR_HALO(halo_idx) = MESH_PTR(num_owned_nodes+1:num_nodes) ! halo nodes
 
           ! destroy field and array, deallocate pointer
-          call ESMF_FieldDestroy(meshField,rc=STATUS);  VERIFY_(STATUS)
-          call ESMF_ArrayDestroy(meshArray,rc=STATUS);  VERIFY_(STATUS)
+          call ESMF_FieldDestroy(meshField,_RC)  
+          call ESMF_ArrayDestroy(meshArray,_RC)  
           deallocate(VAR_DP)
         
        end subroutine apply_halo
@@ -912,7 +912,7 @@ subroutine SetServices ( GC, RC )
           ! even if their values don't make sense;
           ! later on, the coord will be set to element's lat lon.
           call ESMF_GridAddCoord(mesh_grid, _RC)
-          _VERIFY(status)
+          _VERIFY(STATUS)
 
           call ESMF_GridGetCoord(mesh_grid, coordDim=1, localDE=0, &
                staggerloc=ESMF_STAGGERLOC_CENTER, &
@@ -991,56 +991,56 @@ subroutine SetServices ( GC, RC )
     real, pointer, dimension(:)          :: ICEVY_EX     => null() ! pointer to export state (mesh tiles)
 
     ! ice mask level set (tracks glacier terminus)
-    real(dp),    pointer, dimension(:)   :: IMLS_MESH   => null() ! ice mask level set
-    real, pointer, dimension(:)          :: IMLS_IN     => null() ! pointer to internal state (mesh tiles)
+    real(dp),    pointer, dimension(:)   :: IMLS_MESH    => null() ! ice mask level set
+    real, pointer, dimension(:)          :: IMLS_IN      => null() ! pointer to internal state (mesh tiles)
 
     ! ocean mask level set (tracks grounding line)
-    real(dp),    pointer, dimension(:)   :: OMLS_MESH   => null() ! ocean mask level set
-    real, pointer, dimension(:)          :: OMLS_IN     => null() ! pointer to internal state (mesh tiles)
+    real(dp),    pointer, dimension(:)   :: OMLS_MESH    => null() ! ocean mask level set
+    real, pointer, dimension(:)          :: OMLS_IN      => null() ! pointer to internal state (mesh tiles)
 
     ! ice-flow speed on mesh and landice tiles  
-    real(dp),    pointer, dimension(:)   :: ICEVEL_MESH => null() ! ice flow speed on mesh tiles
-    real, pointer, dimension(:)          :: ICEVEL_TILE => null() ! ice flow speed on landice tiles
+    real(dp),    pointer, dimension(:)   :: ICEVEL_MESH  => null() ! ice flow speed on mesh tiles
+    real, pointer, dimension(:)          :: ICEVEL_TILE  => null() ! ice flow speed on landice tiles
   
     ! physical parameters
-    real(dp), parameter                  :: rho_ice   = 917.0     ! pure ice density [kg m-3]
-    real(dp)                             :: ISSM_DT               ! time step [s] (ISSM_DT set in AGCM.rc)
+    real(dp), parameter                  :: rho_ice   = 917.0      ! pure ice density [kg m-3]
+    real(dp)                             :: ISSM_DT                ! time step [s] (ISSM_DT set in AGCM.rc)
 
   ! Get the target components name, mesh and vm
   ! -----------------------------------------------------------
     Iam = "Run"
-    call ESMF_GridCompGet(GC,name=COMP_NAME,mesh=mesh,vm=vm,RC=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_GridCompGet(GC,name=COMP_NAME,mesh=mesh,vm=vm,_RC)
+    
     Iam = trim(COMP_NAME) // Iam
 
   ! Get my internal MAPL_Generic state
   !----------------------------------
     call MAPL_GetObjectFromGC(GC, MAPL, STATUS)
-    VERIFY_(STATUS)
+    _VERIFY(STATUS)
 
-    call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,RC=STATUS )
-    VERIFY_(STATUS)
+    call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC )
+    
 
     ! Start Total timer
   !------------------
     call MAPL_TimerOn(MAPL,"TOTAL")
     call MAPL_TimerOn(MAPL,"RUN" )
 
-    call MAPL_Get(MAPL, RUNALARM = ALARM, RC=STATUS )
-    VERIFY_(STATUS)
+    call MAPL_Get(MAPL, RUNALARM = ALARM, _RC )
+    
 
     ! run ISSM at specified time steps, 
     ! if bootstrapping restart and issm has run not by final time step, run anyways
     ! with timestep of zero, which just gets restart values
-    if (ESMF_AlarmIsRinging(ALARM, RC=STATUS)) then
+    if (ESMF_AlarmIsRinging(ALARM, _RC)) then
 
       ! *************************************************************************** !
       ! BASIC SETUP
       ! *************************************************************************** !
 
       ! get timestep for ISSM
-      call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
-      VERIFY_(STATUS)
+      call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
+      
 
       ! get number of mesh elements
       call ESMF_MeshGet(mesh,nodeCount=num_nodes)
@@ -1073,7 +1073,7 @@ subroutine SetServices ( GC, RC )
       ! get landice tile dimensions
       call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
       
-      call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
+      call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
       issm_tile_state => issm_tile_wrap%ptr
       
       ! *************************************************************************** !
@@ -1082,7 +1082,7 @@ subroutine SetServices ( GC, RC )
       ! allocate tiles for ICESMB 
       if(.not.associated(ICESMB_TILE)) then
         allocate(ICESMB_TILE(NT), STAT=STATUS)
-        VERIFY_(STATUS)
+        _VERIFY(STATUS)
         ICESMB_TILE = MAPL_Undef
       end if
       
@@ -1092,10 +1092,10 @@ subroutine SetServices ( GC, RC )
       ! *************************************************************************** !
       ! TRANSFORM ICESMB FROM TILES TO MESH 
       ! *************************************************************************** !
-      call tile_to_mesh(ICESMB_TILE,ICESMB_MESH,rc=STATUS); VERIFY_(STATUS)
+      call tile_to_mesh(ICESMB_TILE,ICESMB_MESH,_RC)
 
       ! save ICESMB on mesh elements 
-      call MAPL_GetPointer(EXPORT  , ICESMB_EX , 'ICESMB' , RC=STATUS); VERIFY_(STATUS)
+      call MAPL_GetPointer(EXPORT  , ICESMB_EX , 'ICESMB' , _RC)
 
       if(associated(ICESMB_EX)) ICESMB_EX = ICESMB_MESH(internal_state%owned_idx)
 
@@ -1105,12 +1105,12 @@ subroutine SetServices ( GC, RC )
       ! convert SMB to units of [m/s] (ice-equivalent) before passing to ISSM
       ICESMB_MESH = ICESMB_MESH/rho_ice
 
-      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+      call ESMF_VMBarrier(vm, _RC)
 
       ! call run method from ISSM library 
       call RunISSM(ISSM_DT, c_loc(ICESMB_MESH), c_loc(ISSM_OUTPUTS))
 
-      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+      call ESMF_VMBarrier(vm, _RC)
 
       ! update ISSM run flag (for C++ library calls)
       ISSM_RAN = .true.
@@ -1130,49 +1130,49 @@ subroutine SetServices ( GC, RC )
       ICEVEL_MESH = sqrt(ICEVX_MESH**2 + ICEVY_MESH**2)
 
       ! set pointers to tile-mesh exports
-      call MAPL_GetPointer(EXPORT, ICESURF_EX, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
+      call MAPL_GetPointer(EXPORT, ICESURF_EX, 'ICESURF', _RC)
       if(associated(ICESURF_EX)) ICESURF_EX = ICESURF_MESH(internal_state%owned_idx)
 
-      call MAPL_GetPointer(EXPORT, ICEVX_EX, 'ICEVX', RC=STATUS); VERIFY_(STATUS)
+      call MAPL_GetPointer(EXPORT, ICEVX_EX, 'ICEVX', _RC)
       if(associated(ICEVX_EX)) ICEVX_EX = ICEVX_MESH(internal_state%owned_idx)
 
-      call MAPL_GetPointer(EXPORT, ICEVY_EX, 'ICEVY', RC=STATUS); VERIFY_(STATUS)
+      call MAPL_GetPointer(EXPORT, ICEVY_EX, 'ICEVY', _RC)
       if(associated(ICEVY_EX)) ICEVY_EX = ICEVY_MESH(internal_state%owned_idx)
 
-      call MAPL_GetPointer(EXPORT, ICETHICK_EX, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
+      call MAPL_GetPointer(EXPORT, ICETHICK_EX, 'ICETHICK', _RC)
       if(associated(ICETHICK_EX)) ICETHICK_EX = ICETHICK_MESH(internal_state%owned_idx)
 
       ! set pointers to tile-mesh internals
-      call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
+      call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', _RC)
       if(associated(ICESURF_IN)) ICESURF_IN = ICESURF_MESH(internal_state%owned_idx)
 
-      call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
+      call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', _RC)
       if(associated(ICETHICK_IN)) ICETHICK_IN = ICETHICK_MESH(internal_state%owned_idx)
 
-      call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', RC=STATUS); VERIFY_(STATUS)
+      call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', _RC)
       if(associated(OMLS_IN)) OMLS_IN = OMLS_MESH(internal_state%owned_idx)
 
-      call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', RC=STATUS); VERIFY_(STATUS)
+      call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', _RC)
       if(associated(IMLS_IN)) IMLS_IN = IMLS_MESH(internal_state%owned_idx)
 
       ! *************************************************************************** !
       ! REGRID MESH FIELDS ONTO LANDICE TILES AND EXPORT VIA INTERNAL STATE
       ! *************************************************************************** !
       ! transform from mesh to tiles
-      call mesh_to_tile(ICESURF_MESH,ICESURF_TILE,rc=STATUS); VERIFY_(STATUS)
+      call mesh_to_tile(ICESURF_MESH,ICESURF_TILE,_RC)
       issm_tile_state%ICESURF_TILE = ICESURF_TILE
 
-      call mesh_to_tile(ICETHICK_MESH,ICETHICK_TILE,rc=STATUS); VERIFY_(STATUS)
+      call mesh_to_tile(ICETHICK_MESH,ICETHICK_TILE,_RC)
       issm_tile_state%ICETHICK_TILE = ICETHICK_TILE
 
-      call mesh_to_tile(ICEVEL_MESH,ICEVEL_TILE,rc=STATUS); VERIFY_(STATUS)
+      call mesh_to_tile(ICEVEL_MESH,ICEVEL_TILE,_RC)
       issm_tile_state%ICEVEL_TILE = ICEVEL_TILE
 
     end if 
     
     ! barrier to ensure regridding completes before any deallocates
-    call ESMF_VMBarrier(vm, rc=status)
-    VERIFY_(STATUS)
+    call ESMF_VMBarrier(vm,_RC)
+    
 
     ! deallocates
     if(associated(ICESURF_MESH))  deallocate(ICESURF_MESH)
@@ -1228,13 +1228,13 @@ subroutine SetServices ( GC, RC )
     ! Get the target components name and set-up traceback handle.
     ! -----------------------------------------------------------
     Iam = "Finalize"
-    call ESMF_GridCompGet( gc, NAME=comp_name, RC=status )
-    VERIFY_(STATUS)
+    call ESMF_GridCompGet( gc, NAME=comp_name, _RC )
+    
     Iam = trim(comp_name) // Iam
 
 
 	! save number of steps since last ISSM run as a little txt file
-	  call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
+	  call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, STATUS); _VERIFY(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
 	
 	  open(newunit=u, file="ISSM_NSTEPS.txt", status="replace")
@@ -1252,8 +1252,8 @@ subroutine SetServices ( GC, RC )
 
     ! Generic Finalize
     ! ------------------
-    call MAPL_GenericFinalize( GC, IMPORT, EXPORT, CLOCK, RC=status )
-    VERIFY_(STATUS)
+    call MAPL_GenericFinalize( GC, IMPORT, EXPORT, CLOCK, _RC )
+    
 
     ! All Done
     ! ------------------
@@ -1278,8 +1278,8 @@ subroutine SetServices ( GC, RC )
   
     num_owned_nodes = size(internal_state%owned_idx)
 
-    call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, rc=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
+    
 
     allocate(VAR_MESH_OWN(num_owned_nodes))
 
@@ -1287,33 +1287,32 @@ subroutine SetServices ( GC, RC )
 
     ! allocate tiles 
     if (.not.associated(VAR_TILE)) then
-      allocate(VAR_TILE(NT), STAT=STATUS)
-      VERIFY_(STATUS)
+      allocate(VAR_TILE(NT))
       VAR_TILE = MAPL_Undef
     end if
 
     ! create source field: field on mesh nodes
     srcField = ESMF_FieldCreate(mesh=internal_state%mesh,farrayPtr=VAR_MESH_OWN,meshloc=ESMF_MESHLOC_NODE, & 
-    datacopyflag=ESMF_DATACOPY_VALUE,rc=STATUS)
-    VERIFY_(STATUS)
+    datacopyflag=ESMF_DATACOPY_VALUE,_RC)
+    
     
     ! create destination field: field on grid
-    dstField = ESMF_FieldCreate(grid=internal_state%grid,typekind=ESMF_TYPEKIND_R4,rc=STATUS)
-    VERIFY_(STATUS)
+    dstField = ESMF_FieldCreate(grid=internal_state%grid,typekind=ESMF_TYPEKIND_R4,_RC)
+    
 
     ! regrid field from mesh to grid
-    call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_m2g, RC=STATUS); VERIFY_(STATUS)
+    call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_m2g, _RC)
 
     ! get pointer to field on grid
-    call ESMF_FieldGet(dstField,farrayPtr=VAR_GRID,RC=STATUS); VERIFY_(STATUS)
+    call ESMF_FieldGet(dstField,farrayPtr=VAR_GRID,_RC)
 
     ! transform from grid to tiles  
-    call MAPL_LocStreamTransform(internal_state%locstream,VAR_TILE,VAR_GRID, RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_LocStreamTransform(internal_state%locstream,VAR_TILE,VAR_GRID, _RC)
+    
 
     ! destroy regridding fields so they can be reused
-    call ESMF_FieldDestroy(srcField,rc=STATUS); VERIFY_(STATUS)
-    call ESMF_FieldDestroy(dstField,rc=STATUS); VERIFY_(STATUS)
+    call ESMF_FieldDestroy(srcField,_RC)
+    call ESMF_FieldDestroy(dstField,_RC)
 
   end subroutine mesh_to_tile
 
@@ -1333,8 +1332,8 @@ subroutine SetServices ( GC, RC )
     integer                                        :: STATUS
 
     ! get number of ndoes
-    call ESMF_MeshGet(internal_state%mesh,nodeCount=num_nodes,numOwnedNodes=num_owned_nodes,rc=STATUS)
-    VERIFY_(STATUS)
+    call ESMF_MeshGet(internal_state%mesh,nodeCount=num_nodes,numOwnedNodes=num_owned_nodes,_RC)
+    
 
     ! get grid dimensions
     call MAPL_GridGet(internal_state%grid, localCellCountPerDim=local_dims, _RC)
@@ -1342,35 +1341,35 @@ subroutine SetServices ( GC, RC )
     JM = local_dims(2)
 
     ! allocate pointer on grid for regridding 
-    allocate(VAR_GRID(IM,JM), STAT=STATUS); VERIFY_(STATUS)
+    allocate(VAR_GRID(IM,JM))
   
     ! transform from tile to grid
     ! NOTE: we use the "transpose" option with MAPL_LocStreamTransformG2T 
     ! (rather than MAPL_LocStreamTransformT2G) because the "default" value is zero
     ! (rather than MAPL_UNDEF, which leads to errors when regridding onto mesh)
-    call MAPL_LocStreamTransform(internal_state%locstream, VAR_TILE, VAR_GRID, TRANSPOSE=.true., RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_LocStreamTransform(internal_state%locstream, VAR_TILE, VAR_GRID, TRANSPOSE=.true., _RC)
+    
 
     ! create source field on grid
-    srcField = ESMF_FieldCreate(grid=internal_state%grid,farrayPtr=VAR_GRID, datacopyflag=ESMF_DATACOPY_VALUE,rc=STATUS)
-    VERIFY_(STATUS)
+    srcField = ESMF_FieldCreate(grid=internal_state%grid,farrayPtr=VAR_GRID, datacopyflag=ESMF_DATACOPY_VALUE,_RC)
+    
 
     ! create destination field on mesh elements
-    meshArray=ESMF_ArrayCreate(internal_state%nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=internal_state%halolist,rc=STATUS)
-    VERIFY_(STATUS)
+    meshArray=ESMF_ArrayCreate(internal_state%nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=internal_state%halolist,_RC)
+    
 
     ! create field on ISSM mesh
-    dstField=ESMF_FieldCreate(internal_state%mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, rc=STATUS)
-    VERIFY_(STATUS)
+    dstField=ESMF_FieldCreate(internal_state%mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, _RC)
+    
 
     ! regrid from grid to mesh
-    call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_g2m, RC=STATUS); VERIFY_(STATUS)
+    call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_g2m, _RC)
 
     ! append halo values to end of "owned" array
-    call ESMF_FieldHalo(dstField, routehandle=internal_state%halohandle, rc=STATUS); VERIFY_(STATUS)
+    call ESMF_FieldHalo(dstField, routehandle=internal_state%halohandle, _RC)
 
     ! get pointer to field on mesh
-    call ESMF_FieldGet(dstField,farrayPtr=MESH_PTR,RC=STATUS); VERIFY_(STATUS)
+    call ESMF_FieldGet(dstField,farrayPtr=MESH_PTR,_RC)
 
     ! copy values into VAR_MESH
     VAR_MESH(internal_state%owned_idx) = MESH_PTR(1:num_owned_nodes)          ! owned nodes
@@ -1378,9 +1377,9 @@ subroutine SetServices ( GC, RC )
     
     ! destroy fields and arrays so they can be reused
     deallocate(VAR_GRID)
-    call ESMF_FieldDestroy(srcField,rc=STATUS);  VERIFY_(STATUS)
-    call ESMF_FieldDestroy(dstField,rc=STATUS);  VERIFY_(STATUS)
-    call ESMF_ArrayDestroy(meshArray,rc=STATUS); VERIFY_(STATUS)
+    call ESMF_FieldDestroy(srcField,_RC)
+    call ESMF_FieldDestroy(dstField,_RC)
+    call ESMF_ArrayDestroy(meshArray,_RC)
 
   end subroutine tile_to_mesh  
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -10,11 +10,11 @@ module GEOS_IssmGridCompMod
 !
 ! !DESCRIPTION:
 !
-!   {\tt GEOS\_ISSM} is a wrapper that calls ISSM (C++) IRF methods
-!   Imports: ICESMB (defined on landice tiles)  [private internal state]
+!   {\tt GEOS\_ISSM} runs ISSM (Ice-sheet and Sea-level System Model)
+!   Imports: ICESMB (defined on landice tiles)  [via private internal state]
 !   Exports: ICESURF, ICETHICK, ICESMB_ISSM, ICEVX, ICEVY (defined on mesh) [true export state]
-!   Exports: ICESURF, ICETHICK, ICEVEL (defined on landice tiles) [private internal state]
-!   Internals: ICESURF, ICETHICK, IMLS, OMLS (defined on mesh) [true internal state]
+!   Exports: ICESURF, ICETHICK, ICEVEL (defined on landice tiles) [via private internal state]
+!   Internals: ICESURF, ICETHICK, IMLS, OMLS, ISSM_NSTEPS (defined on mesh) [true internal state]
 ! *** NOTES: 
 !            (*) currently we run over all input files (*.bin) that are found in ISSM_EXPDIR (scratch directory)
 !                (e.g., Greenland + Antarctica + any other glaciers that have been configured)
@@ -22,7 +22,12 @@ module GEOS_IssmGridCompMod
 !                imports/exports that is the global combination of all ISSM meshes
 !            (*) we transform imports from landice tiles to attached grid, then regrid to the mesh 
 !            (*) ISSM outputs are saved with HISTORY via a 'mesh tile space' developed by Weiyuan Jiang (GMAO SI Team)  
-!
+!            (*) ISSM time step is generally larger than LANDICE timestep, or even a job duration. We persist ISSM 
+!                variables across job segments through internal state checkpoints (restarts). We make sure that INTERNAL 
+!                and EXPORT variables are 'filled in' by Initialize so that LANDICE and HISTORY have access to ISSM 
+!                variables before it runs.  
+!            (*) Related, we use a custom ISSM run alarm that is keyed to the last time ISSM ran, not the simulation 
+!                start time. The number of LANDICE time steps since ISSM last ran is tracked via the internal state.  
 
 ! !USES:
 use iso_fortran_env, only: dp=>real64
@@ -612,7 +617,6 @@ subroutine SetServices ( GC, RC )
 
     ! get timestep for landice 
     call MAPL_Get(MAPL, HEARTBEAT=LANDICE_DT,_RC)
-    !call MAPL_GetResource (MAPL, LANDICE_DT, Label="DT:", DEFAULT=LANDICE_DT, RC=STATUS)	
     
     ! get timestep for ISSM
     call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
@@ -660,7 +664,7 @@ subroutine SetServices ( GC, RC )
     ! else, ISSM will just use default initial values in ISSM*.bin input files
     if (associated(ICETHICK_IN)) then
        ! simple check for positive ice thickness (initialized to zero if restart not found)
-	   ! ISSM throws error for zero ice thickness
+	     ! ISSM throws error for zero ice thickness
         ISSM_RST_FOUND = minval(ICETHICK_IN) > epsilon(ICETHICK_IN)
     end if
     
@@ -1181,7 +1185,7 @@ subroutine SetServices ( GC, RC )
     
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)	       :: IAm
-    integer			                   :: STATUS
+    integer			                       :: STATUS
     character(len=ESMF_MAXSTR)         :: COMP_NAME
 
     ! variables for writing out timesteps since ISSM (via ISSM_NSTEPS.txt)
@@ -1200,7 +1204,7 @@ subroutine SetServices ( GC, RC )
     call MAPL_GetObjectFromGC(GC, MAPL, STATUS)
     _VERIFY(STATUS)
 
-	! save number of steps since last ISSM run as a little txt file
+	  ! save number of steps since last ISSM run via internal state checkpoints (restarts)
     call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, STATUS); _VERIFY(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -43,9 +43,9 @@ subroutine InitializeISSM(expdir, num_elements, num_nodes, comm) bind(c, name="I
   integer(c_int)                  :: comm
 end subroutine InitializeISSM
     
-subroutine RunISSM(dt, gcm_forcings, issm_outputs) bind(C,NAME="RunISSM")
+subroutine RunISSM(ISSM_DT, gcm_forcings, issm_outputs) bind(C,NAME="RunISSM")
    import :: c_ptr, c_double
-   real(c_double),   value        :: dt
+   real(c_double),   value        :: ISSM_DT
    type(c_ptr),      value        :: gcm_forcings
    type(c_ptr),      value        :: issm_outputs
 end subroutine RunISSM
@@ -90,8 +90,8 @@ type T_ISSM_TILE_STATE
     real, pointer :: ICESURF_TILE(:)
     real, pointer :: ICETHICK_TILE(:)
     real, pointer :: ICEVEL_TILE(:)
-    real, pointer :: ICESMB_TILE(:)
-    integer       :: NSTEPS_INIT
+    real, pointer :: ICESMB_ISSM(:)
+	integer       :: NSTEPS_ISSM
 end type T_ISSM_TILE_STATE
 
 type ISSM_TILE_WRAP
@@ -118,8 +118,10 @@ type ISSM_WRAP
   type (T_ISSM_STATE), pointer :: ptr
 end type ISSM_WRAP
 
-! number of output fields that ISSM sends to GEOS
-integer :: num_outputs = 6   
+
+integer :: num_outputs = 6          ! number of output fields that ISSM sends to GEOS
+logical :: ISSM_RAN = .false.       ! run flag for ISSM C++ solvers
+logical :: ISSM_RST_FOUND = .false. ! restart found flag
 
 contains
                                 
@@ -158,7 +160,7 @@ subroutine SetServices ( GC, RC )
 
     type (ESMF_Config)                 :: CF
 
-    real                               :: dt     ! time step [s] (ISSM_DT set in AGCM.rc)
+    real                               :: ISSM_DT     ! time step [s] (ISSM_DT set in AGCM.rc)
 
     ! Get my internal MAPL_Generic state
 
@@ -192,7 +194,7 @@ subroutine SetServices ( GC, RC )
     VERIFY_(STATUS)
 
     ! get timestep for ISSM
-    call ESMF_ConfigGetAttribute(CF, dt, Label=trim(COMP_NAME)//"_DT:", DEFAULT=302400.0, RC=STATUS)
+    call ESMF_ConfigGetAttribute(CF, ISSM_DT, Label=trim(COMP_NAME)//"_DT:", DEFAULT=302400.0, RC=STATUS)
     VERIFY_(STATUS)
 
 
@@ -254,7 +256,7 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'm',                         &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-		 RESTART    = MAPL_RestartOptional,        &    
+		 RESTART    = MAPL_RestartOptional,        &   
          RC=STATUS  )
     VERIFY_(STATUS)
 
@@ -287,6 +289,7 @@ subroutine SetServices ( GC, RC )
 		 RESTART    = MAPL_RestartOptional,        & 
          RC=STATUS  )
     VERIFY_(STATUS)
+
 
 ! Set the Profiling timers
 ! ------------------------
@@ -327,8 +330,7 @@ subroutine SetServices ( GC, RC )
     real                                   :: HEARTBEAT_DT            ! landice time step [s] (ISSM_DT set in AGCM.rc)
     integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
     integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
-    type(T_ISSM_TILE_STATE), pointer       :: issm_tile_state
-    type(ISSM_TILE_WRAP)                   :: issm_tile_wrap
+	integer                                :: ios, u                  ! for reading ISSM_NSTEPS.txt file
 
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)             :: IAm
@@ -394,7 +396,6 @@ subroutine SetServices ( GC, RC )
     integer                                :: n1,n2,n3
 
     ! restarts from internal state
-	  logical                                :: issm_rst_found          ! process issm_internal_rst if found
     real, pointer, dimension(:)            :: ICESURF_IN    => null() ! ice surface elevation restart
     real, pointer, dimension(:)            :: ICETHICK_IN   => null() ! ice thickness restart
     real, pointer, dimension(:)            :: IMLS_IN       => null() ! ice-mask levelset restart
@@ -588,19 +589,28 @@ subroutine SetServices ( GC, RC )
     call ESMF_GridCompSet(gc, grid=mesh_grid, _RC)
     call MAPL_Set(MAPL, locstream = mesh_locstream, _RC)
 
-    ! Create ISSM Run Alarm 
+    ! Generic initialize
     !-----------------------------------
-    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, STATUS); VERIFY_(STATUS)
-    issm_tile_state => issm_tile_wrap%ptr
+    call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
+    VERIFY_(STATUS)
 
-    NSTEPS_INIT = issm_tile_state%NSTEPS_INIT
+	! Create Custom ISSM Run Alarm 
+    !-----------------------------------
+
+	! get number of time steps since last ISSM run
+    NSTEPS_INIT = 0
+	open(newunit=u, file="ISSM_NSTEPS.txt", status="old", iostat=ios)
+	if (ios == 0) then
+	  read(u, *) NSTEPS_INIT
+	  close(u)
+	end if
 
     ! get timestep for landice (heartbeat)
-    call MAPL_Get(MAPL, HEARTBEAT = HEARTBEAT_DT, RC=STATUS)
+    call MAPL_Get(MAPL, HEARTBEAT=HEARTBEAT_DT,RC=STATUS)
     VERIFY_(STATUS)
 
     ! get timestep for ISSM
-    call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400, RC=STATUS)
+    call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
     VERIFY_(STATUS)
     
     ! total landice time steps between ISSM runs
@@ -616,21 +626,15 @@ subroutine SetServices ( GC, RC )
     call ESMF_TimeIntervalSet(ringInterval,s=nint(ISSM_DT),RC=STATUS)
     VERIFY_(STATUS)
 
-    ! create ISSM_ALARM
-    ISSM_ALARM = ESMF_AlarmCreate(CLOCK,ringTime=ringTime,ringInterval=ringInterval,sticky=.false.)   
+    ! create new ISSM_ALARM
+    ISSM_ALARM = ESMF_AlarmCreate(CLOCK,ringTime=ringTime,ringInterval=ringInterval,sticky=.false.,rc=STATUS)
+	VERIFY_(STATUS)
 
+	! set run alarm
     call MAPL_Set(MAPL, RUNALARM = ISSM_ALARM, _RC)
-
-    ! Generic initialize
-    !-----------------------------------
-    call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
-    VERIFY_(STATUS)
 
     ! Next, send GEOS restarts to ISSM
     !-----------------------------------
-    call MAPL_GetObjectFromGC(GC, MAPL, STATUS)
-    VERIFY_(STATUS)
-
     call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,RC=STATUS)
     VERIFY_(STATUS)
 
@@ -642,13 +646,12 @@ subroutine SetServices ( GC, RC )
 
     ! if restart has been read, apply halo operation and send pointers to ISSM
     ! else, ISSM will just use default initial values in ISSM*.bin input files
-	issm_rst_found = .false.
 	if (associated(ICETHICK_IN)) then
     ! check for positive ice thickness (initialized to zero if restart not found)
-	    issm_rst_found = minval(ICETHICK_IN) > epsilon(ICETHICK_IN)
+	    ISSM_RST_FOUND = minval(ICETHICK_IN) > epsilon(ICETHICK_IN)
 	end if
 	
-	if (issm_rst_found) then
+	if (ISSM_RST_FOUND) then
 
     ! variables for halo operations
     allocate(ICESURF_HALO(num_nodes))
@@ -892,7 +895,14 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
  
   ! physical parameters
   real(dp), parameter                  :: rho_ice   = 917.0     ! pure ice density [kg m-3]
-  real(dp)                             :: dt                    ! time step [s] (ISSM_DT set in AGCM.rc)
+  real(dp)                             :: ISSM_DT               ! time step [s] (ISSM_DT set in AGCM.rc)
+
+  ! testing
+  type(ESMF_Time)                      :: currTime
+  type(ESMF_Time)                      :: stopTime
+  type(ESMF_TimeInterval)              :: timeStep
+  logical                              :: NEED_RST
+  integer                              :: localPET
 
 ! Get the target components name, mesh and vm
 ! -----------------------------------------------------------
@@ -917,16 +927,29 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
   call MAPL_Get(MAPL, RUNALARM = ALARM, RC=STATUS )
   VERIFY_(STATUS)
 
-  ! run ISSM at specified time steps
-  if ( ESMF_AlarmIsRinging (ALARM, RC=STATUS) ) then
+  call ESMF_ClockGet(CLOCK,currTime=currTime,stopTime=stopTime,timeStep=timeStep,rc=STATUS); VERIFY_(STATUS)
+
+  ! if bootstrapping, and at final timestep, we will get restarts from run method
+  NEED_RST = (currTime==(stopTime-timeStep)) .and. ((.not. ISSM_RAN) .and. (.not. ISSM_RST_FOUND))
+
+  call ESMF_VMGet(vm,localPET=localPET,rc=STATUS); VERIFY_(STATUS)
+
+  ! run ISSM at specified time steps, 
+  ! if bootstrapping restart and issm has not by final time step, run anyways
+  ! with timestep of zero, which just gets restart values
+  if ( ESMF_AlarmIsRinging(ALARM, RC=STATUS) .or. NEED_RST ) then
 
     ! *************************************************************************** !
     ! BASIC SETUP
     ! *************************************************************************** !
 
     ! get timestep for ISSM
-    call MAPL_GetResource(MAPL, dt, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
+    call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
     VERIFY_(STATUS)
+
+    if (NEED_RST) then
+        ISSM_DT = 0.0_dp
+	end if 
 
     ! get number of mesh elements
     call ESMF_MeshGet(mesh,elementCount=num_elements,nodeCount=num_nodes,numOwnedNodes=num_owned_nodes)
@@ -995,7 +1018,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     end if
     
     ! copy import values into tile array 
-    ICESMB_TILE = issm_tile_state%ICESMB_TILE
+    ICESMB_TILE = issm_tile_state%ICESMB_ISSM
 
     ! *************************************************************************** !
     ! TRANSFORM ICESMB FROM TILES TO MESH 
@@ -1016,9 +1039,12 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
 
     ! call run method from ISSM library 
-    call RunISSM(dt, c_loc(ICESMB_MESH), c_loc(ISSM_OUTPUTS))
+    call RunISSM(ISSM_DT, c_loc(ICESMB_MESH), c_loc(ISSM_OUTPUTS))
 
     call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+
+    ! update ISSM run flag (for C++ library calls)
+	ISSM_RAN = .true.
 
     ! *************************************************************************** !
     ! UNPACK AND EXPORT ISSM OUTPUTS ON MESH TILES
@@ -1220,8 +1246,13 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)	       :: IAm
-    integer			                       :: STATUS
+    integer			                   :: STATUS
     character(len=ESMF_MAXSTR)         :: COMP_NAME
+
+    ! testing
+	integer :: u
+	type(T_ISSM_TILE_STATE), pointer     :: issm_tile_state
+    type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
 
     ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -1230,8 +1261,23 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     VERIFY_(STATUS)
     Iam = trim(comp_name) // Iam
 
+
+	! save number of steps since last issm run as a little txt file
+	call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
+    issm_tile_state => issm_tile_wrap%ptr
+	
+	open(newunit=u, file="ISSM_NSTEPS.txt", status="replace")
+	write(u, *) issm_tile_state%NSTEPS_ISSM
+	close(u)
+
     ! call ISSM finalize (saves binary output .outbin file)
-    call FinalizeISSM()
+	if (ISSM_RAN) then
+	! NOTE: only call if ISSM C++ solvers were called, because OutputResultsx
+	! in C++ source throws error if 'results' is empty... 
+	! not actually a problem, but this case won't call FemModel destructors,
+	! should really just remove OutputResultsx from FinalizeISSM()....
+        call FinalizeISSM()
+	end if 
 
 ! Generic Finalize
 ! ------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -324,7 +324,7 @@ subroutine SetServices ( GC, RC )
     integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
     integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
     integer                                :: ios, u                  ! for reading ISSM_NSTEPS.txt file
-	real, pointer, dimension(:)            :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
+	  real, pointer, dimension(:)            :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
 	
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)             :: IAm
@@ -600,9 +600,9 @@ subroutine SetServices ( GC, RC )
     !-----------------------------------
 
     ! get internal state
-	call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+	  call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
 
-	! get number of time steps since last ISSM run
+	  ! get number of time steps since last ISSM run
     call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',_RC)
     NSTEPS_INIT = nint(maxval(ISSM_NSTEPS))
 
@@ -663,6 +663,8 @@ subroutine SetServices ( GC, RC )
       ! apply halo operation to all restart variables
       call apply_halo(ICESURF_IN,ICESURF_HALO,_RC)
       call apply_halo(ICETHICK_IN,ICETHICK_HALO,_RC)
+      call apply_halo(ICEVX_IN,ICEVX_HALO,_RC)
+      call apply_halo(ICEVY_IN,ICEVY_HALO,_RC)
       call apply_halo(IMLS_IN,IMLS_HALO,_RC)
       call apply_halo(OMLS_IN,OMLS_HALO,_RC)
 
@@ -702,7 +704,7 @@ subroutine SetServices ( GC, RC )
       ! filter out halo points (keep the owned indices) for restarts
       if(associated(ICESURF_IN)) ICESURF_IN = ICESURF_HALO(owned_idx)
       if(associated(ICETHICK_IN)) ICETHICK_IN = ICETHICK_HALO(owned_idx)
-	  if(associated(ICEVX_IN)) ICEVX_IN = ICEVX_HALO(owned_idx)
+	    if(associated(ICEVX_IN)) ICEVX_IN = ICEVX_HALO(owned_idx)
       if(associated(ICEVY_IN)) ICEVY_IN = ICEVY_HALO(owned_idx)
       if(associated(OMLS_IN)) OMLS_IN = OMLS_HALO(owned_idx)
       if(associated(IMLS_IN)) IMLS_IN = IMLS_HALO(owned_idx)
@@ -790,12 +792,12 @@ subroutine SetServices ( GC, RC )
     contains
        subroutine apply_halo(VAR_IN,VAR_HALO,RC)
           ! apply halo operation to a restart variable
-		  ! arguments:
+		      ! arguments:
           real, pointer, dimension(:), intent(inout)     :: VAR_IN            ! var on owned_nodes
           real(dp), pointer, dimension(:), intent(inout) :: VAR_HALO          ! var on all nodes
-		  integer, optional, intent(out)                 :: RC
+		      integer, optional, intent(out)                 :: RC
 
-		  ! local variables:
+		      ! local variables:
           real(dp), pointer, dimension(:)                :: VAR_DP            ! double version of VAR_IN
           real(dp), pointer, dimension(:)                :: MESH_PTR          ! pointer for ESMF_FieldGet
           real(dp), pointer, dimension(:)                :: ARRAY_PTR         ! pointer for ESMF_FieldGet 
@@ -830,7 +832,7 @@ subroutine SetServices ( GC, RC )
           call ESMF_ArrayDestroy(meshArray,_RC)  
           deallocate(VAR_DP)
 
-		  _RETURN(_SUCCESS)
+		      _RETURN(_SUCCESS)
        end subroutine apply_halo
 
        function create_mesh_grid(rc) result(mesh_grid)
@@ -913,10 +915,10 @@ subroutine SetServices ( GC, RC )
     type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
 
     ! surface mass balance on mesh and landice tiles
-	! note: SMB has been time-averaged between ISSM runs
+	  ! note: SMB has been time-averaged between ISSM runs
     real(dp), pointer, dimension(:)      :: ICESMB_MESH   => null() ! surface mass balce on mesh elements
     real, pointer, dimension(:)          :: ICESMB_TILE   => null() ! surface mass balance on landice tiles
-	real, pointer, dimension(:)          :: ICESMB_EX     => null() ! pointer to export state (mesh tiles)
+	  real, pointer, dimension(:)          :: ICESMB_EX     => null() ! pointer to export state (mesh tiles)
 
     ! ISSM Outputs
     real(dp),    pointer, dimension(:)   :: ISSM_OUTPUTS  => null() ! pointer containing all outputs
@@ -1032,8 +1034,8 @@ subroutine SetServices ( GC, RC )
       ! *************************************************************************** !
       ! GET ICESMB IMPORT (surface mass balance)
       ! *************************************************************************** ! 
-	  ! NOTE: ICESMB (from landice) has been time-averaged between ISSM runs
-	  !       hence the name ICESMB_ISSM
+	    ! NOTE: ICESMB (from landice) has been time-averaged between ISSM runs
+	    !       hence the name ICESMB_ISSM
 	  
       ! allocate tiles for ICESMB 
       if(.not.associated(ICESMB_TILE)) then
@@ -1103,10 +1105,10 @@ subroutine SetServices ( GC, RC )
       call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', _RC)
       if(associated(ICETHICK_IN)) ICETHICK_IN = ICETHICK_MESH(internal_state%owned_idx)
 
-	  call MAPL_GetPointer(INTERNAL, ICEVX_IN, 'ICEVX', _RC)
+	    call MAPL_GetPointer(INTERNAL, ICEVX_IN, 'ICEVX', _RC)
       if(associated(ICEVX_IN)) ICEVX_IN = ICEVX_MESH(internal_state%owned_idx)
 
-	  call MAPL_GetPointer(INTERNAL, ICEVY_IN, 'ICEVY', _RC)
+	    call MAPL_GetPointer(INTERNAL, ICEVY_IN, 'ICEVY', _RC)
       if(associated(ICEVY_IN)) ICEVY_IN = ICEVY_MESH(internal_state%owned_idx)
 
       call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', _RC)
@@ -1174,7 +1176,7 @@ subroutine SetServices ( GC, RC )
     !EOP
     type(MAPL_MetaComp), pointer       :: MAPL 
 
-	type(ESMF_State)                   :: INTERNAL
+	  type(ESMF_State)                   :: INTERNAL
     
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)	       :: IAm
@@ -1185,7 +1187,7 @@ subroutine SetServices ( GC, RC )
     integer :: u
     type(T_ISSM_TILE_STATE), pointer   :: issm_tile_state
     type(ISSM_TILE_WRAP)               :: issm_tile_wrap
-	real, pointer, dimension(:)        :: ISSM_NSTEPS
+	  real, pointer, dimension(:)        :: ISSM_NSTEPS
 
     ! Get the target components name and set-up traceback handle.
     ! -----------------------------------------------------------
@@ -1202,7 +1204,7 @@ subroutine SetServices ( GC, RC )
     issm_tile_state => issm_tile_wrap%ptr
 
     ! get internal state
-	call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+	  call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
 
     ! get number of time steps since last ISSM run
     call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',_RC)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -89,7 +89,7 @@ type T_ISSM_TILE_STATE
     real, pointer :: ICETHICK_TILE(:)
     real, pointer :: ICEVEL_TILE(:)
     real, pointer :: ICESMB_ISSM(:)
-	  integer       :: ISSM_NSTEPS
+    integer       :: ISSM_NSTEPS
 end type T_ISSM_TILE_STATE
 
 type ISSM_TILE_WRAP
@@ -324,8 +324,7 @@ subroutine SetServices ( GC, RC )
     integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
     integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
     integer                                :: ios, u                  ! for reading ISSM_NSTEPS.txt file
-	  real, pointer, dimension(:)            :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
-    integer                                :: ATTR                    ! internal state attribute
+	real, pointer, dimension(:)            :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
 	
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)             :: IAm
@@ -601,22 +600,22 @@ subroutine SetServices ( GC, RC )
     !-----------------------------------
 
     ! get internal state
-	  call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+	call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
 
-	  ! get number of time steps since last ISSM run
+	! get number of time steps since last ISSM run
     call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',_RC)
     NSTEPS_INIT = nint(maxval(ISSM_NSTEPS))
 
     ! get timestep for landice 
     call MAPL_Get(MAPL, HEARTBEAT=LANDICE_DT,_RC)
-    call MAPL_GetResource (MAPL, LANDICE_DT, Label="DT:", DEFAULT=LANDICE_DT, RC=STATUS)	
+    !call MAPL_GetResource (MAPL, LANDICE_DT, Label="DT:", DEFAULT=LANDICE_DT, RC=STATUS)	
     
     ! get timestep for ISSM
     call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
     
     ! total landice time steps between ISSM runs
     NSTEPS_RING = nint(ISSM_DT/LANDICE_DT)
-    
+	
     ! calculate initial ring time from initial time and remaining timesteps
     call ESMF_ClockGet(CLOCK,currTime=startTime)
     sec_to_ring = (NSTEPS_RING-NSTEPS_INIT)*nint(LANDICE_DT)
@@ -1174,6 +1173,8 @@ subroutine SetServices ( GC, RC )
     
     !EOP
     type(MAPL_MetaComp), pointer       :: MAPL 
+
+	type(ESMF_State)                   :: INTERNAL
     
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)	       :: IAm
@@ -1184,21 +1185,28 @@ subroutine SetServices ( GC, RC )
     integer :: u
     type(T_ISSM_TILE_STATE), pointer   :: issm_tile_state
     type(ISSM_TILE_WRAP)               :: issm_tile_wrap
+	real, pointer, dimension(:)        :: ISSM_NSTEPS
 
     ! Get the target components name and set-up traceback handle.
     ! -----------------------------------------------------------
     Iam = "Finalize"
-    call ESMF_GridCompGet( gc, NAME=comp_name, _RC )
+    call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC )
     
     Iam = trim(comp_name) // Iam
+
+    call MAPL_GetObjectFromGC(GC, MAPL, STATUS)
+    _VERIFY(STATUS)
 
 	! save number of steps since last ISSM run as a little txt file
     call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, STATUS); _VERIFY(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
 
+    ! get internal state
+	call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+
     ! get number of time steps since last ISSM run
     call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',_RC)
-    ISSM_NSTEPS(:) = issm_tile_state%ISSM_NSTEPS
+    ISSM_NSTEPS(:) = real(issm_tile_state%ISSM_NSTEPS)
 
     ! call ISSM finalize (saves binary output .outbin file)
     if (ISSM_RAN) then

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -89,7 +89,7 @@ type T_ISSM_TILE_STATE
     real, pointer :: ICETHICK_TILE(:)
     real, pointer :: ICEVEL_TILE(:)
     real, pointer :: ICESMB_ISSM(:)
-	integer       :: ISSM_NSTEPS
+	  integer       :: ISSM_NSTEPS
 end type T_ISSM_TILE_STATE
 
 type ISSM_TILE_WRAP
@@ -278,17 +278,15 @@ subroutine SetServices ( GC, RC )
          VLOCATION  = MAPL_VLocationNone,          &
          RESTART    = MAPL_RestartOptional,        &
          _RC  )
-! ! want to track steps since last ISSM run via internal state checkpoints
-!    call MAPL_AddInternalSpec(GC,                  &
-!         SHORT_NAME = 'ISSM_NSTEPS',               &
-!         LONG_NAME  = 'steps_since_issm',          &
-!         UNITS      = 'none',                      &
-!         DIMS       = MAPL_DimsNone,               &
-!		 PRECISION  = ESMF_KIND_R8,                &
-!		 UNGRIDDED_DIMS = (/1/),                   &
-!         VLOCATION  = MAPL_VLocationNone,          &
-!		 RESTART    = MAPL_RestartSkipInitial,     &
-!         _RC  )
+    
+    call MAPL_AddInternalSpec(GC,                  &
+         SHORT_NAME = 'ISSM_NSTEPS',               &
+         LONG_NAME  = 'steps_since_last_issm',     &
+         UNITS      = 'none',                      &
+         DIMS       = MAPL_DimsTileOnly,           &
+         VLOCATION  = MAPL_VLocationNone,          &
+         RESTART    = MAPL_RestartOptional,        &
+         _RC  )
 
 ! Set the Profiling timers
 ! ------------------------
@@ -326,7 +324,7 @@ subroutine SetServices ( GC, RC )
     integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
     integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
     integer                                :: ios, u                  ! for reading ISSM_NSTEPS.txt file
-	real(dp), pointer, dimension(:)        :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
+	  real, pointer, dimension(:)            :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
     integer                                :: ATTR                    ! internal state attribute
 	
     ! ErrLog Variables
@@ -411,7 +409,6 @@ subroutine SetServices ( GC, RC )
     real(dp), pointer, dimension(:)        :: ICEVX_HALO    => null()
     real(dp), pointer, dimension(:)        :: ICEVY_HALO    => null()
     real(dp), pointer, dimension(:)        :: ICEVEL_HALO   => null()
-
 
     real(dp), pointer, dimension(:)        :: GEOS_RESTARTS => null() ! concatenate restart fields
     real(dp), pointer, dimension(:)        :: ZEROS         => null() ! zero input for bootstrapping
@@ -600,27 +597,15 @@ subroutine SetServices ( GC, RC )
 
     call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, _RC )
 
-	! ! Modify the internal state to only have MAPL_AttrTile attribute because 
-	! ! ISSM_NSTEPS has DIMS=MAPL_DimsNone, which adds a MAPL_AttrGrid attribute.... 
-	! ! NOTE: this hack works only for *writing* checkpoints; the code will still crash 
-	! !       if you try to read back in for the same reason     
-	! ! get internal state
-	! call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
-	! ! Following MAPL_StateCreateFromVarSpecNew:
-	! ATTR = 0
-	! ATTR = IOR(ATTR, MAPL_AttrTile)
-	! call ESMF_AttributeSet(INTERNAL, NAME = "MAPL_GridTypeBits", VALUE=ATTR, RC=status)   
-
 	  ! Create Custom ISSM Run Alarm 
     !-----------------------------------
 
-	! get number of time steps since last ISSM run
-    NSTEPS_INIT = 0
-    open(newunit=u, file="ISSM_NSTEPS.txt", status="old", iostat=ios)
-    if (ios == 0) then
-      read(u, *) NSTEPS_INIT
-      close(u)
-    end if
+    ! get internal state
+	  call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+
+	  ! get number of time steps since last ISSM run
+    call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',_RC)
+    NSTEPS_INIT = nint(maxval(ISSM_NSTEPS))
 
     ! get timestep for landice 
     call MAPL_Get(MAPL, HEARTBEAT=LANDICE_DT,_RC)
@@ -659,9 +644,6 @@ subroutine SetServices ( GC, RC )
     allocate(IMLS_HALO(num_nodes))
     allocate(OMLS_HALO(num_nodes))
     allocate(ZEROS(num_nodes))
-
-    ! get internal state
-	call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
     
     ! get pointers to restarts
     call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', _RC)
@@ -670,10 +652,6 @@ subroutine SetServices ( GC, RC )
     call MAPL_GetPointer(INTERNAL, ICEVY_IN, 'ICEVY',_RC)
     call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', _RC)
     call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS',_RC)
-    
-	! ! tracking NSTEPS via internal state not functional yet... 
-	! call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',alloc=.true.,_RC)
-	! ISSM_NSTEPS(:) = 19.0 ! test value
 
     ! if restart has been read, apply halo operation and send pointers to ISSM
     ! else, ISSM will just use default initial values in ISSM*.bin input files
@@ -749,7 +727,7 @@ subroutine SetServices ( GC, RC )
 
     ! Finally, set the tile export state so landice can access values before ISSM runs
     !-----------------------------------
-	call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
+	  call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
 	
     ! Regrid from mesh to tile
@@ -771,6 +749,8 @@ subroutine SetServices ( GC, RC )
 
     call mesh_to_tile(ICEVEL_HALO,ICEVEL_TILE,_RC)
     issm_tile_state%ICEVEL_TILE = ICEVEL_TILE
+
+    issm_tile_state%ISSM_NSTEPS = NSTEPS_INIT
 
     call ESMF_VMBarrier(vm, _RC)
 
@@ -1212,14 +1192,13 @@ subroutine SetServices ( GC, RC )
     
     Iam = trim(comp_name) // Iam
 
-
 	! save number of steps since last ISSM run as a little txt file
     call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, STATUS); _VERIFY(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
-	
-    open(newunit=u, file="ISSM_NSTEPS.txt", status="replace")
-    write(u, *) issm_tile_state%ISSM_NSTEPS
-    close(u)
+
+    ! get number of time steps since last ISSM run
+    call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',_RC)
+    ISSM_NSTEPS(:) = issm_tile_state%ISSM_NSTEPS
 
     ! call ISSM finalize (saves binary output .outbin file)
     if (ISSM_RAN) then

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -98,6 +98,7 @@ type T_ISSM_TILE_STATE
     real, pointer :: ICEVEL_TILE(:)
     real, pointer :: ICESMB_ISSM(:)
     integer       :: ISSM_NSTEPS
+	real          :: LANDICE_DT
 end type T_ISSM_TILE_STATE
 
 type ISSM_TILE_WRAP
@@ -333,7 +334,7 @@ subroutine SetServices ( GC, RC )
     integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
     integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
     integer                                :: ios, u                  ! for reading ISSM_NSTEPS.txt file
-	  real, pointer, dimension(:)            :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
+    real, pointer, dimension(:)            :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
 	
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)             :: IAm
@@ -605,18 +606,24 @@ subroutine SetServices ( GC, RC )
 
     call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, _RC )
 
-	  ! Create Custom ISSM Run Alarm 
+    ! Get private internal state for sending information to/from LANDICE
+	!-----------------------------------
+	
+    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
+    issm_tile_state => issm_tile_wrap%ptr
+
+	! Create Custom ISSM Run Alarm 
     !-----------------------------------
 
     ! get internal state
-	  call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+    call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
 
-	  ! get number of time steps since last ISSM run
+	! get number of time steps since last ISSM run
     call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',_RC)
     NSTEPS_INIT = nint(maxval(ISSM_NSTEPS))
 
     ! get timestep for landice 
-    call MAPL_Get(MAPL, HEARTBEAT=LANDICE_DT,_RC)
+    LANDICE_DT = issm_tile_state%LANDICE_DT
     
     ! get timestep for ISSM
     call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
@@ -734,8 +741,6 @@ subroutine SetServices ( GC, RC )
 
     ! Finally, set the tile export state so landice can access values before ISSM runs
     !-----------------------------------
-	  call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
-    issm_tile_state => issm_tile_wrap%ptr
 	
     ! Regrid from mesh to tile
     call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -698,7 +698,7 @@ subroutine SetServices ( GC, RC )
       ZEROS = 0.0_dp
 
       call ESMF_VMBarrier(vm, _RC)
-      call RunISSM(epsilon(ISSM_DT), c_loc(ZEROS), c_loc(GEOS_RESTARTS))
+      call RunISSM(0.0_dp, c_loc(ZEROS), c_loc(GEOS_RESTARTS))
       call ESMF_VMBarrier(vm, _RC)
 
       ! update ISSM run flag (for C++ library calls)
@@ -1285,6 +1285,7 @@ subroutine SetServices ( GC, RC )
     real(dp), pointer, dimension(:)                :: MESH_PTR           ! pointer for ESMF_FieldGet 
     type(ESMF_Field)                               :: srcField
     type(ESMF_Field)                               :: dstField
+    type(ESMF_Array)                               :: meshArray
     integer                                        :: num_owned_nodes
     integer                                        :: num_nodes
     integer                                        :: IM, JM, local_dims(3)   

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -323,8 +323,8 @@ subroutine SetServices ( GC, RC )
     type(ESMF_TimeInterval)                :: startInterval           ! time interval to first ring
     type(ESMF_Time)                        :: ringTime                ! time of first ring
     type(ESMF_TimeInterval)                :: ringInterval            ! ring time interval (ISSM_DT)
-    integer                                :: ISSM_DT                 ! ISSM time step [s] (ISSM_DT set in AGCM.rc)
-    integer                                :: HEARTBEAT_DT            ! landice time step [s] (ISSM_DT set in AGCM.rc)
+    real                                   :: ISSM_DT                 ! ISSM time step [s] (ISSM_DT set in AGCM.rc)
+    real                                   :: HEARTBEAT_DT            ! landice time step [s] (ISSM_DT set in AGCM.rc)
     integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
     integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
     type(T_ISSM_TILE_STATE), pointer       :: issm_tile_state
@@ -590,7 +590,7 @@ subroutine SetServices ( GC, RC )
 
     ! Create ISSM Run Alarm 
     !-----------------------------------
-    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
+    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, STATUS); VERIFY_(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
 
     NSTEPS_INIT = issm_tile_state%NSTEPS_INIT
@@ -607,13 +607,14 @@ subroutine SetServices ( GC, RC )
     NSTEPS_RING = nint(ISSM_DT/HEARTBEAT_DT)
     
     ! calculate initial ring time from initial time and remaining timesteps
-    startTime = ESMF_ClockGet(clock,currTime=startTime)
-    sec_to_ring = (NSTEPS_RING-NSTEPS_INIT)*HEARTBEAT_DT
+    call ESMF_ClockGet(CLOCK,currTime=startTime)
+    sec_to_ring = (NSTEPS_RING-NSTEPS_INIT)*nint(HEARTBEAT_DT)
     call ESMF_TimeIntervalSet(startInterval,s = sec_to_ring )
     ringTime = startTime + startInterval
 
     ! set ring interval to ISSM time step
-    call ESMF_TimeIntervalSet(ringInterval,s=ISSM_DT,_RC)
+    call ESMF_TimeIntervalSet(ringInterval,s=nint(ISSM_DT),RC=STATUS)
+    VERIFY_(STATUS)
 
     ! create ISSM_ALARM
     ISSM_ALARM = ESMF_AlarmCreate(CLOCK,ringTime=ringTime,ringInterval=ringInterval,sticky=.false.)   

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -91,6 +91,7 @@ type T_ISSM_TILE_STATE
     real, pointer :: ICETHICK_TILE(:)
     real, pointer :: ICEVEL_TILE(:)
     real, pointer :: ICESMB_TILE(:)
+    integer       :: NSTEPS_INIT
 end type T_ISSM_TILE_STATE
 
 type ISSM_TILE_WRAP
@@ -287,7 +288,6 @@ subroutine SetServices ( GC, RC )
          RC=STATUS  )
     VERIFY_(STATUS)
 
-
 ! Set the Profiling timers
 ! ------------------------
 
@@ -314,8 +314,21 @@ subroutine SetServices ( GC, RC )
     integer, optional,       intent(OUT)   :: RC                      ! Error code
     
     type(MAPL_MetaComp), pointer           :: MAPL   
-    type(ESMF_State)                       :: INTERNAL                !internal state
+    type(ESMF_State)                       :: INTERNAL                ! internal state
 
+    ! ISSM alarm variables
+    type(ESMF_Alarm)                       :: ISSM_ALARM              ! custom ISSM RUNALARM
+    integer                                :: sec_to_ring             ! seconds remaining until first ISSM run
+    type(ESMF_Time)                        :: startTime               ! initial time
+    type(ESMF_TimeInterval)                :: startInterval           ! time interval to first ring
+    type(ESMF_Time)                        :: ringTime                ! time of first ring
+    type(ESMF_TimeInterval)                :: ringInterval            ! ring time interval (ISSM_DT)
+    integer                                :: ISSM_DT                 ! ISSM time step [s] (ISSM_DT set in AGCM.rc)
+    integer                                :: HEARTBEAT_DT            ! landice time step [s] (ISSM_DT set in AGCM.rc)
+    integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
+    integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
+    type(T_ISSM_TILE_STATE), pointer       :: issm_tile_state
+    type(ISSM_TILE_WRAP)                   :: issm_tile_wrap
 
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)             :: IAm
@@ -381,7 +394,7 @@ subroutine SetServices ( GC, RC )
     integer                                :: n1,n2,n3
 
     ! restarts from internal state
-	logical                                :: issm_rst_found          ! process issm_internal_rst if found
+	  logical                                :: issm_rst_found          ! process issm_internal_rst if found
     real, pointer, dimension(:)            :: ICESURF_IN    => null() ! ice surface elevation restart
     real, pointer, dimension(:)            :: ICETHICK_IN   => null() ! ice thickness restart
     real, pointer, dimension(:)            :: IMLS_IN       => null() ! ice-mask levelset restart
@@ -573,13 +586,47 @@ subroutine SetServices ( GC, RC )
               tilelons=ownedNodeLons, tilelats=ownedNodeLats,  _RC)
     call MAPL%grid%set(mesh_grid, _RC)
     call ESMF_GridCompSet(gc, grid=mesh_grid, _RC)
-    call MAPL_set(MAPL, locstream = mesh_locstream, _RC)
+    call MAPL_Set(MAPL, locstream = mesh_locstream, _RC)
 
-    ! generic initialize 
+    ! Create ISSM Run Alarm 
+    !-----------------------------------
+    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
+    issm_tile_state => issm_tile_wrap%ptr
+
+    NSTEPS_INIT = issm_tile_state%NSTEPS_INIT
+
+    ! get timestep for landice (heartbeat)
+    call MAPL_Get(MAPL, HEARTBEAT = HEARTBEAT_DT, RC=STATUS)
+    VERIFY_(STATUS)
+
+    ! get timestep for ISSM
+    call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400, RC=STATUS)
+    VERIFY_(STATUS)
+    
+    ! total landice time steps between ISSM runs
+    NSTEPS_RING = nint(ISSM_DT/HEARTBEAT_DT)
+    
+    ! calculate initial ring time from initial time and remaining timesteps
+    startTime = ESMF_ClockGet(clock,currTime=startTime)
+    sec_to_ring = (NSTEPS_RING-NSTEPS_INIT)*HEARTBEAT_DT
+    call ESMF_TimeIntervalSet(startInterval,s = sec_to_ring )
+    ringTime = startTime + startInterval
+
+    ! set ring interval to ISSM time step
+    call ESMF_TimeIntervalSet(ringInterval,s=ISSM_DT,_RC)
+
+    ! create ISSM_ALARM
+    ISSM_ALARM = ESMF_AlarmCreate(CLOCK,ringTime=ringTime,ringInterval=ringInterval,sticky=.false.)   
+
+    call MAPL_Set(MAPL, RUNALARM = ISSM_ALARM, _RC)
+
+    ! Generic initialize
+    !-----------------------------------
     call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
     VERIFY_(STATUS)
 
     ! Next, send GEOS restarts to ISSM
+    !-----------------------------------
     call MAPL_GetObjectFromGC(GC, MAPL, STATUS)
     VERIFY_(STATUS)
 
@@ -753,7 +800,10 @@ subroutine SetServices ( GC, RC )
 
 
 subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
-! ! Run ISSM ice-sheet model 
+! ! ****** Run ISSM ice-sheet model ******
+! !  the core C++ solvers and associated pre/post-processing of imports/exports
+! !  are only performed at ISSM_DT intervals. However, the Run method is engaged
+! !  at every landice timestep to ensure that ISSM restarts persist  
 ! !ARGUMENTS:
   type(ESMF_GridComp), intent(inout)   :: GC                      ! Gridded component 
   type(ESMF_State),    intent(inout)   :: IMPORT                  ! Import state
@@ -874,7 +924,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     ! *************************************************************************** !
 
     ! get timestep for ISSM
-    call MAPL_GetResource (MAPL, dt, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
+    call MAPL_GetResource(MAPL, dt, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
     VERIFY_(STATUS)
 
     ! get number of mesh elements

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -70,6 +70,9 @@ subroutine GetElementsISSM(elementIds, elementConn, elementCoords, glacIds) bind
 end subroutine GetElementsISSM
 
 subroutine FinalizeISSM() bind(C,NAME="FinalizeISSM")
+! produces binary output files from ISSM
+! not currently used because we use GEOS restarts, and this
+! will throw an error if ISSM has not run during a job segment.
 end subroutine FinalizeISSM
 
 end interface
@@ -118,7 +121,6 @@ type ISSM_WRAP
 end type ISSM_WRAP
 
 integer                      :: num_outputs = 6          ! number of output fields that ISSM sends to GEOS
-logical                      :: ISSM_RAN = .false.       ! run flag for ISSM C++ solvers
 logical                      :: ISSM_RST_FOUND = .false. ! restart found flag
 type(T_ISSM_STATE), pointer  :: internal_state=>null()   ! internal state for regridding and halo operations
 
@@ -292,6 +294,8 @@ subroutine SetServices ( GC, RC )
 ! ------------------------
 
     call MAPL_TimerAdd(GC,    name="RUN"   ,_RC)
+    call MAPL_TimerAdd(GC,    name="ISSMCore"   ,_RC)
+	
        
 ! ----------------------------------
     call MAPL_GenericSetServices    ( GC, _RC)
@@ -655,7 +659,8 @@ subroutine SetServices ( GC, RC )
     ! if restart has been read, apply halo operation and send pointers to ISSM
     ! else, ISSM will just use default initial values in ISSM*.bin input files
     if (associated(ICETHICK_IN)) then
-      ! check for positive ice thickness (initialized to zero if restart not found)
+       ! simple check for positive ice thickness (initialized to zero if restart not found)
+	   ! ISSM throws error for zero ice thickness
         ISSM_RST_FOUND = minval(ICETHICK_IN) > epsilon(ICETHICK_IN)
     end if
     
@@ -684,14 +689,11 @@ subroutine SetServices ( GC, RC )
 
     else
       ! bootstrap restart values from ISSM input files (ISSM*.bin)
-      ! by running with near-zero time step and zero forcing
+      ! by running with 'fake' time step with zero forcing
 
       call ESMF_VMBarrier(vm, _RC)
-      call RunISSM(1.0_dp, c_loc(ZEROS), c_loc(GEOS_RESTARTS))
+      call RunISSM(real(ISSM_DT,kind=dp), c_loc(ZEROS), c_loc(GEOS_RESTARTS))
       call ESMF_VMBarrier(vm, _RC)
-
-      ! update ISSM run flag (for C++ library calls)
-      ISSM_RAN = .true.
 
       ! Unpack restart array 
       ICESURF_HALO(:)  = GEOS_RESTARTS(1:num_nodes) 
@@ -704,7 +706,7 @@ subroutine SetServices ( GC, RC )
       ! filter out halo points (keep the owned indices) for restarts
       if(associated(ICESURF_IN)) ICESURF_IN = ICESURF_HALO(owned_idx)
       if(associated(ICETHICK_IN)) ICETHICK_IN = ICETHICK_HALO(owned_idx)
-	    if(associated(ICEVX_IN)) ICEVX_IN = ICEVX_HALO(owned_idx)
+      if(associated(ICEVX_IN)) ICEVX_IN = ICEVX_HALO(owned_idx)
       if(associated(ICEVY_IN)) ICEVY_IN = ICEVY_HALO(owned_idx)
       if(associated(OMLS_IN)) OMLS_IN = OMLS_HALO(owned_idx)
       if(associated(IMLS_IN)) IMLS_IN = IMLS_HALO(owned_idx)
@@ -1062,14 +1064,13 @@ subroutine SetServices ( GC, RC )
       ICESMB_MESH = ICESMB_MESH/rho_ice
 
       call ESMF_VMBarrier(vm, _RC)
+	  call MAPL_TimerOn(MAPL,"ISSMCore" )
 
       ! call run method from ISSM library 
       call RunISSM(ISSM_DT, c_loc(ICESMB_MESH), c_loc(ISSM_OUTPUTS))
 
       call ESMF_VMBarrier(vm, _RC)
-
-      ! update ISSM run flag (for C++ library calls)
-      ISSM_RAN = .true.
+	  call MAPL_TimerOff(MAPL,"ISSMCore" )
 
       ! *************************************************************************** !
       ! UNPACK AND EXPORT ISSM OUTPUTS ON MESH TILES
@@ -1204,26 +1205,16 @@ subroutine SetServices ( GC, RC )
     issm_tile_state => issm_tile_wrap%ptr
 
     ! get internal state
-	  call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
+    call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
 
     ! get number of time steps since last ISSM run
     call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',_RC)
     ISSM_NSTEPS(:) = real(issm_tile_state%ISSM_NSTEPS)
 
-    ! call ISSM finalize (saves binary output .outbin file)
-    if (ISSM_RAN) then
-	  ! NOTE: only call if ISSM C++ solvers were called, because OutputResultsx
-	  ! in C++ source throws error if 'results' is empty... 
-	  ! not actually a problem, but this case won't call FemModel destructors,
-	  ! should probably just remove OutputResultsx from FinalizeISSM()....
-       call FinalizeISSM()
-    end if 
-
     ! Generic Finalize
     ! ------------------
     call MAPL_GenericFinalize( GC, IMPORT, EXPORT, CLOCK, _RC )
     
-
     ! All Done
     ! ------------------
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -119,7 +119,6 @@ type ISSM_WRAP
   type (T_ISSM_STATE), pointer :: ptr
 end type ISSM_WRAP
 
-
 integer                      :: num_outputs = 6          ! number of output fields that ISSM sends to GEOS
 logical                      :: ISSM_RAN = .false.       ! run flag for ISSM C++ solvers
 logical                      :: ISSM_RST_FOUND = .false. ! restart found flag
@@ -159,9 +158,7 @@ subroutine SetServices ( GC, RC )
 !=============================================================================
 
     type(MAPL_MetaComp), pointer       :: MAPL
-
     type (ESMF_Config)                 :: CF
-
     real                               :: ISSM_DT     ! time step [s] (ISSM_DT set in AGCM.rc)
 
     ! Get my internal MAPL_Generic state
@@ -172,18 +169,15 @@ subroutine SetServices ( GC, RC )
 ! ---------------------------------------
 
     call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC )
-    
     Iam = trim(COMP_NAME) // 'SetServices'
 
 ! Set the Initialize, Run, and Finalize entry points
 !-----------------------------------
 
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE,   Initialize, _RC)
-    
 
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,          Run,        _RC)
     
-
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_FINALIZE,     Finalize,   _RC)
     
 
@@ -191,16 +185,12 @@ subroutine SetServices ( GC, RC )
 
     call MAPL_GetObjectFromGC (GC, MAPL, _RC)
     
-
     call ESMF_GridCompGet(GC, CONFIG = CF, _RC)
-    
 
     ! get timestep for ISSM
     call ESMF_ConfigGetAttribute(CF, ISSM_DT, Label=trim(COMP_NAME)//"_DT:", DEFAULT=302400.0, _RC)
     
-
-
-    ! Set the state variable specs.
+! Set the state variable specs.
 !-----------------------------------
 
 !   Import states: ICESMB is imported via the ISSM_TILE private internal state
@@ -214,7 +204,6 @@ subroutine SetServices ( GC, RC )
          VLOCATION  = MAPL_VLocationNone,          &
          _RC  )
     
-
     call MAPL_AddExportSpec(GC,                    &
          SHORT_NAME = 'ICEVX',                     &
          LONG_NAME  = 'ice_velocity_x_direction',  &
@@ -223,7 +212,6 @@ subroutine SetServices ( GC, RC )
          VLOCATION  = MAPL_VLocationNone,          &
          _RC  )
     
-
     call MAPL_AddExportSpec(GC,                    &
         SHORT_NAME = 'ICEVY',                      &
         LONG_NAME  = 'ice_velocity_y_direction',   &
@@ -232,7 +220,6 @@ subroutine SetServices ( GC, RC )
         VLOCATION  = MAPL_VLocationNone,           &
         _RC  )
     
-
     call MAPL_AddExportSpec(GC,                    &
          SHORT_NAME = 'ICETHICK',                  &
          LONG_NAME  = 'ice_thickness',             &
@@ -241,7 +228,6 @@ subroutine SetServices ( GC, RC )
          VLOCATION  = MAPL_VLocationNone,          &
          _RC  )
     
-
     call MAPL_AddExportSpec(GC,                    &
          SHORT_NAME = 'ICESMB',                    &
          LONG_NAME  = 'ice_surface_mass_balance',  &
@@ -250,7 +236,6 @@ subroutine SetServices ( GC, RC )
          VLOCATION  = MAPL_VLocationNone,          &
          _RC  )
     
-
     !   Internal states:
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICESURF',                   &
@@ -261,7 +246,6 @@ subroutine SetServices ( GC, RC )
 		     RESTART    = MAPL_RestartOptional,        &   
          _RC  )
     
-
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICETHICK',                  &
          LONG_NAME  = 'ice_sheet_thickness',       &
@@ -270,7 +254,6 @@ subroutine SetServices ( GC, RC )
          VLOCATION  = MAPL_VLocationNone,          &
 		     RESTART    = MAPL_RestartOptional,        & 
          _RC  )
-    
     
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'IMLS',                      &
@@ -281,7 +264,6 @@ subroutine SetServices ( GC, RC )
 		     RESTART    = MAPL_RestartOptional,        & 
          _RC  )
     
-
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'OMLS',                      &
          LONG_NAME  = 'ocean_mask_levelset',       &
@@ -291,7 +273,6 @@ subroutine SetServices ( GC, RC )
 		     RESTART    = MAPL_RestartOptional,        & 
          _RC  )
     
-
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICEVX',                     &
          LONG_NAME  = 'ice_velocity_x_direction',  &
@@ -301,7 +282,6 @@ subroutine SetServices ( GC, RC )
          RESTART    = MAPL_RestartOptional,        &
          _RC  )
     
-
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICEVY',                     &
          LONG_NAME  = 'ice_velocity_y_direction',  &
@@ -317,15 +297,11 @@ subroutine SetServices ( GC, RC )
 ! ------------------------
 
     call MAPL_TimerAdd(GC,    name="RUN"   ,_RC)
-    
-
-   
+       
 ! ----------------------------------
     call MAPL_GenericSetServices    ( GC, _RC)
     
-
-
-    RETURN_(ESMF_SUCCESS)
+    _RETURN(_SUCCESS)
   
   end subroutine SetServices
 
@@ -378,7 +354,7 @@ subroutine SetServices ( GC, RC )
     integer, pointer, dimension(:)         :: nodeOwners    => null() ! Specify which PET owns each node
     integer, pointer, dimension(:)         :: glacIds       => null() ! glacier ID for each element
     
-    ! regridding 
+    ! regridding varibales
     type(ESMF_Grid)                        :: grid                    ! atmospheric grid
     type(ESMF_RouteHandle)                 :: routehandle_m2g         ! routehandle for regridding mesh to grid
     type(ESMF_RouteHandle)                 :: routehandle_g2m         ! routehandle for regridding grid to mesh
@@ -391,8 +367,7 @@ subroutine SetServices ( GC, RC )
     type(T_ISSM_TILE_STATE), pointer       :: issm_tile_state
     type(ISSM_TILE_WRAP)                   :: issm_tile_wrap
 
-
-    ! field halo
+    ! field halo variables
     integer                                :: num_halo_nodes          ! num_nodes minus num_owned_nodes
     type(ESMF_RouteHandle)                 :: halohandle              ! routehandle for field halos
     integer, pointer, dimension(:)         :: halolist      => null() ! list of halo nodeIds
@@ -468,21 +443,17 @@ subroutine SetServices ( GC, RC )
     !-----------------------------------
 
     call MAPL_GetObjectFromGC ( GC, MAPL, _RC)
-    
 
     call ESMF_VMGetCurrent(vm, _RC)
     
-
     call ESMF_VMGet(vm,mpiCommunicator=comm,localPet=localPET,_RC)
     
-
     ! ****************************************************
     ! call ISSM initialize C++ code so we can set up mesh
 
     ! get directory with ISSM binary input files (can modify if needed)
     call GET_ENVIRONMENT_VARIABLE("SCRDIR",ISSM_EXPDIR,STATUS=STATUS); _VERIFY(STATUS)
     
-
     EXPDIR = trim(ISSM_EXPDIR)//"/"//c_null_char ! create string for C++
     
     ! Call the C++ function for initializing ISSM
@@ -540,7 +511,6 @@ subroutine SetServices ( GC, RC )
     ! associate ESMF_Mesh representation of ISSM mesh with GC for regridding imports/exports in Run method       
     call ESMF_GridCompSet(GC,mesh=mesh,_RC)
     
-
     ! set up field halos
     !-----------------------------------
     call ESMF_MeshGet(mesh=mesh,nodeOwners=nodeOwners,numOwnedNodes=num_owned_nodes,nodalDistgrid=nodalDistgrid)
@@ -572,15 +542,12 @@ subroutine SetServices ( GC, RC )
     ! create array with halo information
     meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,_RC)
     
-
     ! create field on ISSM mesh 
     meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, _RC)
     
-
     ! store the halo operation in a routehandle
     call ESMF_FieldHaloStore(meshField, routehandle=halohandle, _RC)
     
-
     ! Set up regridding next
     !-----------------------------------
     ! get atmospheric (attached) grid 
@@ -594,11 +561,9 @@ subroutine SetServices ( GC, RC )
     unmappedaction=ESMF_UNMAPPEDACTION_IGNORE,extrapmethod=ESMF_EXTRAPMETHOD_CREEP,&
     extrapNumLevels=1,_RC)
     
-
     ! create routehandle for grid-to-mesh regridding (set dstMaskValues to 1 if needed... )
     call ESMF_FieldRegridStore(srcField=gridField, dstField=meshField,routehandle=routehandle_g2m,& 
     unmappedaction=ESMF_UNMAPPEDACTION_IGNORE,extrapmethod=ESMF_EXTRAPMETHOD_NEAREST_D,_RC)
-    
     
     ! create component's private internal state
     ! stores everything needed for regrid and halo operations during run method
@@ -622,7 +587,6 @@ subroutine SetServices ( GC, RC )
     wrap%ptr => internal_state
     call ESMF_UserCompSetInternalState ( GC, 'ISSM_WRAP', wrap, STATUS ); _VERIFY(STATUS)
     
-
     ! Create losctream that match mesh element id, then set it to this GC and MAPL
     ! note: original attached/atmospheric grid and landice tile locstream have
     ! been stored in the internal state
@@ -642,7 +606,6 @@ subroutine SetServices ( GC, RC )
     !-----------------------------------
     call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, _RC )
     
-
 	  ! Create Custom ISSM Run Alarm 
     !-----------------------------------
 
@@ -657,10 +620,8 @@ subroutine SetServices ( GC, RC )
     ! get timestep for landice (heartbeat)
     call MAPL_Get(MAPL, HEARTBEAT=HEARTBEAT_DT,_RC)
     
-
     ! get timestep for ISSM
     call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
-    
     
     ! total landice time steps between ISSM runs
     NSTEPS_RING = nint(ISSM_DT/HEARTBEAT_DT)
@@ -674,17 +635,14 @@ subroutine SetServices ( GC, RC )
     ! set ring interval to ISSM time step
     call ESMF_TimeIntervalSet(ringInterval,s=nint(ISSM_DT),_RC)
     
-
     ! create new ISSM_ALARM
     ISSM_ALARM = ESMF_AlarmCreate(CLOCK,ringTime=ringTime,ringInterval=ringInterval,sticky=.false.,_RC)
 	  
-
 	! set run alarm
     call MAPL_Set(MAPL, RUNALARM = ISSM_ALARM, _RC)
 
     ! Next, send GEOS restarts to ISSM
     !-----------------------------------
-
     ! array holding all restarts to send to/from ISSM
     allocate(GEOS_RESTARTS(num_outputs*num_nodes))
     allocate(ICESURF_HALO(num_nodes))
@@ -698,7 +656,6 @@ subroutine SetServices ( GC, RC )
 
     call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC)
     
-
     ! get pointers to restarts
     call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', _RC)
     call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', _RC)
@@ -839,7 +796,7 @@ subroutine SetServices ( GC, RC )
     call ESMF_FieldDestroy(meshField, _RC)
     call ESMF_ArrayDestroy(meshArray, _RC)
     
-    RETURN_(ESMF_SUCCESS)
+    _RETURN(_SUCCESS)
 
     contains
        subroutine apply_halo(VAR_IN,VAR_HALO)
@@ -1032,7 +989,7 @@ subroutine SetServices ( GC, RC )
     ! run ISSM at specified time steps, 
     ! if bootstrapping restart and issm has run not by final time step, run anyways
     ! with timestep of zero, which just gets restart values
-    if (ESMF_AlarmIsRinging(ALARM, _RC)) then
+    if (ESMF_AlarmIsRinging (ALARM, RC=STATUS)) then
 
       ! *************************************************************************** !
       ! BASIC SETUP
@@ -1192,7 +1149,7 @@ subroutine SetServices ( GC, RC )
     call MAPL_TimerOff(MAPL,"RUN"  )
     call MAPL_TimerOff(MAPL,"TOTAL")
   
-    RETURN_(ESMF_SUCCESS)
+    _RETURN(_SUCCESS)
 
   end subroutine RUN
 
@@ -1258,7 +1215,7 @@ subroutine SetServices ( GC, RC )
     ! All Done
     ! ------------------
 
-    RETURN_(ESMF_SUCCESS)
+    _RETURN(_SUCCESS)
   end subroutine Finalize
 
 
@@ -1313,6 +1270,8 @@ subroutine SetServices ( GC, RC )
     ! destroy regridding fields so they can be reused
     call ESMF_FieldDestroy(srcField,_RC)
     call ESMF_FieldDestroy(dstField,_RC)
+
+    _RETURN(_SUCCESS)
 
   end subroutine mesh_to_tile
 
@@ -1380,6 +1339,8 @@ subroutine SetServices ( GC, RC )
     call ESMF_FieldDestroy(srcField,_RC)
     call ESMF_FieldDestroy(dstField,_RC)
     call ESMF_ArrayDestroy(meshArray,_RC)
+
+    _RETURN(_SUCCESS)
 
   end subroutine tile_to_mesh  
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -109,6 +109,7 @@ type T_ISSM_STATE
   integer, pointer,dimension(:) :: halolist        ! list of halo nodeIds
   type(ESMF_DistGrid)           :: nodalDistgrid   ! distgrid (owned nodes)
   type(ESMF_GRID)               :: grid            ! original grid (atmosphere)
+  type(ESMF_MESH)               :: mesh            ! ISSM mesh
   type(MAPL_LocStream)          :: locstream       ! original locstream (landice tiles)
 end type T_ISSM_STATE
 
@@ -119,9 +120,10 @@ type ISSM_WRAP
 end type ISSM_WRAP
 
 
-integer :: num_outputs = 6          ! number of output fields that ISSM sends to GEOS
-logical :: ISSM_RAN = .false.       ! run flag for ISSM C++ solvers
-logical :: ISSM_RST_FOUND = .false. ! restart found flag
+integer                      :: num_outputs = 6          ! number of output fields that ISSM sends to GEOS
+logical                      :: ISSM_RAN = .false.       ! run flag for ISSM C++ solvers
+logical                      :: ISSM_RST_FOUND = .false. ! restart found flag
+type(T_ISSM_STATE), pointer  :: internal_state=>null()   ! internal state for regridding and halo operations
 
 contains
                                 
@@ -256,7 +258,7 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'm',                         &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-		 RESTART    = MAPL_RestartOptional,        &   
+		     RESTART    = MAPL_RestartOptional,        &   
          RC=STATUS  )
     VERIFY_(STATUS)
 
@@ -266,7 +268,7 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'm',                         &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-		 RESTART    = MAPL_RestartOptional,        & 
+		     RESTART    = MAPL_RestartOptional,        & 
          RC=STATUS  )
     VERIFY_(STATUS)
     
@@ -276,7 +278,7 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'none',                      &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-		 RESTART    = MAPL_RestartOptional,        & 
+		     RESTART    = MAPL_RestartOptional,        & 
          RC=STATUS  )
     VERIFY_(STATUS)
 
@@ -286,7 +288,27 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'none',                      &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-		 RESTART    = MAPL_RestartOptional,        & 
+		     RESTART    = MAPL_RestartOptional,        & 
+         RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddInternalSpec(GC,                  &
+         SHORT_NAME = 'ICEVX',                     &
+         LONG_NAME  = 'ice_velocity_x_direction',  &
+         UNITS      = 'm s-1',                     &
+         DIMS       = MAPL_DimsTileOnly,           &
+         VLOCATION  = MAPL_VLocationNone,          &
+         RESTART    = MAPL_RestartOptional,        &
+         RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddInternalSpec(GC,                  &
+         SHORT_NAME = 'ICEVY',                     &
+         LONG_NAME  = 'ice_velocity_y_direction',  &
+         UNITS      = 'm s-1',                     &
+         DIMS       = MAPL_DimsTileOnly,           &
+         VLOCATION  = MAPL_VLocationNone,          &
+         RESTART    = MAPL_RestartOptional,        &
          RC=STATUS  )
     VERIFY_(STATUS)
 
@@ -330,7 +352,7 @@ subroutine SetServices ( GC, RC )
     real                                   :: HEARTBEAT_DT            ! landice time step [s] (ISSM_DT set in AGCM.rc)
     integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
     integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
-	integer                                :: ios, u                  ! for reading ISSM_NSTEPS.txt file
+	  integer                                :: ios, u                  ! for reading ISSM_NSTEPS.txt file
 
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)             :: IAm
@@ -362,8 +384,8 @@ subroutine SetServices ( GC, RC )
     type(ESMF_RouteHandle)                 :: routehandle_g2m         ! routehandle for regridding grid to mesh
     type(ESMF_Field)                       :: meshField               ! field on mesh
     type(ESMF_Field)                       :: gridField               ! field on grid
-    type(T_ISSM_STATE), pointer            :: internal_state          ! store the routehandles for access during run
-    type(ISSM_WRAP)                        :: wrap                    ! wrapper for routehandle container
+    type(ISSM_WRAP)                        :: wrap                    ! wrapper for internal state
+    integer                                :: NT                      ! local number of landice tiles
 
     ! field halo
     integer                                :: num_halo_nodes          ! num_nodes minus num_owned_nodes
@@ -395,18 +417,39 @@ subroutine SetServices ( GC, RC )
     integer, pointer, dimension(:)         :: nodeMask => null()
     integer                                :: n1,n2,n3
 
-    ! restarts from internal state
+    ! pointers to internal state for restart
     real, pointer, dimension(:)            :: ICESURF_IN    => null() ! ice surface elevation restart
     real, pointer, dimension(:)            :: ICETHICK_IN   => null() ! ice thickness restart
+    real, pointer, dimension(:)            :: ICEVX_IN      => null() ! ice velocity (x direction) restart
+    real, pointer, dimension(:)            :: ICEVY_IN      => null() ! ice velocity (y direction) restart
     real, pointer, dimension(:)            :: IMLS_IN       => null() ! ice-mask levelset restart
     real, pointer, dimension(:)            :: OMLS_IN       => null() ! ocean-mask levelset restart
 
-    ! restarts with halo points
+    ! restarts with halo points (interleaved)
     real(dp), pointer, dimension(:)        :: ICESURF_HALO  => null()
     real(dp), pointer, dimension(:)        :: ICETHICK_HALO => null()
     real(dp), pointer, dimension(:)        :: IMLS_HALO     => null()
     real(dp), pointer, dimension(:)        :: OMLS_HALO     => null()
+    real(dp), pointer, dimension(:)        :: ICEVX_HALO    => null()
+    real(dp), pointer, dimension(:)        :: ICEVY_HALO    => null()
+    real(dp), pointer, dimension(:)        :: ICEVEL_HALO   => null()
+
+
     real(dp), pointer, dimension(:)        :: GEOS_RESTARTS => null() ! concatenate restart fields
+    real(dp), pointer, dimension(:)        :: ZEROS         => null() ! zero input for bootstrapping
+
+    ! export variables on landice tile space
+    real, pointer, dimension(:)            :: ICESURF_TILE  => null() ! ice surface elevation on landice tiles
+    real, pointer, dimension(:)            :: ICETHICK_TILE => null() ! ice thickness on landice tiles
+    real, pointer, dimension(:)            :: ICEVEL_TILE   => null() ! ice flow speed on landice tiles
+
+    ! export variables on mesh tile space
+    real, pointer, dimension(:)            :: ICESURF_EX    => null() ! ice surface elevation on mesh tiles
+    real, pointer, dimension(:)            :: ICETHICK_EX   => null() ! ice thickness on mesh tiles
+    real, pointer, dimension(:)            :: ICEVX_EX      => null() ! ice velocity (x direction) on mesh tiles
+    real, pointer, dimension(:)            :: ICEVY_EX      => null() ! ice velocity (y direction) on mesh tiles
+
+
 
     ! Get the target components name and set-up traceback handle.
     ! -----------------------------------------------------------
@@ -565,6 +608,7 @@ subroutine SetServices ( GC, RC )
     internal_state%halo_idx = halo_idx
     internal_state%owned_idx = owned_idx  
     internal_state%grid = grid
+    internal_state%mesh = mesh
     internal_state%halolist = halolist
     internal_state%nodalDistgrid = nodalDistgrid
     call MAPL_Get(MAPL, LocStream = internal_state%locstream, _RC)
@@ -594,16 +638,16 @@ subroutine SetServices ( GC, RC )
     call MAPL_GenericInitialize( GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
     VERIFY_(STATUS)
 
-	! Create Custom ISSM Run Alarm 
+	  ! Create Custom ISSM Run Alarm 
     !-----------------------------------
 
 	! get number of time steps since last ISSM run
     NSTEPS_INIT = 0
-	open(newunit=u, file="ISSM_NSTEPS.txt", status="old", iostat=ios)
-	if (ios == 0) then
-	  read(u, *) NSTEPS_INIT
-	  close(u)
-	end if
+    open(newunit=u, file="ISSM_NSTEPS.txt", status="old", iostat=ios)
+    if (ios == 0) then
+      read(u, *) NSTEPS_INIT
+      close(u)
+    end if
 
     ! get timestep for landice (heartbeat)
     call MAPL_Get(MAPL, HEARTBEAT=HEARTBEAT_DT,RC=STATUS)
@@ -628,61 +672,131 @@ subroutine SetServices ( GC, RC )
 
     ! create new ISSM_ALARM
     ISSM_ALARM = ESMF_AlarmCreate(CLOCK,ringTime=ringTime,ringInterval=ringInterval,sticky=.false.,rc=STATUS)
-	VERIFY_(STATUS)
+	  VERIFY_(STATUS)
 
 	! set run alarm
     call MAPL_Set(MAPL, RUNALARM = ISSM_ALARM, _RC)
 
     ! Next, send GEOS restarts to ISSM
     !-----------------------------------
+
+    ! array holding all restarts to send to/from ISSM
+    allocate(GEOS_RESTARTS(num_outputs*num_nodes))
+    allocate(ICESURF_HALO(num_nodes))
+    allocate(ICETHICK_HALO(num_nodes))
+    allocate(ICEVX_HALO(num_nodes))
+    allocate(ICEVY_HALO(num_nodes))
+    allocate(ICEVEL_HALO(num_nodes))
+    allocate(IMLS_HALO(num_nodes))
+    allocate(OMLS_HALO(num_nodes))
+    allocate(ZEROS(num_nodes))
+
     call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,RC=STATUS)
     VERIFY_(STATUS)
 
     ! get pointers to restarts
     call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(INTERNAL, ICEVX_IN, 'ICEVX', RC=STATUS); VERIFY_(STATUS)
+    call MAPL_GetPointer(INTERNAL, ICEVY_IN, 'ICEVY', RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', RC=STATUS); VERIFY_(STATUS)
     call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', RC=STATUS); VERIFY_(STATUS)
 
     ! if restart has been read, apply halo operation and send pointers to ISSM
     ! else, ISSM will just use default initial values in ISSM*.bin input files
-	if (associated(ICETHICK_IN)) then
-    ! check for positive ice thickness (initialized to zero if restart not found)
-	    ISSM_RST_FOUND = minval(ICETHICK_IN) > epsilon(ICETHICK_IN)
-	end if
-	
-	if (ISSM_RST_FOUND) then
-
-    ! variables for halo operations
-    allocate(ICESURF_HALO(num_nodes))
-    allocate(ICETHICK_HALO(num_nodes))
-    allocate(IMLS_HALO(num_nodes))
-    allocate(OMLS_HALO(num_nodes))
-    allocate(GEOS_RESTARTS(num_outputs*num_nodes))
+    if (associated(ICETHICK_IN)) then
+      ! check for positive ice thickness (initialized to zero if restart not found)
+        ISSM_RST_FOUND = minval(ICETHICK_IN) > epsilon(ICETHICK_IN)
+    end if
     
-    ! apply halo operation to all restart variables
-    call apply_halo(ICESURF_IN,ICESURF_HALO)
-    call apply_halo(ICETHICK_IN,ICETHICK_HALO)
-    call apply_halo(IMLS_IN,IMLS_HALO)
-    call apply_halo(OMLS_IN,OMLS_HALO)
+    if (ISSM_RST_FOUND) then
+      ! apply halo operation to all restart variables
+      call apply_halo(ICESURF_IN,ICESURF_HALO)
+      call apply_halo(ICETHICK_IN,ICETHICK_HALO)
+      call apply_halo(IMLS_IN,IMLS_HALO)
+      call apply_halo(OMLS_IN,OMLS_HALO)
 
-    ! package restarts into one pointer
-    ! note: same size as full issm output pointer in case
-    ! we need to supply velocity restarts at some point
-    GEOS_RESTARTS(:) = 0.0_dp
-    GEOS_RESTARTS(1:num_nodes) = ICESURF_HALO(:) 
-    GEOS_RESTARTS(num_nodes+1:2*num_nodes) = ICETHICK_HALO(:) 
-    GEOS_RESTARTS(4*num_nodes+1:5*num_nodes) = OMLS_HALO(:) 
-    GEOS_RESTARTS(5*num_nodes+1:6*num_nodes) = IMLS_HALO(:) 
+      ! package restarts into one pointer
+      GEOS_RESTARTS(:) = 0.0_dp
+      GEOS_RESTARTS(1:num_nodes) = ICESURF_HALO(:) 
+      GEOS_RESTARTS(num_nodes+1:2*num_nodes) = ICETHICK_HALO(:) 
+      GEOS_RESTARTS(2*num_nodes+1:3*num_nodes) = ICEVX_HALO(:) 
+      GEOS_RESTARTS(3*num_nodes+1:4*num_nodes) = ICEVY_HALO(:) 
+      GEOS_RESTARTS(4*num_nodes+1:5*num_nodes) = OMLS_HALO(:) 
+      GEOS_RESTARTS(5*num_nodes+1:6*num_nodes) = IMLS_HALO(:) 
 
-    ! set restarts on the ISSM side
-    call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
-    
-    call InputFromRestarts(c_loc(GEOS_RESTARTS))
+      ! set restarts on the ISSM side
+      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)      
+      call InputFromRestarts(c_loc(GEOS_RESTARTS))
+      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
 
-    call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+    else
+      ! bootstrap restart values from ISSM input files (ISSM*.bin)
+      ! by running with zero time step and zero forcing
+      ZEROS = 0.0_dp
+
+      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+      call RunISSM(epsilon(ISSM_DT), c_loc(ZEROS), c_loc(GEOS_RESTARTS))
+      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+
+      ! update ISSM run flag (for C++ library calls)
+      ISSM_RAN = .true.
+
+      ! Unpack restart array 
+      ICESURF_HALO(:)  = GEOS_RESTARTS(1:num_nodes) 
+      ICETHICK_HALO(:) = GEOS_RESTARTS(num_nodes+1:2*num_nodes) 
+      ICEVX_HALO(:) = GEOS_RESTARTS(2*num_nodes+1:3*num_nodes)
+      ICEVY_HALO(:) = GEOS_RESTARTS(3*num_nodes+1:4*num_nodes)
+      OMLS_HALO(:)  = GEOS_RESTARTS(4*num_nodes+1:5*num_nodes) 
+      IMLS_HALO(:)  = GEOS_RESTARTS(5*num_nodes+1:6*num_nodes) 
+
+      ! filter out halo points (keep the owned indices) for restarts
+      if(associated(ICESURF_IN)) ICESURF_IN = ICESURF_HALO(owned_idx)
+      if(associated(ICETHICK_IN)) ICETHICK_IN = ICETHICK_HALO(owned_idx)
+      if(associated(OMLS_IN)) OMLS_IN = OMLS_HALO(owned_idx)
+      if(associated(IMLS_IN)) IMLS_IN = IMLS_HALO(owned_idx)
 
     end if 
+
+    ! Initialize Export pointers on mesh tile space so history has something to write
+    !-----------------------------------
+
+    call MAPL_GetPointer(EXPORT, ICESURF_EX, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
+    if(associated(ICESURF_EX)) ICESURF_EX = ICESURF_HALO(owned_idx)
+
+    call MAPL_GetPointer(EXPORT, ICETHICK_EX, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
+    if(associated(ICETHICK_EX)) ICETHICK_EX = ICETHICK_HALO(owned_idx)
+
+    call MAPL_GetPointer(EXPORT, ICEVX_EX, 'ICEVX', RC=STATUS); VERIFY_(STATUS)
+    if(associated(ICEVX_EX)) ICEVX_EX = ICEVX_HALO(owned_idx)
+
+    call MAPL_GetPointer(EXPORT, ICEVY_EX, 'ICEVY', RC=STATUS); VERIFY_(STATUS)
+    if(associated(ICEVY_EX)) ICEVY_EX = ICEVY_HALO(owned_idx)
+
+    ! Finally, set the tile export state so landice can access values before ISSM runs
+    !-----------------------------------
+    ! Regrid from mesh to tile
+    call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
+
+    ! allocate variables on landice tile space
+    allocate(ICESURF_TILE(NT))
+    allocate(ICETHICK_TILE(NT))
+    allocate(ICEVEL_TILE(NT))
+
+    ! calculate ice flow speed
+    ICEVEL_HALO = sqrt(ICEVX_HALO**2 + ICEVY_HALO**2)
+
+    call mesh_to_tile(ICESURF_HALO,ICESURF_TILE)
+    issm_tile_state%ICESURF_TILE = ICESURF_TILE
+
+    call mesh_to_tile(ICETHICK_HALO,ICETHICK_TILE)
+    issm_tile_state%ICETHICK_TILE = ICETHICK_TILE
+
+    call mesh_to_tile(ICEVEL_HALO,ICEVEL_TILE)
+    issm_tile_state%ICEVEL_TILE = ICEVEL_TILE
+
+
+    call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
 
     ! deallocate pointers
     if(associated(nodeCoords))      deallocate(nodeCoords)
@@ -704,7 +818,13 @@ subroutine SetServices ( GC, RC )
     if(associated(ICETHICK_HALO))   deallocate(ICETHICK_HALO)
     if(associated(IMLS_HALO))       deallocate(IMLS_HALO)
     if(associated(OMLS_HALO))       deallocate(OMLS_HALO)
+    if(associated(ICEVX_HALO))      deallocate(ICEVX_HALO)
+    if(associated(ICEVY_HALO))      deallocate(ICEVY_HALO)
     if(associated(GEOS_RESTARTS))   deallocate(GEOS_RESTARTS)
+    if(associated(ZEROS))           deallocate(ZEROS)
+    if(associated(ICESURF_TILE))    deallocate(ICESURF_TILE)
+    if(associated(ICETHICK_TILE))   deallocate(ICETHICK_TILE)
+    if(associated(ICEVEL_TILE))     deallocate(ICEVEL_TILE)
 
     ! destroy fields and arrays
     call ESMF_FieldDestroy(gridField, rc=STATUS); VERIFY_(STATUS)
@@ -715,43 +835,43 @@ subroutine SetServices ( GC, RC )
 
     contains
        subroutine apply_halo(VAR_IN,VAR_HALO)
-        ! apply halo operation to a restart variable
-        real, pointer, dimension(:), intent(inout)     :: VAR_IN            ! var on owned_nodes
-        real(dp), pointer, dimension(:), intent(inout) :: VAR_HALO          ! var on all nodes
-        real(dp), pointer, dimension(:)                :: VAR_DP            ! double version of VAR_IN
-        real(dp), pointer, dimension(:)                :: MESH_PTR          ! pointer for ESMF_FieldGet
-        real(dp), pointer, dimension(:)                :: ARRAY_PTR         ! pointer for ESMF_FieldGet 
-        type(ESMF_Array)                               :: meshArray         ! array for creating mesh fields
-        type(ESMF_Field)                               :: meshField         ! field associated with meshArray
+          ! apply halo operation to a restart variable
+          real, pointer, dimension(:), intent(inout)     :: VAR_IN            ! var on owned_nodes
+          real(dp), pointer, dimension(:), intent(inout) :: VAR_HALO          ! var on all nodes
+          real(dp), pointer, dimension(:)                :: VAR_DP            ! double version of VAR_IN
+          real(dp), pointer, dimension(:)                :: MESH_PTR          ! pointer for ESMF_FieldGet
+          real(dp), pointer, dimension(:)                :: ARRAY_PTR         ! pointer for ESMF_FieldGet 
+          type(ESMF_Array)                               :: meshArray         ! array for creating mesh fields
+          type(ESMF_Field)                               :: meshField         ! field associated with meshArray
 
-        allocate(VAR_DP(num_nodes))
-        VAR_DP(:) = 0.0_dp
-        VAR_DP(1:num_owned_nodes) = REAL(VAR_IN,kind=dp)
-    
-        ! create array with halo information
-        meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,rc=STATUS)
+          allocate(VAR_DP(num_nodes))
+          VAR_DP(:) = 0.0_dp
+          VAR_DP(1:num_owned_nodes) = REAL(VAR_IN,kind=dp)
+      
+          ! create array with halo information
+          meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,rc=STATUS)
 
-        call ESMF_ArrayGet(array=meshArray,farrayPtr=ARRAY_PTR)
-        ARRAY_PTR(:) = VAR_DP(:)
+          call ESMF_ArrayGet(array=meshArray,farrayPtr=ARRAY_PTR)
+          ARRAY_PTR(:) = VAR_DP(:)
 
-        ! create field on ISSM mesh 
-        meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, rc=STATUS)
-        VERIFY_(STATUS)
+          ! create field on ISSM mesh 
+          meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, rc=STATUS)
+          VERIFY_(STATUS)
 
-        ! append halo values to end of "owned" array
-        call ESMF_FieldHalo(meshField, routehandle=halohandle, rc=STATUS); VERIFY_(STATUS)
-    
-        ! get pointer to field on mesh
-        call ESMF_FieldGet(meshField,farrayPtr=MESH_PTR,RC=STATUS); VERIFY_(STATUS)
+          ! append halo values to end of "owned" array
+          call ESMF_FieldHalo(meshField, routehandle=halohandle, rc=STATUS); VERIFY_(STATUS)
+      
+          ! get pointer to field on mesh
+          call ESMF_FieldGet(meshField,farrayPtr=MESH_PTR,RC=STATUS); VERIFY_(STATUS)
 
-        ! copy values into VAR_HALO, interleave according to owned and halo indices
-        VAR_HALO(owned_idx) = MESH_PTR(1:num_owned_nodes)          ! owned nodes
-        VAR_HALO(halo_idx) = MESH_PTR(num_owned_nodes+1:num_nodes) ! halo nodes
+          ! copy values into VAR_HALO, interleave according to owned and halo indices
+          VAR_HALO(owned_idx) = MESH_PTR(1:num_owned_nodes)          ! owned nodes
+          VAR_HALO(halo_idx) = MESH_PTR(num_owned_nodes+1:num_nodes) ! halo nodes
 
-        ! destroy field and array, deallocate pointer
-        call ESMF_FieldDestroy(meshField,rc=STATUS);  VERIFY_(STATUS)
-        call ESMF_ArrayDestroy(meshArray,rc=STATUS);  VERIFY_(STATUS)
-        deallocate(VAR_DP)
+          ! destroy field and array, deallocate pointer
+          call ESMF_FieldDestroy(meshField,rc=STATUS);  VERIFY_(STATUS)
+          call ESMF_ArrayDestroy(meshArray,rc=STATUS);  VERIFY_(STATUS)
+          deallocate(VAR_DP)
         
        end subroutine apply_halo
 
@@ -803,429 +923,272 @@ subroutine SetServices ( GC, RC )
   !BOP
 
 
-subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
-! ! ****** Run ISSM ice-sheet model ******
-! !  the core C++ solvers and associated pre/post-processing of imports/exports
-! !  are only performed at ISSM_DT intervals. However, the Run method is engaged
-! !  at every landice timestep to ensure that ISSM restarts persist  
-! !ARGUMENTS:
-  type(ESMF_GridComp), intent(inout)   :: GC                      ! Gridded component 
-  type(ESMF_State),    intent(inout)   :: IMPORT                  ! Import state
-  type(ESMF_State),    intent(inout)   :: EXPORT                  ! Export state
-  type(ESMF_Clock),    intent(inout)   :: CLOCK                   ! The clock
-  integer, optional,   intent(  out)   :: RC                      ! Error code
-  type(ESMF_Alarm)                     :: ALARM                   ! run alarm for ISSM component 
+  subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
+  ! ! ****** Run ISSM ice-sheet model ******
+  ! !  the core C++ solvers and associated pre/post-processing of imports/exports
+  ! !  are only performed at ISSM_DT intervals. However, the Run method is engaged
+  ! !  at every landice timestep to ensure that ISSM restarts persist  
+  ! !ARGUMENTS:
+    type(ESMF_GridComp), intent(inout)   :: GC                      ! Gridded component 
+    type(ESMF_State),    intent(inout)   :: IMPORT                  ! Import state
+    type(ESMF_State),    intent(inout)   :: EXPORT                  ! Export state
+    type(ESMF_Clock),    intent(inout)   :: CLOCK                   ! The clock
+    integer, optional,   intent(  out)   :: RC                      ! Error code
+    type(ESMF_Alarm)                     :: ALARM                   ! run alarm for ISSM component 
+    
+    ! ErrLog Variables
+    character(len=ESMF_MAXSTR)           :: IAm
+    integer                              :: STATUS
+    character(len=ESMF_MAXSTR)           :: COMP_NAME
+
+    type(MAPL_MetaComp), pointer         :: MAPL
+    type(ESMF_State)                     :: INTERNAL
+    type(ESMF_VM)                        :: vm  
+
+    ! internal state for regridding and halo operations
+    type(ESMF_Mesh)                      :: mesh                    ! ESMF version of ISSM mesh
+    integer                              :: num_nodes               ! number of nodes on PET
+
+    ! tile information
+    integer                              :: NT                      ! number of landice tiles
+
+    type(T_ISSM_TILE_STATE), pointer     :: issm_tile_state
+    type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
+
+    ! surface mass balance on mesh and landice tiles
+    real(dp), pointer, dimension(:)      :: ICESMB_MESH   => null() ! surface mass balce on mesh elements
+    real, pointer, dimension(:)          :: ICESMB_TILE   => null() ! surface mass balance on landice tiles
+    real, pointer, dimension(:)          :: ICESMB_EX     => null() ! pointer to SMB export (mesh)
+
+    ! ISSM Outputs
+    real(dp),    pointer, dimension(:)   :: ISSM_OUTPUTS  => null() ! pointer containing all outputs
+
+    ! ice-surface elevation on mesh and landice tiles
+    real(dp),    pointer, dimension(:)   :: ICESURF_MESH  => null() ! ice elevation on mesh
+    real, pointer, dimension(:)          :: ICESURF_TILE  => null() ! ice elevation on landice tiles
+    real, pointer, dimension(:)          :: ICESURF_EX    => null() ! pointer to export state (mesh tiles)
+    real, pointer, dimension(:)          :: ICESURF_IN    => null() ! pointer to internal state (mesh tiles)
+
+    ! ice thickness on mesh and landice tiles
+    real(dp),    pointer, dimension(:)   :: ICETHICK_MESH => null() ! ice thickness on mesh
+    real, pointer, dimension(:)          :: ICETHICK_TILE => null() ! ice thickness on landice tiles
+    real, pointer, dimension(:)          :: ICETHICK_EX   => null() ! pointer to ice thickness export state (mesh tiles)
+    real, pointer, dimension(:)          :: ICETHICK_IN   => null() ! pointer to ice thicknesss internal state (mesh tiles)
+
+    ! ice-flow velocity in x direction (in projection coordinates)
+    real(dp),    pointer, dimension(:)   :: ICEVX_MESH   => null() ! ice x-velocity on mesh
+    real, pointer, dimension(:)          :: ICEVX_EX     => null() ! pointer to export state (mesh tiles)
+
+    ! ice-flow velocity in y direction (in projection coordinates)
+    real(dp),    pointer, dimension(:)   :: ICEVY_MESH   => null() ! ice y-velocity on mesh
+    real, pointer, dimension(:)          :: ICEVY_EX     => null() ! pointer to export state (mesh tiles)
+
+    ! ice mask level set (tracks glacier terminus)
+    real(dp),    pointer, dimension(:)   :: IMLS_MESH   => null() ! ice mask level set
+    real, pointer, dimension(:)          :: IMLS_IN     => null() ! pointer to internal state (mesh tiles)
+
+    ! ocean mask level set (tracks grounding line)
+    real(dp),    pointer, dimension(:)   :: OMLS_MESH   => null() ! ocean mask level set
+    real, pointer, dimension(:)          :: OMLS_IN     => null() ! pointer to internal state (mesh tiles)
+
+    ! ice-flow speed on mesh and landice tiles  
+    real(dp),    pointer, dimension(:)   :: ICEVEL_MESH => null() ! ice flow speed on mesh tiles
+    real, pointer, dimension(:)          :: ICEVEL_TILE => null() ! ice flow speed on landice tiles
   
-  ! ErrLog Variables
-  character(len=ESMF_MAXSTR)           :: IAm
-  integer                              :: STATUS
-  character(len=ESMF_MAXSTR)           :: COMP_NAME
+    ! physical parameters
+    real(dp), parameter                  :: rho_ice   = 917.0     ! pure ice density [kg m-3]
+    real(dp)                             :: ISSM_DT               ! time step [s] (ISSM_DT set in AGCM.rc)
 
-  type(MAPL_MetaComp), pointer         :: MAPL
-  type(ESMF_State)                     :: INTERNAL
-  type(ESMF_VM)                        :: vm  
-
-  ! regridding
-  type(ESMF_RouteHandle)               :: routehandle_m2g         ! mesh to grid routehandle
-  type(ESMF_RouteHandle)               :: routehandle_g2m         ! grid to mesh routehandle
-  type(ESMF_Field)                     :: srcField                ! source field for regridding
-  type(ESMF_Field)                     :: dstField                ! destination field for regridding
-  type(T_ISSM_STATE), pointer          :: internal_state=>null()  ! stores everything needed for regridding
-  type(ISSM_WRAP)                      :: wrap                    ! wrapper for routehandle container
-  type(ESMF_Mesh)                      :: mesh                    ! ESMF version of ISSM mesh
-  integer                              :: num_elements            ! number of elements on PET
-  integer                              :: num_nodes               ! number of nodes on PET
-  integer                              :: num_owned_nodes         ! number of nodes owned by PET
-  integer                              :: IM, JM, local_dims(3)   ! local grid size
-
-  ! halo information
-  integer                              :: num_halo_nodes          ! num_nodes minus num_owned_nodes
-  type(ESMF_RouteHandle)               :: halohandle              ! field halo routehandle
-  integer, pointer, dimension(:)       :: halolist      => null() ! list of halo nodeIds
-  integer, pointer,dimension(:)        :: halo_idx      => null() ! indices of halo nodes in arrays
-  integer, pointer,dimension(:)        :: owned_idx     => null() ! indices of owned nodes in arrays
-  type(ESMF_DistGrid)                  :: nodalDistgrid           ! distgrid (owned nodes)
-  type(ESMF_Array)                     :: meshArray               ! array for creating mesh fields
-
-  ! tile information
-  integer                              :: NT                      ! number of landice tiles
-
-  type(T_ISSM_TILE_STATE), pointer     :: issm_tile_state
-  type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
-
-  ! surface mass balance on mesh and landice tiles
-  real(dp), pointer, dimension(:)      :: ICESMB_MESH   => null() ! surface mass balce on mesh elements
-  real, pointer, dimension(:)          :: ICESMB_TILE   => null() ! surface mass balance on landice tiles
-  real, pointer, dimension(:)          :: ICESMB_EX     => null() ! pointer to SMB export (mesh)
-
-  ! ISSM Outputs
-  real(dp),    pointer, dimension(:)   :: ISSM_OUTPUTS  => null() ! pointer containing all outputs
-
-  ! ice-surface elevation on mesh and landice tiles
-  real(dp),    pointer, dimension(:)   :: ICESURF_MESH  => null() ! ice elevation on mesh
-  real, pointer, dimension(:)          :: ICESURF_TILE  => null() ! ice elevation on landice tiles
-  real, pointer, dimension(:)          :: ICESURF_EX    => null() ! pointer to export state (mesh tiles)
-  real, pointer, dimension(:)          :: ICESURF_IN    => null() ! pointer to internal state (mesh tiles)
-
-  ! ice thickness on mesh and landice tiles
-  real(dp),    pointer, dimension(:)   :: ICETHICK_MESH => null() ! ice thickness on mesh
-  real, pointer, dimension(:)          :: ICETHICK_TILE => null() ! ice thickness on landice tiles
-  real, pointer, dimension(:)          :: ICETHICK_EX   => null() ! pointer to ice thickness export state (mesh tiles)
-  real, pointer, dimension(:)          :: ICETHICK_IN   => null() ! pointer to ice thicknesss internal state (mesh tiles)
-
-  ! ice-flow velocity in x direction (in projection coordinates)
-  real(dp),    pointer, dimension(:)   :: ICEVX_MESH   => null() ! ice x-velocity on mesh
-  real, pointer, dimension(:)          :: ICEVX_EX     => null() ! pointer to export state (mesh tiles)
-
-  ! ice-flow velocity in y direction (in projection coordinates)
-  real(dp),    pointer, dimension(:)   :: ICEVY_MESH   => null() ! ice y-velocity on mesh
-  real, pointer, dimension(:)          :: ICEVY_EX     => null() ! pointer to export state (mesh tiles)
-
-  ! ice mask level set (tracks glacier terminus)
-  real(dp),    pointer, dimension(:)   :: IMLS_MESH   => null() ! ice mask level set
-  real, pointer, dimension(:)          :: IMLS_IN     => null() ! pointer to internal state (mesh tiles)
-
-  ! ocean mask level set (tracks grounding line)
-  real(dp),    pointer, dimension(:)   :: OMLS_MESH   => null() ! ocean mask level set
-  real, pointer, dimension(:)          :: OMLS_IN     => null() ! pointer to internal state (mesh tiles)
-
-  ! ice-flow speed on mesh and landice tiles  
-  real(dp),    pointer, dimension(:)   :: ICEVEL_MESH => null() ! ice flow speed on mesh tiles
-  real, pointer, dimension(:)          :: ICEVEL_TILE => null() ! ice flow speed on landice tiles
- 
-  ! physical parameters
-  real(dp), parameter                  :: rho_ice   = 917.0     ! pure ice density [kg m-3]
-  real(dp)                             :: ISSM_DT               ! time step [s] (ISSM_DT set in AGCM.rc)
-
-  ! testing
-  type(ESMF_Time)                      :: currTime
-  type(ESMF_Time)                      :: stopTime
-  type(ESMF_TimeInterval)              :: timeStep
-  logical                              :: NEED_RST
-  integer                              :: localPET
-
-! Get the target components name, mesh and vm
-! -----------------------------------------------------------
-  Iam = "Run"
-  call ESMF_GridCompGet( GC, name=COMP_NAME,mesh=mesh,vm=vm,RC=STATUS )
-  VERIFY_(STATUS)
-  Iam = trim(COMP_NAME) // Iam
+  ! Get the target components name, mesh and vm
+  ! -----------------------------------------------------------
+    Iam = "Run"
+    call ESMF_GridCompGet(GC,name=COMP_NAME,mesh=mesh,vm=vm,RC=STATUS)
+    VERIFY_(STATUS)
+    Iam = trim(COMP_NAME) // Iam
 
   ! Get my internal MAPL_Generic state
-!----------------------------------
-  call MAPL_GetObjectFromGC(GC, MAPL, STATUS)
-  VERIFY_(STATUS)
-
-  call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,RC=STATUS )
-  VERIFY_(STATUS)
-
-  ! Start Total timer
-!------------------
-  call MAPL_TimerOn(MAPL,"TOTAL")
-  call MAPL_TimerOn(MAPL,"RUN" )
-
-  call MAPL_Get(MAPL, RUNALARM = ALARM, RC=STATUS )
-  VERIFY_(STATUS)
-
-  call ESMF_ClockGet(CLOCK,currTime=currTime,stopTime=stopTime,timeStep=timeStep,rc=STATUS); VERIFY_(STATUS)
-
-  ! if bootstrapping, and at final timestep, we will get restarts from run method
-  NEED_RST = (currTime==(stopTime-timeStep)) .and. ((.not. ISSM_RAN) .and. (.not. ISSM_RST_FOUND))
-
-  call ESMF_VMGet(vm,localPET=localPET,rc=STATUS); VERIFY_(STATUS)
-
-  ! run ISSM at specified time steps, 
-  ! if bootstrapping restart and issm has run not by final time step, run anyways
-  ! with timestep of zero, which just gets restart values
-  if ( ESMF_AlarmIsRinging(ALARM, RC=STATUS) .or. NEED_RST ) then
-
-    ! *************************************************************************** !
-    ! BASIC SETUP
-    ! *************************************************************************** !
-
-    ! get timestep for ISSM
-    call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
+  !----------------------------------
+    call MAPL_GetObjectFromGC(GC, MAPL, STATUS)
     VERIFY_(STATUS)
 
-    ! if just getting restart, set timestep to zero
-    if (NEED_RST) then
-        ISSM_DT = 0.0_dp
-	  end if 
+    call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,RC=STATUS )
+    VERIFY_(STATUS)
 
-    ! get number of mesh elements
-    call ESMF_MeshGet(mesh,elementCount=num_elements,nodeCount=num_nodes,numOwnedNodes=num_owned_nodes)
+    ! Start Total timer
+  !------------------
+    call MAPL_TimerOn(MAPL,"TOTAL")
+    call MAPL_TimerOn(MAPL,"RUN" )
 
-    ! allocate ice-elevation output (export from ISSM)
-    allocate(ISSM_OUTPUTS(num_outputs*num_nodes))  
+    call MAPL_Get(MAPL, RUNALARM = ALARM, RC=STATUS )
+    VERIFY_(STATUS)
 
-    ! allocate output arrays defined on mesh nodes
-    allocate(ICESURF_MESH(num_nodes))
-    allocate(ICETHICK_MESH(num_nodes))
-    allocate(ICEVX_MESH(num_nodes))
-    allocate(ICEVY_MESH(num_nodes))
-    allocate(ICEVEL_MESH(num_nodes))
-    allocate(IMLS_MESH(num_nodes))
-    allocate(OMLS_MESH(num_nodes))
-    
-    ! allocate input arrays defined on mesh nodes
-    allocate(ICESMB_MESH(num_nodes))  
+    ! run ISSM at specified time steps, 
+    ! if bootstrapping restart and issm has run not by final time step, run anyways
+    ! with timestep of zero, which just gets restart values
+    if (ESMF_AlarmIsRinging(ALARM, RC=STATUS)) then
 
-    ! initialize ISSM outputs to zero 
-    ICESURF_MESH(:) = 0.0_dp
-    ICETHICK_MESH(:) = 0.0_dp
-    ICEVX_MESH(:) = 0.0_dp
-    ICEVY_MESH(:) = 0.0_dp
-    ICEVEL_MESH(:) = 0.0_dp
-    IMLS_MESH(:) = 0.0_dp
-    OMLS_MESH(:) = 0.0_dp
-    ISSM_OUTPUTS(:) = 0.0_dp
+      ! *************************************************************************** !
+      ! BASIC SETUP
+      ! *************************************************************************** !
 
-    ! get internal state for regridding
-    call ESMF_UserCompGetInternalState(GC, 'ISSM_WRAP', wrap, status); VERIFY_(STATUS)
-    internal_state => wrap%ptr
-    routehandle_m2g = internal_state%routehandle_m2g  ! mesh to grid 
-    routehandle_g2m = internal_state%routehandle_g2m  ! grid to mesh
-
-    ! get field halo information
-    num_halo_nodes = num_nodes - num_owned_nodes
-    allocate(halo_idx(num_halo_nodes))
-    allocate(owned_idx(num_owned_nodes))
-    allocate(halolist(num_halo_nodes))
-    halo_idx = internal_state%halo_idx
-    owned_idx = internal_state%owned_idx
-    halohandle = internal_state%halohandle
-    halolist = internal_state%halolist
-    nodalDistgrid = internal_state%nodalDistgrid
-
-    ! get landice tile dimensions
-    call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
-
-    ! get grid dimensions, used below in regridding subroutines
-    call MAPL_GridGet(internal_state%grid, localCellCountPerDim=local_dims, _RC)
-    IM = local_dims(1)
-    JM = local_dims(2)
-     
-    call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
-    issm_tile_state => issm_tile_wrap%ptr
-    
-    ! *************************************************************************** !
-    ! GET ICESMB IMPORT (surface mass balance)
-    ! *************************************************************************** !    
-    ! allocate tiles for ICESMB 
-    if(.not.associated(ICESMB_TILE)) then
-      allocate(ICESMB_TILE(NT), STAT=STATUS)
+      ! get timestep for ISSM
+      call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, RC=STATUS)
       VERIFY_(STATUS)
-      ICESMB_TILE = MAPL_Undef
-    end if
+
+      ! get number of mesh elements
+      call ESMF_MeshGet(mesh,elementCount=num_elements,nodeCount=num_nodes)
+
+      ! allocate ice-elevation output (export from ISSM)
+      allocate(ISSM_OUTPUTS(num_outputs*num_nodes))  
+
+      ! allocate output arrays defined on mesh nodes
+      allocate(ICESURF_MESH(num_nodes))
+      allocate(ICETHICK_MESH(num_nodes))
+      allocate(ICEVX_MESH(num_nodes))
+      allocate(ICEVY_MESH(num_nodes))
+      allocate(ICEVEL_MESH(num_nodes))
+      allocate(IMLS_MESH(num_nodes))
+      allocate(OMLS_MESH(num_nodes))
+      
+      ! allocate input arrays defined on mesh nodes
+      allocate(ICESMB_MESH(num_nodes))  
+
+      ! initialize ISSM outputs to zero 
+      ICESURF_MESH(:) = 0.0_dp
+      ICETHICK_MESH(:) = 0.0_dp
+      ICEVX_MESH(:) = 0.0_dp
+      ICEVY_MESH(:) = 0.0_dp
+      ICEVEL_MESH(:) = 0.0_dp
+      IMLS_MESH(:) = 0.0_dp
+      OMLS_MESH(:) = 0.0_dp
+      ISSM_OUTPUTS(:) = 0.0_dp
+
+      ! get landice tile dimensions
+      call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
+      
+      call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); VERIFY_(STATUS)
+      issm_tile_state => issm_tile_wrap%ptr
+      
+      ! *************************************************************************** !
+      ! GET ICESMB IMPORT (surface mass balance)
+      ! *************************************************************************** !    
+      ! allocate tiles for ICESMB 
+      if(.not.associated(ICESMB_TILE)) then
+        allocate(ICESMB_TILE(NT), STAT=STATUS)
+        VERIFY_(STATUS)
+        ICESMB_TILE = MAPL_Undef
+      end if
+      
+      ! copy import values into tile array 
+      ICESMB_TILE = issm_tile_state%ICESMB_ISSM
+
+      ! *************************************************************************** !
+      ! TRANSFORM ICESMB FROM TILES TO MESH 
+      ! *************************************************************************** !
+      call tile_to_mesh(ICESMB_TILE,ICESMB_MESH)
+
+      ! save ICESMB on mesh elements 
+      call MAPL_GetPointer(EXPORT  , ICESMB_EX , 'ICESMB' , RC=STATUS); VERIFY_(STATUS)
+
+      if(associated(ICESMB_EX)) ICESMB_EX = ICESMB_MESH(internal_state%owned_idx)
+
+      ! *************************************************************************** !
+      !  RUN ISSM WITH SMB INPUT AND ICE-ELEVATION OUTPUT
+      ! *************************************************************************** !
+      ! convert SMB to units of [m/s] (ice-equivalent) before passing to ISSM
+      ICESMB_MESH = ICESMB_MESH/rho_ice
+
+      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+
+      ! call run method from ISSM library 
+      call RunISSM(ISSM_DT, c_loc(ICESMB_MESH), c_loc(ISSM_OUTPUTS))
+
+      call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
+
+      ! update ISSM run flag (for C++ library calls)
+      ISSM_RAN = .true.
+
+      ! *************************************************************************** !
+      ! UNPACK AND EXPORT ISSM OUTPUTS ON MESH TILES
+      ! *************************************************************************** !
+      ! unpack ISSM output pointer
+      ICESURF_MESH(:) = ISSM_OUTPUTS(1:num_nodes)
+      ICETHICK_MESH(:) = ISSM_OUTPUTS(num_nodes+1:2*num_nodes)
+      ICEVX_MESH(:) = ISSM_OUTPUTS(2*num_nodes+1:3*num_nodes)
+      ICEVY_MESH(:) = ISSM_OUTPUTS(3*num_nodes+1:4*num_nodes)
+      OMLS_MESH(:) = ISSM_OUTPUTS(4*num_nodes+1:5*num_nodes)
+      IMLS_MESH(:) = ISSM_OUTPUTS(5*num_nodes+1:6*num_nodes)
+
+      ! calculate ice flow speed
+      ICEVEL_MESH = sqrt(ICEVX_MESH**2 + ICEVY_MESH**2)
+
+      ! set pointers to tile-mesh exports
+      call MAPL_GetPointer(EXPORT, ICESURF_EX, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
+      if(associated(ICESURF_EX)) ICESURF_EX = ICESURF_MESH(internal_state%owned_idx)
+
+      call MAPL_GetPointer(EXPORT, ICEVX_EX, 'ICEVX', RC=STATUS); VERIFY_(STATUS)
+      if(associated(ICEVX_EX)) ICEVX_EX = ICEVX_MESH(internal_state%owned_idx)
+
+      call MAPL_GetPointer(EXPORT, ICEVY_EX, 'ICEVY', RC=STATUS); VERIFY_(STATUS)
+      if(associated(ICEVY_EX)) ICEVY_EX = ICEVY_MESH(internal_state%owned_idx)
+
+      call MAPL_GetPointer(EXPORT, ICETHICK_EX, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
+      if(associated(ICETHICK_EX)) ICETHICK_EX = ICETHICK_MESH(internal_state%owned_idx)
+
+      ! set pointers to tile-mesh internals
+      call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
+      if(associated(ICESURF_IN)) ICESURF_IN = ICESURF_MESH(internal_state%owned_idx)
+
+      call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
+      if(associated(ICETHICK_IN)) ICETHICK_IN = ICETHICK_MESH(internal_state%owned_idx)
+
+      call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', RC=STATUS); VERIFY_(STATUS)
+      if(associated(OMLS_IN)) OMLS_IN = OMLS_MESH(internal_state%owned_idx)
+
+      call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', RC=STATUS); VERIFY_(STATUS)
+      if(associated(IMLS_IN)) IMLS_IN = IMLS_MESH(internal_state%owned_idx)
+
+      ! *************************************************************************** !
+      ! REGRID MESH FIELDS ONTO LANDICE TILES AND EXPORT VIA INTERNAL STATE
+      ! *************************************************************************** !
+      ! transform from mesh to tiles
+      call mesh_to_tile(ICESURF_MESH,ICESURF_TILE)
+      issm_tile_state%ICESURF_TILE = ICESURF_TILE
+
+      call mesh_to_tile(ICETHICK_MESH,ICETHICK_TILE)
+      issm_tile_state%ICETHICK_TILE = ICETHICK_TILE
+
+      call mesh_to_tile(ICEVEL_MESH,ICEVEL_TILE)
+      issm_tile_state%ICEVEL_TILE = ICEVEL_TILE
+
+    end if 
     
-    ! copy import values into tile array 
-    ICESMB_TILE = issm_tile_state%ICESMB_ISSM
+    ! barrier to ensure regridding completes before any deallocates
+    call ESMF_VMBarrier(vm, rc=status)
+    VERIFY_(STATUS)
 
-    ! *************************************************************************** !
-    ! TRANSFORM ICESMB FROM TILES TO MESH 
-    ! *************************************************************************** !
-    call tile_to_mesh(ICESMB_TILE,ICESMB_MESH)
+    ! deallocates
+    if(associated(ICESURF_MESH))  deallocate(ICESURF_MESH)
+    if(associated(ICETHICK_MESH)) deallocate(ICETHICK_MESH)
+    if(associated(ICEVEL_MESH))   deallocate(ICEVEL_MESH)
+    if(associated(ICEVX_MESH))    deallocate(ICEVX_MESH)
+    if(associated(ICEVY_MESH))    deallocate(ICEVY_MESH)
+    if(associated(IMLS_MESH))     deallocate(IMLS_MESH)
+    if(associated(OMLS_MESH))     deallocate(OMLS_MESH)  
+    if(associated(ICESMB_MESH))   deallocate(ICESMB_MESH) 
+    if(associated(ISSM_OUTPUTS))  deallocate(ISSM_OUTPUTS)
+    if(associated(ICESMB_TILE))   deallocate(ICESMB_TILE)
+    if(associated(ICESURF_TILE))  deallocate(ICESURF_TILE)
+    if(associated(ICETHICK_TILE)) deallocate(ICETHICK_TILE)
+    if(associated(ICEVEL_TILE))   deallocate(ICEVEL_TILE)
 
-    ! save ICESMB on mesh elements 
-    call MAPL_GetPointer(EXPORT  , ICESMB_EX , 'ICESMB' , RC=STATUS); VERIFY_(STATUS)
-
-    if(associated(ICESMB_EX)) ICESMB_EX = ICESMB_MESH(owned_idx)
-
-    ! *************************************************************************** !
-    !  RUN ISSM WITH SMB INPUT AND ICE-ELEVATION OUTPUT
-    ! *************************************************************************** !
-    ! convert SMB to units of [m/s] (ice-equivalent) before passing to ISSM
-    ICESMB_MESH = ICESMB_MESH/rho_ice
-
-    call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
-
-    ! call run method from ISSM library 
-    call RunISSM(ISSM_DT, c_loc(ICESMB_MESH), c_loc(ISSM_OUTPUTS))
-
-    call ESMF_VMBarrier(vm, rc=status); VERIFY_(STATUS)
-
-    ! update ISSM run flag (for C++ library calls)
-	  ISSM_RAN = .true.
-
-    ! *************************************************************************** !
-    ! UNPACK AND EXPORT ISSM OUTPUTS ON MESH TILES
-    ! *************************************************************************** !
-    ! unpack ISSM output pointer
-    ICESURF_MESH(:) = ISSM_OUTPUTS(1:num_nodes)
-    ICETHICK_MESH(:) = ISSM_OUTPUTS(num_nodes+1:2*num_nodes)
-    ICEVX_MESH(:) = ISSM_OUTPUTS(2*num_nodes+1:3*num_nodes)
-    ICEVY_MESH(:) = ISSM_OUTPUTS(3*num_nodes+1:4*num_nodes)
-    OMLS_MESH(:) = ISSM_OUTPUTS(4*num_nodes+1:5*num_nodes)
-    IMLS_MESH(:) = ISSM_OUTPUTS(5*num_nodes+1:6*num_nodes)
-
-    ! calculate ice flow speed
-    ICEVEL_MESH = sqrt(ICEVX_MESH**2 + ICEVY_MESH**2)
-
-    ! set pointers to tile-mesh exports
-    call MAPL_GetPointer(EXPORT, ICESURF_EX, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
-    if(associated(ICESURF_EX)) ICESURF_EX = ICESURF_MESH(owned_idx)
-
-    call MAPL_GetPointer(EXPORT, ICEVX_EX, 'ICEVX', RC=STATUS); VERIFY_(STATUS)
-    if(associated(ICEVX_EX)) ICEVX_EX = ICEVX_MESH(owned_idx)
-
-    call MAPL_GetPointer(EXPORT, ICEVY_EX, 'ICEVY', RC=STATUS); VERIFY_(STATUS)
-    if(associated(ICEVY_EX)) ICEVY_EX = ICEVY_MESH(owned_idx)
-
-    call MAPL_GetPointer(EXPORT, ICETHICK_EX, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
-    if(associated(ICETHICK_EX)) ICETHICK_EX = ICETHICK_MESH(owned_idx)
-
-    ! set pointers to tile-mesh internals
-    call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', RC=STATUS); VERIFY_(STATUS)
-    if(associated(ICESURF_IN)) ICESURF_IN = ICESURF_MESH(owned_idx)
-
-    call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK', RC=STATUS); VERIFY_(STATUS)
-    if(associated(ICETHICK_IN)) ICETHICK_IN = ICETHICK_MESH(owned_idx)
-
-    call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS', RC=STATUS); VERIFY_(STATUS)
-    if(associated(OMLS_IN)) OMLS_IN = OMLS_MESH(owned_idx)
-
-    call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', RC=STATUS); VERIFY_(STATUS)
-    if(associated(IMLS_IN)) IMLS_IN = IMLS_MESH(owned_idx)
-
-    ! *************************************************************************** !
-    ! REGRID MESH FIELDS ONTO LANDICE TILES AND EXPORT VIA INTERNAL STATE
-    ! *************************************************************************** !
-    ! transform from mesh to tiles
-    call mesh_to_tile(ICESURF_MESH,ICESURF_TILE)
-    issm_tile_state%ICESURF_TILE = ICESURF_TILE
-
-    call mesh_to_tile(ICETHICK_MESH,ICETHICK_TILE)
-    issm_tile_state%ICETHICK_TILE = ICETHICK_TILE
-
-    call mesh_to_tile(ICEVEL_MESH,ICEVEL_TILE)
-    issm_tile_state%ICEVEL_TILE = ICEVEL_TILE
-
-  end if 
+    call MAPL_TimerOff(MAPL,"RUN"  )
+    call MAPL_TimerOff(MAPL,"TOTAL")
   
-  ! barrier to ensure regridding completes before any deallocates
-  call ESMF_VMBarrier(vm, rc=status)
-  VERIFY_(STATUS)
+    RETURN_(ESMF_SUCCESS)
 
-  ! deallocates
-  if(associated(ICESURF_MESH))  deallocate(ICESURF_MESH)
-  if(associated(ICETHICK_MESH)) deallocate(ICETHICK_MESH)
-  if(associated(ICEVEL_MESH))   deallocate(ICEVEL_MESH)
-  if(associated(ICEVX_MESH))    deallocate(ICEVX_MESH)
-  if(associated(ICEVY_MESH))    deallocate(ICEVY_MESH)
-  if(associated(IMLS_MESH))     deallocate(IMLS_MESH)
-  if(associated(OMLS_MESH))     deallocate(OMLS_MESH)  
-  if(associated(ICESMB_MESH))   deallocate(ICESMB_MESH) 
-  if(associated(ISSM_OUTPUTS))  deallocate(ISSM_OUTPUTS)
-  if(associated(ICESMB_TILE))   deallocate(ICESMB_TILE)
-  if(associated(ICESURF_TILE))  deallocate(ICESURF_TILE)
-  if(associated(ICETHICK_TILE)) deallocate(ICETHICK_TILE)
-  if(associated(ICEVEL_TILE))   deallocate(ICEVEL_TILE)
-  if(associated(halolist))      deallocate(halolist)
-  if(associated(halo_idx))      deallocate(halo_idx)
-  if(associated(owned_idx))     deallocate(owned_idx)
+  end subroutine RUN
 
-  call MAPL_TimerOff(MAPL,"RUN"  )
-  call MAPL_TimerOff(MAPL,"TOTAL")
- 
-  RETURN_(ESMF_SUCCESS)
-
-  contains
-
-  subroutine mesh_to_tile(VAR_MESH,VAR_TILE)
-    ! regrid from mesh to grid, then transform from grid to landice tiles
-    real(dp),    pointer, dimension(:), intent(inout)   :: VAR_MESH           ! var on mesh nodes
-    real, pointer, dimension(:), intent(inout)          :: VAR_TILE           ! var on landice tiles
-    real, pointer, dimension(:,:)                       :: VAR_GRID => null() ! var on attached grid
-    real(dp),    pointer, dimension(:)                  :: VAR_MESH_OWN       ! var on owned mesh nodes
-
-    allocate(VAR_MESH_OWN(num_owned_nodes))
-
-    VAR_MESH_OWN = VAR_MESH(owned_idx)
-
-    ! allocate tiles 
-    if (.not.associated(VAR_TILE)) then
-      allocate(VAR_TILE(NT), STAT=STATUS)
-      VERIFY_(STATUS)
-      VAR_TILE = MAPL_Undef
-    end if
-
-    ! create source field: field on mesh nodes
-    srcField = ESMF_FieldCreate(mesh=mesh,farrayPtr=VAR_MESH_OWN,meshloc=ESMF_MESHLOC_NODE, & 
-    datacopyflag=ESMF_DATACOPY_VALUE,rc=STATUS)
-    VERIFY_(STATUS)
-    
-    ! create destination field: field on grid
-    dstField = ESMF_FieldCreate(grid=internal_state%grid,typekind=ESMF_TYPEKIND_R4,rc=STATUS)
-    VERIFY_(STATUS)
-
-    ! regrid field from mesh to grid
-    call ESMF_FieldRegrid(srcField, dstField, routehandle_m2g, RC=STATUS); VERIFY_(STATUS)
-
-    ! get pointer to field on grid
-    call ESMF_FieldGet(dstField,farrayPtr=VAR_GRID,RC=STATUS); VERIFY_(STATUS)
-
-    ! transform from grid to tiles  
-    call MAPL_LocStreamTransform(internal_state%locstream,VAR_TILE,VAR_GRID, RC=STATUS)
-    VERIFY_(STATUS)
-
-    ! destroy regridding fields so they can be reused
-    call ESMF_FieldDestroy(srcField,rc=STATUS); VERIFY_(STATUS)
-    call ESMF_FieldDestroy(dstField,rc=STATUS); VERIFY_(STATUS)
-
-  end subroutine mesh_to_tile
-
-  subroutine tile_to_mesh(VAR_TILE,VAR_MESH)
-    ! transform from landice tile to grid, then regrid onto mesh
-    real, pointer, dimension(:), intent(inout)     :: VAR_TILE           ! var on landice tiles
-    real(dp), pointer, dimension(:), intent(inout) :: VAR_MESH           ! var on mesh elements
-    real, pointer, dimension(:,:)                  :: VAR_GRID => null() ! var on attached grid
-    real(dp), pointer, dimension(:)                :: MESH_PTR           ! pointer for ESMF_FieldGet 
-
-    ! allocate pointer on grid for regridding 
-    allocate(VAR_GRID(IM,JM), STAT=STATUS); VERIFY_(STATUS)
-  
-    ! transform from tile to grid
-    ! NOTE: we use the "transpose" option with MAPL_LocStreamTransformG2T 
-    ! (rather than MAPL_LocStreamTransformT2G) because the "default" value is zero
-    ! (rather than MAPL_UNDEF, which leads to errors when regridding onto mesh)
-    call MAPL_LocStreamTransform(internal_state%LOCSTREAM, VAR_TILE, VAR_GRID, TRANSPOSE=.true., RC=STATUS)
-    VERIFY_(STATUS)
-
-    ! create source field on grid
-    srcField = ESMF_FieldCreate(grid=internal_state%grid,farrayPtr=VAR_GRID, datacopyflag=ESMF_DATACOPY_VALUE,rc=STATUS)
-    VERIFY_(STATUS)
-
-    ! create destination field on mesh elements
-    meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,rc=STATUS)
-    VERIFY_(STATUS)
-
-    ! create field on ISSM mesh
-    dstField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, rc=STATUS)
-    VERIFY_(STATUS)
-
-    ! regrid from grid to mesh
-    call ESMF_FieldRegrid(srcField, dstField, routehandle_g2m, RC=STATUS); VERIFY_(STATUS)
-
-    ! append halo values to end of "owned" array
-    call ESMF_FieldHalo(dstField, routehandle=halohandle, rc=STATUS); VERIFY_(STATUS)
-
-    ! get pointer to field on mesh
-    call ESMF_FieldGet(dstField,farrayPtr=MESH_PTR,RC=STATUS); VERIFY_(STATUS)
-
-    ! copy values into VAR_MESH
-    VAR_MESH(owned_idx) = MESH_PTR(1:num_owned_nodes)          ! owned nodes
-    VAR_MESH(halo_idx) = MESH_PTR(num_owned_nodes+1:num_nodes) ! halo nodes
-    
-    ! destroy fields and arrays so they can be reused
-    deallocate(VAR_GRID)
-    call ESMF_FieldDestroy(srcField,rc=STATUS);  VERIFY_(STATUS)
-    call ESMF_FieldDestroy(dstField,rc=STATUS);  VERIFY_(STATUS)
-    call ESMF_ArrayDestroy(meshArray,rc=STATUS); VERIFY_(STATUS)
-
-  end subroutine tile_to_mesh  
-
- 
- end subroutine RUN
 
  !BOP
     
@@ -1247,7 +1210,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)	       :: IAm
-    integer			                   :: STATUS
+    integer			                       :: STATUS
     character(len=ESMF_MAXSTR)         :: COMP_NAME
 
     ! variables for writing out timesteps since ISSM (via ISSM_NSTEPS.txt)
@@ -1256,7 +1219,7 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
     type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
 
     ! Get the target components name and set-up traceback handle.
-! -----------------------------------------------------------
+    ! -----------------------------------------------------------
     Iam = "Finalize"
     call ESMF_GridCompGet( gc, NAME=comp_name, RC=status )
     VERIFY_(STATUS)
@@ -1280,15 +1243,135 @@ subroutine RUN ( GC, IMPORT, EXPORT, CLOCK, RC )
         call FinalizeISSM()
 	  end if 
 
-! Generic Finalize
-! ------------------
+    ! Generic Finalize
+    ! ------------------
     call MAPL_GenericFinalize( GC, IMPORT, EXPORT, CLOCK, RC=status )
     VERIFY_(STATUS)
 
-! All Done
-!---------
+    ! All Done
+    ! ------------------
 
     RETURN_(ESMF_SUCCESS)
   end subroutine Finalize
+
+
+  subroutine mesh_to_tile(VAR_MESH,VAR_TILE)
+    ! regrid from mesh to grid, then transform from grid to landice tiles
+    real(dp),    pointer, dimension(:), intent(inout)   :: VAR_MESH           ! var on mesh nodes
+    real, pointer, dimension(:), intent(inout)          :: VAR_TILE           ! var on landice tiles
+
+    real, pointer, dimension(:,:)                       :: VAR_GRID => null() ! var on attached grid
+    real(dp),    pointer, dimension(:)                  :: VAR_MESH_OWN       ! var on owned mesh nodes
+    type(ESMF_Field)                                    :: srcField
+    type(ESMF_Field)                                    :: dstField
+    integer                                             :: num_owned_nodes
+    integer                                             :: NT
+    integer                                             :: STATUS
+  
+    num_owned_nodes = size(internal_state%owned_idx)
+
+    call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
+
+    allocate(VAR_MESH_OWN(num_owned_nodes))
+
+    VAR_MESH_OWN = VAR_MESH(internal_state%owned_idx)
+
+    ! allocate tiles 
+    if (.not.associated(VAR_TILE)) then
+      allocate(VAR_TILE(NT), STAT=STATUS)
+      VERIFY_(STATUS)
+      VAR_TILE = MAPL_Undef
+    end if
+
+    ! create source field: field on mesh nodes
+    srcField = ESMF_FieldCreate(mesh=internal_state%mesh,farrayPtr=VAR_MESH_OWN,meshloc=ESMF_MESHLOC_NODE, & 
+    datacopyflag=ESMF_DATACOPY_VALUE,rc=STATUS)
+    VERIFY_(STATUS)
+    
+    ! create destination field: field on grid
+    dstField = ESMF_FieldCreate(grid=internal_state%grid,typekind=ESMF_TYPEKIND_R4,rc=STATUS)
+    VERIFY_(STATUS)
+
+    ! regrid field from mesh to grid
+    call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_m2g, RC=STATUS); VERIFY_(STATUS)
+
+    ! get pointer to field on grid
+    call ESMF_FieldGet(dstField,farrayPtr=VAR_GRID,RC=STATUS); VERIFY_(STATUS)
+
+    ! transform from grid to tiles  
+    call MAPL_LocStreamTransform(internal_state%locstream,VAR_TILE,VAR_GRID, RC=STATUS)
+    VERIFY_(STATUS)
+
+    ! destroy regridding fields so they can be reused
+    call ESMF_FieldDestroy(srcField,rc=STATUS); VERIFY_(STATUS)
+    call ESMF_FieldDestroy(dstField,rc=STATUS); VERIFY_(STATUS)
+
+  end subroutine mesh_to_tile
+
+  subroutine tile_to_mesh(VAR_TILE,VAR_MESH)
+    ! transform from landice tile to grid, then regrid onto mesh
+    real, pointer, dimension(:), intent(inout)     :: VAR_TILE           ! var on landice tiles
+    real(dp), pointer, dimension(:), intent(inout) :: VAR_MESH           ! var on mesh elements
+
+    real, pointer, dimension(:,:)                  :: VAR_GRID => null() ! var on attached grid
+    real(dp), pointer, dimension(:)                :: MESH_PTR           ! pointer for ESMF_FieldGet 
+    type(ESMF_Field)                               :: srcField
+    type(ESMF_Field)                               :: dstField
+    integer                                        :: num_owned_nodes
+    integer                                        :: num_nodes
+    integer                                        :: IM, JM, local_dims(3)   
+    integer                                        :: STATUS
+
+    ! get number of ndoes
+    call ESMF_MeshGet(internal_state%mesh,nodeCount=num_nodes,numOwnedNodes=num_owned_nodes,rc=STATUS)
+    VERIFY_(STATUS)
+
+    ! get grid dimensions
+    call MAPL_GridGet(internal_state%grid, localCellCountPerDim=local_dims, _RC)
+    IM = local_dims(1)
+    JM = local_dims(2)
+
+    ! allocate pointer on grid for regridding 
+    allocate(VAR_GRID(IM,JM), STAT=STATUS); VERIFY_(STATUS)
+  
+    ! transform from tile to grid
+    ! NOTE: we use the "transpose" option with MAPL_LocStreamTransformG2T 
+    ! (rather than MAPL_LocStreamTransformT2G) because the "default" value is zero
+    ! (rather than MAPL_UNDEF, which leads to errors when regridding onto mesh)
+    call MAPL_LocStreamTransform(internal_state%locstream, VAR_TILE, VAR_GRID, TRANSPOSE=.true., RC=STATUS)
+    VERIFY_(STATUS)
+
+    ! create source field on grid
+    srcField = ESMF_FieldCreate(grid=internal_state%grid,farrayPtr=VAR_GRID, datacopyflag=ESMF_DATACOPY_VALUE,rc=STATUS)
+    VERIFY_(STATUS)
+
+    ! create destination field on mesh elements
+    meshArray=ESMF_ArrayCreate(internal_state%nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=internal_state%halolist,rc=STATUS)
+    VERIFY_(STATUS)
+
+    ! create field on ISSM mesh
+    dstField=ESMF_FieldCreate(internal_state%mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, rc=STATUS)
+    VERIFY_(STATUS)
+
+    ! regrid from grid to mesh
+    call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_g2m, RC=STATUS); VERIFY_(STATUS)
+
+    ! append halo values to end of "owned" array
+    call ESMF_FieldHalo(dstField, routehandle=internal_state%halohandle, rc=STATUS); VERIFY_(STATUS)
+
+    ! get pointer to field on mesh
+    call ESMF_FieldGet(dstField,farrayPtr=MESH_PTR,RC=STATUS); VERIFY_(STATUS)
+
+    ! copy values into VAR_MESH
+    VAR_MESH(internal_state%owned_idx) = MESH_PTR(1:num_owned_nodes)          ! owned nodes
+    VAR_MESH(internal_state%halo_idx) = MESH_PTR(num_owned_nodes+1:num_nodes) ! halo nodes
+    
+    ! destroy fields and arrays so they can be reused
+    deallocate(VAR_GRID)
+    call ESMF_FieldDestroy(srcField,rc=STATUS);  VERIFY_(STATUS)
+    call ESMF_FieldDestroy(dstField,rc=STATUS);  VERIFY_(STATUS)
+    call ESMF_ArrayDestroy(meshArray,rc=STATUS); VERIFY_(STATUS)
+
+  end subroutine tile_to_mesh  
 
 end module GEOS_IssmGridCompMod


### PR DESCRIPTION
This PR introduces capability to continue ISSM runs across job segments when ISSM does not run during a segment, which may occur in the typical case where the ISSM time step is several days. 

**Major points:**

- ISSM's Run method is engaged every time Landice runs so that restarts persist. However, the 'core' ISSM C++ solvers (and regridding imports/exports) are only called at ISSM_DT time intervals.
- A custom ISSM_ALARM is created that keeps track of how many time steps have accrued since the last ISSM run (C++ solve), even if this happened in a previous job segment. The number of time steps since a previous run (ISSM_NSTEPS) is kept track of via a new INTERNAL state variable that is checkpointed. This variable ISSM_NSTEPS is used (along with timestep sizes) to create the new ISSM_ALARM. 
- Landice sends ISSM a running mean of the surface mass balance (ICESMB=ACCUM-RUNOFF) called ICESMB_ISSM. To keep this running calculation going across job segments, we use an internal state to get the restart value, as well as the timestep count ISSM_NSTEPS internal state variable.

