### PR TITLE
Port GEOSagcm/GEOShs/Superdyn gridcomps to MAPL3

### DIFF
--- a/GEOSagcm_GridComp/GEOS_AgcmSimpleGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmSimpleGridComp.F90
@@ -137,11 +137,11 @@ contains
       call MAPL_GridCompAddConnection(gc, &
            src_comp="PHYS", &
            dst_comp="SDYN", &
-           src_names="DUDT, DVDT, DTDT", _RC)
+           src_names="D_UV_DT, DTDT", _RC)
       call MAPL_GridCompAddConnection(gc, &
            src_comp="SDYN", &
            dst_comp="PHYS", &
-           src_names="UV, T, PLE", &
+           src_names="UV, T, PLE4", &
            dst_names="UV, TEMP, PLE", _RC)
       call MAPL_GridCompAddConnection(gc, &
            src_comp="<self>", &

--- a/GEOSagcm_GridComp/GEOShs_GridComp/GEOS_HsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/GEOS_HsGridComp.F90
@@ -176,16 +176,6 @@ contains
 #include "HS_Export___.h"
 #include "HS_Internal___.h"
 
-      ! TODO: pchakrab - till we have a way to specify a VECTOR in acg
-      call MAPL_GridCompAddSpec(gc, &
-           state_intent=ESMF_STATEINTENT_IMPORT, &
-           short_name="UV", &
-           standard_name="(eastward_wind, northward_wind)", &
-           dims="xyz", &
-           vstagger=VERTICAL_STAGGER_CENTER, &
-           units="m/s", &
-           itemtype=MAPL_STATEITEM_VECTOR, _RC)
-
       ! Set the Initialize and Run entry points
       call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_INITIALIZE, Initialize, _RC)
       call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_RUN, Run, phase_name="run", _RC)
@@ -216,7 +206,6 @@ contains
       real :: dx, dy, x0, y0, afac, phi0, qmax
       ! Pointers to internals
 #include "HS_DeclarePointer___.h"
-      real, pointer :: phis(:, :)
       integer :: status
 
       ! Get coordinate information
@@ -227,7 +216,12 @@ contains
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
 
       ! Get pointers to internal variables
-#include "HS_GetPointer___.h"
+      ! TODO: pchakrab - till ACG bug is fixed
+! #include "HS_GetPointer___.h"
+      call MAPL_StateGetPointer(internal, SPHI2,  'SPHI2' , _RC)
+      call MAPL_StateGetPointer(internal, CPHI2,  'CPHI2' , _RC)
+      call MAPL_StateGetPointer(internal, HFCN,  'HFCN' , _RC)
+      call MAPL_StateGetPointer(internal, P_I,  'P_I' , _RC)
 
       ! Initialize geometric factors
       SPHI2 = sin(lats)**2
@@ -296,17 +290,18 @@ contains
       type(ESMF_State) :: internal
       type(ESMF_Grid) :: grid
       type(ESMF_Logical) :: friendly
-      type(ESMF_FieldBundle) :: uv
+      type(ESMF_FieldBundle) :: tmp_bundle
 
       ! Pointers to imports/internals/exports
 #include "HS_DeclarePointer___.h"
       real, pointer, contiguous :: PLE0(:,:,:) ! 0-based PLE
       real, pointer :: u(:, :, :), v(:, :, :)
+      real, pointer, dimension(:, :, :) :: dudt, dvdt
 
       ! Scratch arrays and working pointers
       real, allocatable, dimension(:, :) :: pii, dp, pl, uu, vv, vr, te, f1, rr, ds, dm, pk
       real, pointer, dimension(:, :) :: ps, pt
-      integer :: level, im, jm, lm, fricq
+      integer :: field_count, level, im, jm, lm, fricq
       integer :: i1, in, j1, jn, status
       logical :: friendly_temp, friendly_wind
       real :: dt, ka, ks, kf
@@ -328,7 +323,32 @@ contains
 
       ! Pointers to internals
       call MAPL_GridCompGetInternalState(gc, internal, _RC)
-#include "HS_GetPointer___.h"
+      ! TODO: pchakrab - till ACG bug is fixed
+! #include "HS_GetPointer___.h"
+      call MAPL_StateGetPointer(export, DTDT,  'DTDT' , _RC)
+      DTDT = 0.0
+      ! DUDT/DVDT
+      call ESMF_StateGet(export, "D_UV_DT", tmp_bundle, _RC)
+      call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
+      if (field_count == 2) then ! export bundle is connected
+         call MAPL_FieldBundleGetPointer(tmp_bundle, 1, dudt, _RC)
+         call MAPL_FieldBundleGetPointer(tmp_bundle, 2, dvdt, _RC)
+      end if
+      call MAPL_StateGetPointer(export, T_EQ,  'T_EQ' , _RC)
+      call MAPL_StateGetPointer(export, THEQ,  'THEQ' , _RC)
+      call MAPL_StateGetPointer(export, TAUX,  'TAUX' , _RC)
+      call MAPL_StateGetPointer(export, TAUY,  'TAUY' , _RC)
+      call MAPL_StateGetPointer(export, DISS,  'DISS' , _RC)
+      call ESMF_StateGet(import, "UV", tmp_bundle, _RC) ! U/V
+      call MAPL_FieldBundleGetPointer(tmp_bundle, 1, u, _RC) ! U
+      call MAPL_FieldBundleGetPointer(tmp_bundle, 2, v, _RC) ! V
+      call MAPL_StateGetPointer(import, TEMP,  'TEMP' , _RC)
+      call MAPL_StateGetPointer(import, PLE,  'PLE' , _RC)
+      call MAPL_StateGetPointer(internal, SPHI2,  'SPHI2' , _RC)
+      call MAPL_StateGetPointer(internal, CPHI2,  'CPHI2' , _RC)
+      call MAPL_StateGetPointer(internal, HFCN,  'HFCN' , _RC)
+      call MAPL_StateGetPointer(internal, P_I,  'P_I' , _RC)
+
       ! Edge variable PLE is expected to be 0-based
       i1 = lbound(PLE, 1); in = ubound(PLE, 1); j1 = lbound(PLE, 2); jn = ubound(PLE, 2)
       PLE0(i1:in, j1:jn, 0:lm) => PLE(i1:in, j1:jn, 1:lm+1)
@@ -400,12 +420,6 @@ contains
       ka = 1.0 / (DAYLEN * taua)
       ks = 1.0 / (DAYLEN * taus)
       kf = 1.0 / (DAYLEN * tauf)
-
-      ! u/v
-      call ESMF_StateGet(import, "UV", uv, _RC)
-      call MAPL_FieldBundleGetPointer(uv, 1, u, _RC)
-      call MAPL_FieldBundleGetPointer(uv, 2, v, _RC)
-
       LEVELS: do level = 1, lm
 
          dp = (PLE0(:, :, level) - PLE0(:, :, level - 1))

--- a/GEOSagcm_GridComp/GEOShs_GridComp/GEOS_HsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/GEOS_HsGridComp.F90
@@ -326,13 +326,12 @@ contains
       ! TODO: pchakrab - till ACG bug is fixed
 ! #include "HS_GetPointer___.h"
       call MAPL_StateGetPointer(export, DTDT,  'DTDT' , _RC)
-      DTDT = 0.0
       ! DUDT/DVDT
-      call ESMF_StateGet(export, "D_UV_DT", tmp_bundle, _RC)
+      call ESMF_StateGet(export, "D_UV_DT", tmp_bundle, _RC) ! DUDT/DVDT
       call ESMF_FieldBundleGet(tmp_bundle, fieldCount=field_count, _RC)
       if (field_count == 2) then ! export bundle is connected
-         call MAPL_FieldBundleGetPointer(tmp_bundle, 1, dudt, _RC)
-         call MAPL_FieldBundleGetPointer(tmp_bundle, 2, dvdt, _RC)
+         call MAPL_FieldBundleGetPointer(tmp_bundle, 1, dudt, _RC) ! DUDT
+         call MAPL_FieldBundleGetPointer(tmp_bundle, 2, dvdt, _RC) ! DVDT
       end if
       call MAPL_StateGetPointer(export, T_EQ,  'T_EQ' , _RC)
       call MAPL_StateGetPointer(export, THEQ,  'THEQ' , _RC)

--- a/GEOSagcm_GridComp/GEOShs_GridComp/HS_StateSpecs.rc
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/HS_StateSpecs.rc
@@ -2,26 +2,24 @@ schema_version: 2.0.0
 component: HS
 
 category: EXPORT
-#------------------------------------------------
- SHORT_NAME | UNITS    | DIMS | VLOC | LONG_NAME
-#------------------------------------------------
- DTDT       | Pa K s-1 | xyz  | C    | pressure_weighted_air_temperature_tendency
- DUDT       | m s-2    | xyz  | C    | eastward_wind_tendency
- DVDT       | m s-2    | xyz  | C    | northward_wind_tendency
- T_EQ       | K        | xyz  | C    | equilibrium_temperature
- THEQ       | K        | xyz  | C    | equilibrium_potential_temperature
- TAUX       | N m-2    | xy   | N    | eastward_surface_stress
- TAUY       | N m-2    | xy   | N    | northward_surface_stress
- DISS       | W m-2    | xy   | N    | frictional_dissipation
+#-----------------------------------------------------------
+ SHORT_NAME | UNITS    | DIMS | itemtype | VLOC | LONG_NAME
+#-----------------------------------------------------------
+ DTDT       | Pa K s-1 | xyz  |          | C    | pressure_weighted_air_temperature_tendency
+ D_UV_DT    | m s-2    | xyz  | V        | C    | (eastward,northward)_wind_tendency
+ T_EQ       | K        | xyz  |          | C    | equilibrium_temperature
+ THEQ       | K        | xyz  |          | C    | equilibrium_potential_temperature
+ TAUX       | N m-2    | xy   |          | N    | eastward_surface_stress
+ TAUY       | N m-2    | xy   |          | N    | northward_surface_stress
+ DISS       | W m-2    | xy   |          | N    | frictional_dissipation
 
 category: IMPORT
-#-------------------------------------------------------
- SHORT_NAME | UNITS | DEFAULT | DIMS | VLOC | LONG_NAME
-#-------------------------------------------------------
-#U          | m s-1 | 0.0     | xyz  | C    | eastward_wind
-#V          | m s-1 | 0.0     | xyz  | C    | northward_wind
- TEMP       | K     | 300.0   | xyz  | C    | air_temperature
- PLE        | Pa    |         | xyz  | E    | edge_pressure
+#------------------------------------------------------------------
+ SHORT_NAME | UNITS | DEFAULT | DIMS | itemtype | VLOC | LONG_NAME
+#------------------------------------------------------------------
+ UV         | m s-1 | 0.0     | xyz  | V        | C    | (eastward,northward)_wind
+ TEMP       | K     | 300.0   | xyz  |          | C    | air_temperature
+ PLE        | Pa    |         | xyz  |          | E    | edge_pressure
 
 category: INTERNAL
 #-------------------------------------------------------------------

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/agcm-simple.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/agcm-simple.yaml
@@ -8,9 +8,12 @@ mapl:
     DataMoist:
       dso: libconfigurable_gridcomp
       config_file: data-moist.yaml
+      setservice: setservices_
+
     DataAna:
       dso: libconfigurable_gridcomp
       config_file: data-ana.yaml
+      setservice: setservices_
 
   connections:
     - src_name: TRADV

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOS_SuperdynGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOS_SuperdynGridComp.F90
@@ -120,9 +120,7 @@ contains
          call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="SHOBS", _RC)
       end if
 
-      ! Re-export, use MAPL_GridCompReexport(gc, src_comp="DYN", src_name="U", _RC)
-      ! call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="U", _RC)
-      ! call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="V", _RC)
+      ! Re-export
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="UV", _RC) ! vector
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="W", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="T", _RC)
@@ -141,8 +139,7 @@ contains
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="PKE", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="PS", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="DELP", _RC)
-      call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="US", _RC)
-      call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="VS", _RC)
+      call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="UV_S", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="TA", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="QA", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="SPEED", _RC)
@@ -168,8 +165,7 @@ contains
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="PE", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="QV_DYN_IN", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="T_DYN_IN", _RC)
-      call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="U_DYN_IN", _RC)
-      call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="V_DYN_IN", _RC)
+      call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="UV_DYN_IN", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="PLE_DYN_IN", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="DTDTDYN", _RC)
       call MAPL_GridCompReexport(gc, src_comp="DYN", src_name="DQVDTDYN", _RC)


### PR DESCRIPTION
## Summary

Ports GEOSagcm, GEOShs (Held-Suarez), and GEOSsuperdyn gridcomps to MAPL3.

### Changes

- Replace separate `DUDT`/`DVDT` exports with a single `D_UV_DT` vector export in `HS_StateSpecs.rc` and update connections in `GEOS_AgcmSimpleGridComp` accordingly
- Add `itemtype` column to `HS_StateSpecs.rc` import/export tables; replace individual U/V import entries with a single `UV` vector import; rename `PLE` -> `PLE4` in the AgcmSimple connection to match the FVdycoreCubed export name
- Replace ACG-generated `HS_GetPointer___.h` includes (broken by an ACG bug) with explicit `MAPL_StateGetPointer` calls in both Initialize and Run; move UV bundle pointer fetch to top of Run alongside the other state gets
- Remove unused `phis` pointer and `uv` FieldBundle variable; add `dudt`/`dvdt` pointers and `field_count` integer for the vector export path
- Remove stale UV manual `AddSpec` workaround in `GEOS_HsGridComp`
- Add explicit `setservice: setservices_` entries to regression YAML configs for DataMoist and DataAna components
- Clean up stale commented-out re-export lines in `GEOS_SuperdynGridComp`

## Related PRs
- FVdycoreCubed_GridComp: GEOS-ESM/FVdycoreCubed_GridComp#401