### PR TITLE
Port GEOShs_GridComp and GEOSagcm components to MAPL3 API

### DIFF
--- a/GEOSagcm_GridComp/GEOS_AgcmSimpleGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmSimpleGridComp.F90
@@ -16,12 +16,14 @@ module GEOS_AgcmSimpleGridCompMod
    !USES:
    use ESMF
    use MAPL, only: MAPL_GridCompSetEntryPoint
-   use MAPL, only: MAPL_GridCompAddSpec, user_setservices, MAPL_GridCompReexport
+   use MAPL, only: MAPL_GridCompAddSpec, MAPL_GridCompReexport
    use MAPL, only: MAPL_GridCompAddChild, MAPL_GridCompAddConnection
-   use MAPL, only: user_setservices, MAPL_StateGetPointer
+   use MAPL, only: MAPL_StateGetPointer
    use MAPL, only: MAPL_GridCompGet, MAPL_GridCompGetResource, MAPL_GridCompGetChildName
    use MAPL, only: MAPL_GridCompGetInternalState, MAPL_GridCompRunChild
-   use MAPL, only: VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, VERTICAL_STAGGER_NONE
+   use MAPL, only: MAPL_VERTICAL_STAGGER_CENTER
+   use MAPL, only: MAPL_VERTICAL_STAGGER_EDGE
+   use MAPL, only: MAPL_VERTICAL_STAGGER_NONE
    use MAPL, only: MAPL_RESTART_SKIP, MAPL_STATEITEM_SERVICE
    use MAPL, only: MAPL_Verify, MAPL_Return
    ! use GEOS_TopoGetMod, only: GEOS_TopoGet
@@ -97,7 +99,7 @@ contains
            standard_name="surface_geopotential_height", &
            units="m+2 s-2", &
            dims="xy", &
-           vstagger=VERTICAL_STAGGER_NONE, &
+           vertical_stagger=MAPL_VERTICAL_STAGGER_NONE, &
            add_to_export=.true., _RC)
       call MAPL_GridCompAddSpec(gc, &
            state_intent=ESMF_STATEINTENT_INTERNAL, &
@@ -105,7 +107,7 @@ contains
            standard_name="variance_of_filtered_topography", &
            units="m+2", &
            dims="xy", &
-           vstagger=VERTICAL_STAGGER_NONE, &
+           vertical_stagger=MAPL_VERTICAL_STAGGER_NONE, &
            add_to_export=.true., _RC)
 
       ! SUBSCRIBED "FAKE" spec to bundle tracers for FV3
@@ -122,12 +124,12 @@ contains
       !      standard_name='advected_quantities', &
       !      units="unknown", &
       !      dims="xyz", & ! TODO: we shouldn't need dims/vstagger for bundles
-      !      vstagger=VERTICAL_STAGGER_NONE, &
+      !      vertical_stagger=MAPL_VERTICAL_STAGGER_NONE, &
       !      itemtype=MAPL_STATEITEM_SERVICE, &
       !      service_items=service_items, _RC)
 
-      call MAPL_GridCompAddChild(gc, "SDYN", user_setservices(SDYN_SetServices), "superdyn.yaml", _RC)
-      call MAPL_GridCompAddChild(gc, "PHYS", user_setservices(PHYS_SetServices), "held-suarez.yaml", _RC)
+      call MAPL_GridCompAddChild(gc, "SDYN", SDYN_SetServices, "superdyn.yaml", _RC)
+      call MAPL_GridCompAddChild(gc, "PHYS", PHYS_SetServices, "held-suarez.yaml", _RC)
 
       ! TODO: pchakrab - we don't really need these, do we?
       ! call MAPL_GridCompReexport(gc, src_comp="SDYN", src_name="T", _RC)

--- a/GEOSagcm_GridComp/GEOShs_GridComp/GEOS_HsGridComp.F90
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/GEOS_HsGridComp.F90
@@ -129,7 +129,9 @@ module GEOS_HSGridCompMod
    use ESMF
    use MAPL, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompAddSpec
    use MAPL, only: MAPL_GridCompGet, MAPL_GridCompGetInternalState, MAPL_GridCompGetResource
-   use MAPL, only: VERTICAL_STAGGER_CENTER, VERTICAL_STAGGER_EDGE, VERTICAL_STAGGER_NONE
+   use MAPL, only: MAPL_VERTICAL_STAGGER_CENTER
+   use MAPL, only: MAPL_VERTICAL_STAGGER_EDGE
+   use MAPL, only: MAPL_VERTICAL_STAGGER_NONE
    use MAPL, only: MAPL_GridGet, MAPL_GridGetCoordinates
    use MAPL, only: MAPL_StateGetPointer, MAPL_FieldBundleGetPointer
    use MAPL, only: MAPL_RESTART_SKIP, MAPL_STATEITEM_VECTOR
@@ -294,7 +296,6 @@ contains
 
       ! Pointers to imports/internals/exports
 #include "HS_DeclarePointer___.h"
-      real, pointer, contiguous :: PLE0(:,:,:) ! 0-based PLE
       real, pointer :: u(:, :, :), v(:, :, :)
       real, pointer, dimension(:, :, :) :: dudt, dvdt
 
@@ -347,10 +348,6 @@ contains
       call MAPL_StateGetPointer(internal, CPHI2,  'CPHI2' , _RC)
       call MAPL_StateGetPointer(internal, HFCN,  'HFCN' , _RC)
       call MAPL_StateGetPointer(internal, P_I,  'P_I' , _RC)
-
-      ! Edge variable PLE is expected to be 0-based
-      i1 = lbound(PLE, 1); in = ubound(PLE, 1); j1 = lbound(PLE, 2); jn = ubound(PLE, 2)
-      PLE0(i1:in, j1:jn, 0:lm) => PLE(i1:in, j1:jn, 1:lm+1)
 
       ! Get parameters from the configuration
 
@@ -405,8 +402,8 @@ contains
       allocate(pk(im, jm), _STAT)
 
       ! Begin calculations.
-      ps => PLE0(:, :, lm)
-      pt => PLE0(:, :, 0)
+      ps => PLE(:, :, lm+1)
+      pt => PLE(:, :, 1)
 
       pii = p_d - (p_d - pt) * 0.5 * P_I
 
@@ -421,8 +418,8 @@ contains
       kf = 1.0 / (DAYLEN * tauf)
       LEVELS: do level = 1, lm
 
-         dp = (PLE0(:, :, level) - PLE0(:, :, level - 1))
-         pl = (PLE0(:, :, level) + PLE0(:, :, level - 1)) * 0.5
+         dp = (PLE(:, :, level+1) - PLE(:, :, level))
+         pl = (PLE(:, :, level+1) + PLE(:, :, level)) * 0.5
          dm = dp / MAPL_GRAV
          pk = (pl / MAPL_P00)**MAPL_KAPPA
 

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
@@ -8,7 +8,7 @@ macro(run_case CASE)
   # Run the case
   set(num_procs "6")
   execute_process(
-    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${num_procs} -prepend-rank ${MPIEXEC_PREFLAGS} ${MY_BINARY_DIR}/GEOS.x cap.yaml
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${num_procs} ${MPIEXEC_PREFLAGS} ${MY_BINARY_DIR}/GEOS.x cap.yaml
     RESULT_VARIABLE CMD_RESULT
     WORKING_DIRECTORY ${tempdir}
     COMMAND_ECHO STDOUT


### PR DESCRIPTION
## Summary

This PR ports several components to the MAPL3 API as part of the ongoing MAPL v3 migration.

## Changes

- **Port `GEOS_AgcmSimpleGridComp` to MAPL3 API**
- **Use 1-based PLE indexing directly**, replacing 0-based pointer alias
- **Fix regression test runner**: remove `-prepend-rank` flag from `mpirun` command in `GEOShs_GridComp` regression — this flag is not universally supported across MPI implementations

## Testing

Regression tests (`ctest -L REGRESSION`) pass with these changes.