### PR TITLE
Hotfix for M21C: Read and apply climatological precipitation rescaling factors

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -5136,8 +5136,8 @@ module GEOS_SurfaceGridCompMod
     type (ESMF_Field)                   :: Field
     type (ESMF_Grid)                    :: GRID
     type (ESMF_Time)                    :: CurrentTime
-    character(len=ESMF_MAXSTR)          :: PRECIP_FILE
-    character(len=ESMF_MAXSTR)          :: PRECIP_SCALE_FILE
+    character(len=ESMF_MAXPATHLEN)      :: PRECIP_FILE
+    character(len=ESMF_MAXPATHLEN)      :: PRECIP_FILE_CLIMSCALE
 
     type (T_SURFACE_STATE), pointer     :: surf_internal_state 
     type (SURF_wrap)                    :: wrap
@@ -6230,7 +6230,7 @@ module GEOS_SurfaceGridCompMod
 
     ! for now, do not allow the combination of precip replacement and clim rescaling
     
-    _ASSERT( .not. (PRECIP_FILE /= "null" .and. PRECIP_FILE_CLIMSCALE /= "null"), &
+    _ASSERT( .not. (trim(PRECIP_FILE) /= "null" .and. trim(PRECIP_FILE_CLIMSCALE) /= "null"), &
          "only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set" )
     
 ! These exports are the rainfalls and total snowfall that
@@ -6265,7 +6265,7 @@ module GEOS_SurfaceGridCompMod
     ICE = ICEFL
     FRZR= FRZRFL
 
-    REPLACE_PRECIP: if(PRECIP_FILE /= "null" .or. PRECIP_FILE_CLIMSCALE /= "null") then
+    REPLACE_PRECIP: if(trim(PRECIP_FILE) /= "null" .or. trim(PRECIP_FILE_CLIMSCALE) /= "null") then
 
        bundle = ESMF_FieldBundleCreate (NAME='PRECIP', RC=STATUS)
        VERIFY_(STATUS)
@@ -6287,7 +6287,7 @@ module GEOS_SurfaceGridCompMod
                           RC=STATUS )
        VERIFY_(STATUS)
        
-       if(PRECIP_FILE /= "null") then
+       if( trim(PRECIP_FILE) /= "null") then
           
           ! read corrected precip (PTTe) directly from (hourly) file if file exists (crashes otherwise?)
           
@@ -7431,7 +7431,7 @@ module GEOS_SurfaceGridCompMod
        VERIFY_(STATUS)
 
        ! Do not correct the precip over ocean tiles
-       if(Precip_File /= "null") then
+       if( trim(Precip_File) /= "null"  .or. trim(PRECIP_FILE_CLIMSCALE) /= "null" ) then
 
           call MAPL_LocStreamTransform( LOCSTREAM, TMPTILE  , PCU,     RC=STATUS); VERIFY_(STATUS)
           where(tiletype == MAPL_OCEAN)  PCUTILE = TMPTILE
@@ -7451,7 +7451,7 @@ module GEOS_SurfaceGridCompMod
        end if
 
        ! Adjust the discharge going to the ocean
-       if(Precip_File /= "null" .and. DischargeAdjustFile /= "null") then
+       if( (trim(Precip_File) /= "null"  .or. trim(PRECIP_FILE_CLIMSCALE) /= "null") .and. DischargeAdjustFile /= "null") then
 
           call MAPL_GetPointer(INTERNAL, DISCHARGE_ADJUST, 'DISCHARGE_ADJUST',  RC=STATUS)
           VERIFY_(STATUS)
@@ -7490,7 +7490,7 @@ module GEOS_SurfaceGridCompMod
     call MAPL_GetPointer(EXPORT, CN_PRCP, 'CN_PRCP', ALLOC=.true., RC=STATUS)
     VERIFY_(STATUS)
 
-    if(PRECIP_FILE /= "null") then
+    if( trim(PRECIP_FILE) /= "null" .or. trim(PRECIP_FILE_CLIMSCALE) /= "null" ) then
        TMPTILE = PCUTILE
        call MAPL_LocStreamTransform( LOCSTREAM, CN_PRCP, TMPTILE, RC=STATUS)
        VERIFY_(STATUS)
@@ -7503,7 +7503,7 @@ module GEOS_SurfaceGridCompMod
     call MAPL_GetPointer(EXPORT, PRECTOT, 'PRECTOT', ALLOC=.true., RC=STATUS)
     VERIFY_(STATUS)
 
-    if(PRECIP_FILE /= "null") then
+    if( trim(PRECIP_FILE) /= "null" .or. trim(PRECIP_FILE_CLIMSCALE) /= "null" ) then
        TMPTILE = PCUTILE + PLSTILE + SNOFLTILE + ICEFLTILE + FRZRFLTILE
        call MAPL_LocStreamTransform( LOCSTREAM, PRECTOT, TMPTILE, RC=STATUS)
        VERIFY_(STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -5137,6 +5137,7 @@ module GEOS_SurfaceGridCompMod
     type (ESMF_Grid)                    :: GRID
     type (ESMF_Time)                    :: CurrentTime
     character(len=ESMF_MAXSTR)          :: PRECIP_FILE
+    character(len=ESMF_MAXSTR)          :: PRECIP_SCALE_FILE
 
     type (T_SURFACE_STATE), pointer     :: surf_internal_state 
     type (SURF_wrap)                    :: wrap
@@ -6226,6 +6227,26 @@ module GEOS_SurfaceGridCompMod
                                         RC=STATUS )
     VERIFY_(STATUS)
 
+! Read in precip scale data as a second option to get "corrected" precip 
+!------------------------------------------------------
+    
+    call MAPL_GetResource(MAPL,PRECIP_SCALE_FILE,LABEL="PRECIP_SCALE_FILE:",default="null", RC=STATUS)
+    VERIFY_(STATUS)
+
+    call ESMF_ClockGet(CLOCK, currTime=CurrentTime, rc=STATUS)     
+    VERIFY_(STATUS)
+    call ESMF_TimeGet (currentTime,               &                
+                       YY=YEAR, MM=MONTH, DD=DAY, &
+                       H=HR,    M=MN,     S=SE,   &
+                                        RC=STATUS ) 
+    VERIFY_(STATUS)  
+    ! daily climatology, only need month/day information                   
+    call ESMF_TimeSet (currentTime,               &
+                       YY=8888, MM=MONTH, DD=DAY, & 
+                       H=0,    M =0,    S = 0,  & 
+                                        RC=STATUS ) 
+    VERIFY_(STATUS)
+
 
 ! These exports are the rainfalls and total snowfall that
 !  the children of surface see. They can be the exports of
@@ -6263,19 +6284,32 @@ module GEOS_SurfaceGridCompMod
 !  a "corrected" precip according to Rolf et al. This was used in MERRA-2 and
 !  would typically be done one during reanalysis or replay. Also, OGCM-coupled
 !  replays require special treatment.
+! Option to read a scale factor and compute the "corrected" precipiation to 
+! address IMERG-Late v7B quality issues.
 !-----------------------------------------------------------------------------
 
-    REPLACE_PRECIP: if(PRECIP_FILE /= "null") then
+    REPLACE_PRECIP: if(PRECIP_FILE /= "null" or PRECIP_FILE /= "null") then
 
        bundle = ESMF_FieldBundleCreate (NAME='PRECIP', RC=STATUS)
        VERIFY_(STATUS)
        call ESMF_FieldBundleSet(bundle, GRID=GRID, RC=STATUS)
        VERIFY_(STATUS)
 
-       call MAPL_read_bundle( Bundle,PRECIP_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
-       VERIFY_(STATUS)
-       call ESMFL_BundleGetPointerToData(Bundle,'PRECTOT',PTTe, RC=STATUS)
-       VERIFY_(STATUS)
+       if(PRECIP_FILE /= "null") then
+          ! read corrected precip (PTTe) directly from file if file exists
+          call MAPL_read_bundle( Bundle,PRECIP_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
+          VERIFY_(STATUS)
+          call ESMFL_BundleGetPointerToData(Bundle,'PRECTOT',PTTe, RC=STATUS)
+          VERIFY_(STATUS)
+       else
+          ! read scale factor from file and apply to uncorrected precip (PRECSUM) 
+          ! to create the "corrected" precip (PTTe)
+          call MAPL_read_bundle( Bundle,PRECIP_SCALE_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
+          VERIFY_(STATUS)
+          call ESMFL_BundleGetPointerToData(Bundle,'factor_clim',PTTe, RC=STATUS)
+          PTTe = PTTe * PRECSUM
+          VERIFY_(STATUS)
+       end if
 
 
 ! Catchment required convective and large-scale rain and total snowfall,

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -6295,6 +6295,11 @@ module GEOS_SurfaceGridCompMod
        call ESMF_FieldBundleSet(bundle, GRID=GRID, RC=STATUS)
        VERIFY_(STATUS)
 
+       allocate( PRECSUM(IM,JM), stat=STATUS )
+       VERIFY_(STATUS)
+
+       PRECSUM = RCU+RLS+SNO+ICE+FRZR
+
        if(PRECIP_FILE /= "null") then
           ! read corrected precip (PTTe) directly from file if file exists
           call MAPL_read_bundle( Bundle,PRECIP_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
@@ -6329,11 +6334,7 @@ module GEOS_SurfaceGridCompMod
 
        allocate( PCSCALE(IM,JM), stat=STATUS )
        VERIFY_(STATUS)
-       allocate( PRECSUM(IM,JM), stat=STATUS )
-       VERIFY_(STATUS)
 
-       PRECSUM = RCU+RLS+SNO+ICE+FRZR
-       
        where (PTTe == MAPL_UNDEF)
           RCU = PCU
           RLS = PLS

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -6208,46 +6208,31 @@ module GEOS_SurfaceGridCompMod
 
     end if
 
-! Read in precip data. This is used in 'coupled' replay
-!------------------------------------------------------
+! Read in precip or precip clim scaling data. This is used in 'coupled' replay
+!-----------------------------------------------------------------------------
+! This code is used to have the surface components (land, salwater, etc.) see
+!  a "corrected" precip according to Rolf et al. This was used in MERRA-2 and
+!  would typically be done during reanalysis or replay. Also, OGCM-coupled
+!  replays require special treatment.
+! Alternatively, read climatological scaling factors that convert the model
+!  precipitation to an observed climatology.  This rescaled precip is then
+!  processed just like the "corrected" precipitation (that is, disaggregated
+!  into components and tapered with the (raw) model precipitation.  Introduced 
+!  for M21C to address IMERG-Late V07B quality issues while preserving the
+!  climatology of the corrected precip after the end of IMERG-Final on data-day 1 Oct 2025.
+!------------------------------------------------------------------------------------------
 
-    call MAPL_GetResource(MAPL,PRECIP_FILE,LABEL="PRECIP_FILE:",default="null", RC=STATUS)
+    call MAPL_GetResource(MAPL,PRECIP_FILE,          LABEL="PRECIP_FILE:",          default="null", RC=STATUS)
     VERIFY_(STATUS)
-
-    call ESMF_ClockGet(CLOCK, currTime=CurrentTime, rc=STATUS)
-    VERIFY_(STATUS)
-    call ESMF_TimeGet (currentTime,               &
-                       YY=YEAR, MM=MONTH, DD=DAY, &
-                       H=HR,    M=MN,     S=SE,   &
-                                        RC=STATUS )
-    VERIFY_(STATUS)
-    call ESMF_TimeSet (currentTime,               &
-                       YY=YEAR, MM=MONTH, DD=DAY, &
-                       H=HR,    M =30,    S = 0,  &
-                                        RC=STATUS )
-    VERIFY_(STATUS)
-
-! Read in precip scale data as a second option to get "corrected" precip 
-!------------------------------------------------------
     
-    call MAPL_GetResource(MAPL,PRECIP_SCALE_FILE,LABEL="PRECIP_SCALE_FILE:",default="null", RC=STATUS)
+    call MAPL_GetResource(MAPL,PRECIP_FILE_CLIMSCALE,LABEL="PRECIP_FILE_CLIMSCALE:",default="null", RC=STATUS)
     VERIFY_(STATUS)
 
-    call ESMF_ClockGet(CLOCK, currTime=CurrentTime, rc=STATUS)     
-    VERIFY_(STATUS)
-    call ESMF_TimeGet (currentTime,               &                
-                       YY=YEAR, MM=MONTH, DD=DAY, &
-                       H=HR,    M=MN,     S=SE,   &
-                                        RC=STATUS ) 
-    VERIFY_(STATUS)  
-    ! daily climatology, only need month/day information                   
-    call ESMF_TimeSet (currentTime,               &
-                       YY=8888, MM=MONTH, DD=DAY, & 
-                       H=0,    M =0,    S = 0,  & 
-                                        RC=STATUS ) 
-    VERIFY_(STATUS)
-
-
+    ! for now, do not allow the combination of precip replacement and clim rescaling
+    
+    _ASSERT( .not. (PRECIP_FILE /= "null" .and. PRECIP_FILE_CLIMSCALE /= "null"), &
+         "only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set" )
+    
 ! These exports are the rainfalls and total snowfall that
 !  the children of surface see. They can be the exports of
 !  moist or can be read from a file.
@@ -6280,15 +6265,7 @@ module GEOS_SurfaceGridCompMod
     ICE = ICEFL
     FRZR= FRZRFL
 
-! This code is used to have the surface components (land, salwater, etc.) see
-!  a "corrected" precip according to Rolf et al. This was used in MERRA-2 and
-!  would typically be done one during reanalysis or replay. Also, OGCM-coupled
-!  replays require special treatment.
-! Option to read a scale factor and compute the "corrected" precipiation to 
-! address IMERG-Late v7B quality issues.
-!-----------------------------------------------------------------------------
-
-    REPLACE_PRECIP: if(PRECIP_FILE /= "null" or PRECIP_FILE /= "null") then
+    REPLACE_PRECIP: if(PRECIP_FILE /= "null" .or. PRECIP_FILE_CLIMSCALE /= "null") then
 
        bundle = ESMF_FieldBundleCreate (NAME='PRECIP', RC=STATUS)
        VERIFY_(STATUS)
@@ -6300,16 +6277,45 @@ module GEOS_SurfaceGridCompMod
 
        PRECSUM = RCU+RLS+SNO+ICE+FRZR
 
+       ! get and parse current time (needed to create file time stamp)
+       
+       call ESMF_ClockGet(CLOCK, currTime=CurrentTime, rc=STATUS)
+       VERIFY_(STATUS)
+       call ESMF_TimeGet (currentTime,               &
+                          YY=YEAR, MM=MONTH, DD=DAY, &
+                          H=HR,    M=MN,     S=SE,   &
+                          RC=STATUS )
+       VERIFY_(STATUS)
+       
        if(PRECIP_FILE /= "null") then
-          ! read corrected precip (PTTe) directly from file if file exists
-          call MAPL_read_bundle( Bundle,PRECIP_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
+          
+          ! read corrected precip (PTTe) directly from (hourly) file if file exists (crashes otherwise?)
+          
+          call ESMF_TimeSet (currentTime,               &
+                             YY=YEAR, MM=MONTH, DD=DAY, &
+                             H=HR,    M =30,    S = 0,  &
+                             RC=STATUS )
+          VERIFY_(STATUS)
+          
+          call MAPL_read_bundle( Bundle, PRECIP_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
           VERIFY_(STATUS)
           call ESMFL_BundleGetPointerToData(Bundle,'PRECTOT',PTTe, RC=STATUS)
           VERIFY_(STATUS)
+          
        else
-          ! read scale factor from file and apply to uncorrected precip (PRECSUM) 
+          
+          ! read clim scale factor from file and apply to uncorrected (model) precip (PRECSUM) 
           ! to create the "corrected" precip (PTTe)
-          call MAPL_read_bundle( Bundle,PRECIP_SCALE_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
+          
+          ! climatology is daily, only need month/day information, use leap year (8888) as nominal year
+          ! (matching time stamps in files)
+          call ESMF_TimeSet (currentTime,               &
+                             YY=8888, MM=MONTH, DD=DAY, & 
+                             H=0,     M =0,     S = 0,  & 
+                             RC=STATUS ) 
+          VERIFY_(STATUS)
+                    
+          call MAPL_read_bundle( Bundle, PRECIP_FILE_CLIMSCALE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
           VERIFY_(STATUS)
           call ESMFL_BundleGetPointerToData(Bundle,'factor_clim',PTTe, RC=STATUS)
           PTTe = PTTe * PRECSUM


### PR DESCRIPTION
REPLACED BY PR #1468 (MERGED)

---

The modification implements Rolf's suggestion as follows. @gmao-rreichle @mathomp4 

"The M21C corrected precip (and thus the land variables) are bad in the Tropics (20S-20N) after the switch from IMERG-Final to IMERG-Late on 1 Oct 2025, and the problem is with the IMERG-Late data. 

The best fix that I can think of right now is to add a new option in the GCM executable.  This new option rescales the model precip to the IMERG-Final climatology using seasonally varying scaling parameters (as opposed to replacing it with the precip from the corrected precip files).  This option requires new (scaling) files and a new DAS tag, which is a tall order.  But the fix addresses the two most important things: (1) It removes IMERG-Late from the system entirely and (2) avoids a step change in the M21C soil moisture, ET, etc climatology in Oct 2025."

**Update on AGCM Testing:** @sdrabenh @gmao-rreichle 
AGCM testing was completed using the current m21c precipitation setting versus the new climatological factor setting.

Current (PRECIP_FILE):
`ExtData/PCP/precip_corr_R21C/diag/Y%y4/M%m2/R21C.tavg_1hr_prcpcorr_c360_sfc.%y4%m2%d2_%h230.nc4`
New (PRECIP_FILE_CLIMSCALE): 
`/home/qliu/pclim_scale/M21CtoIMGv7BF.precip_clim_scale.%y4%m2%d2.nc4`

Beginning with data-day 1 Oct 2025 (after the end of IMERG-Final data), the M21C config needs to be changed.  The rc variable PRECIP_FILE needs to be commented out in the config.  A new rc variable PRECIP_FILE_CLIMSCALE needs to be added that points to the new "precip_clim_scale" files.

**Testing Results:**
When using the IMERG-Final based corrections ("PRECIP_FILE") in the AGCM, the output PREC[xxx] and PREC[xxx]CORR variables show zero differences (0-diff) when compared against the GEOSgcm R21 branch. 
When using the climatological rescaling ("PRECIP_FILE_CLIMSCALE") in the AGCM, the new setting works as intended.

**Additional Testing To Be Done:**
The 0-diff test for PRECIP_FILE should be done with the M21C ADAS.
The new PRECIP_FILE_CLIMSCALE functionality needs to be verified with the M21C ADAS