### PR TITLE
Refactor GEOShs regression test infrastructure

### DIFF
--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/CMakeLists.txt
@@ -1,55 +1,30 @@
-# Detect if we are using Open MPI and add oversubscribe/bind-to/map-by flags
-string(REPLACE " " ";" MPI_Fortran_LIBRARY_VERSION_LIST ${MPI_Fortran_LIBRARY_VERSION_STRING})
-list(GET MPI_Fortran_LIBRARY_VERSION_LIST 0 MPI_Fortran_LIBRARY_VERSION_FIRSTWORD)
-if(MPI_Fortran_LIBRARY_VERSION_FIRSTWORD MATCHES "Open")
-  set(MPIEXEC_PREFLAGS "--oversubscribe;--bind-to;core;--map-by;core" CACHE STRING "Flags for mpiexec" FORCE)
-endif()
-
 file(STRINGS "cases.txt" TEST_CASES)
 
 if(APPLE)
   set(LD_PATH "DYLD_LIBRARY_PATH")
 else()
   set(LD_PATH "LD_LIBRARY_PATH")
+  # OpenMPI flags
+  string(REPLACE " " ";" MPI_Fortran_LIBRARY_VERSION_LIST ${MPI_Fortran_LIBRARY_VERSION_STRING})
+  list(GET MPI_Fortran_LIBRARY_VERSION_LIST 0 MPI_Fortran_LIBRARY_VERSION_FIRSTWORD)
+  if(MPI_Fortran_LIBRARY_VERSION_FIRSTWORD MATCHES "Open")
+    set(MPIEXEC_PREFLAGS "--oversubscribe;--bind-to;core;--map-by;core" CACHE STRING "Flags for mpiexec" FORCE)
+  endif()
 endif()
 
-string(ASCII 27 ESC)
-set(ORANGE "${ESC}[1;38;5;214m")
-set(RESET  "${ESC}[0m")
-
-# # Sync regression test data from S3 (skipped if aws CLI, API key, or internet is not available)
-# find_program(AWS_CLI aws)
-
-# set(_api_key_exists FALSE)
-# if(DEFINED ENV{AWS_API_KEY_GMAO_SITEAM_S3} AND NOT "$ENV{AWS_API_KEY_GMAO_SITEAM_S3}" STREQUAL "")
-#   set(_api_key_exists TRUE)
-# endif()
-
-# set(_internet_is_available FALSE)
-# file(DOWNLOAD https://www.nasa.gov/ ${CMAKE_BINARY_DIR}/.nasa_connectivity_test
-#   TIMEOUT 10
-#   STATUS _download_status
-# )
-# list(GET _download_status 0 _download_result)
-# if(_download_result EQUAL 0)
-#   set(_internet_is_available TRUE)
-# endif()
-# file(REMOVE ${CMAKE_BINARY_DIR}/.nasa_connectivity_test)
-
-# if(AWS_CLI AND _api_key_exists AND _internet_is_available)
-#   set(S3_URI "s3://gmao-usw2-si-team/regression-data")
-#   set(LOCAL_DIR "${CMAKE_BINARY_DIR}/regression-data")
-#   add_custom_target(sync_regression_data ALL
-#     COMMAND ${CMAKE_COMMAND} -E make_directory "${LOCAL_DIR}"
-#     COMMAND ${CMAKE_COMMAND} -DAWS_CLI=${AWS_CLI} -DS3_URI=${S3_URI} -DLOCAL_DIR=${LOCAL_DIR}
-#       -P ${CMAKE_CURRENT_SOURCE_DIR}/sync_data.cmake
-#     BYPRODUCTS "${LOCAL_DIR}"
-#     COMMENT "Syncing regression test data from ${S3_URI}"
-#     VERBATIM
-#   )
-# else()
-#   message(WARNING "${ORANGE}AWS CLI or AWS_API_KEY_GMAO_SITEAM_S3 not available - regression test data sync and comparisons will be skipped${RESET}")
-# endif()
+# Sync regression test data from S3
+set(HS_PATH GEOSagcm_GridComp/GEOShs_GridComp)
+set(REGRESSION_DATA_DIR ${CMAKE_BINARY_DIR}/regression-data/${HS_PATH})
+if (NOT EXISTS ${REGRESSION_DATA_DIR})
+  message(STATUS "Syncing regression data from S3: ${HS_PATH}")
+  esma_sync_data(
+    TARGET sync_regression_data_hs
+    URI "s3://gmao-usw2-si-team/regression-data/${HS_PATH}"
+    DESTINATION "${REGRESSION_DATA_DIR}"
+    CREDENTIALS_URL "https://llvsm4u7ij.execute-api.us-east-1.amazonaws.com/credentials"
+    ALL
+  )
+endif()
 
 # Regression tests
 foreach(TEST_CASE ${TEST_CASES})
@@ -61,6 +36,7 @@ foreach(TEST_CASE ${TEST_CASES})
       -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
       -DMY_BINARY_DIR=${CMAKE_BINARY_DIR}/bin
       "-DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}"
+      -DREGRESSION_DATA_DIR=${REGRESSION_DATA_DIR}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_case.cmake
   )
   set_tests_properties("${TEST_CASE}" PROPERTIES

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
@@ -1,54 +1,55 @@
-macro(run_case CASE)
-  string(RANDOM LENGTH 24 tempdir)
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${tempdir}
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/${CASE} ${tempdir}
-  )
-
-  # Run the case
-  set(num_procs "6")
+function(run_geos num_procs case_name expdir)
   execute_process(
     COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${num_procs} ${MPIEXEC_PREFLAGS} ${MY_BINARY_DIR}/GEOS.x cap.yaml
     RESULT_VARIABLE CMD_RESULT
-    WORKING_DIRECTORY ${tempdir}
+    WORKING_DIRECTORY ${expdir}
     COMMAND_ECHO STDOUT
   )
-  if(EXISTS ${tempdir}/PET0.ESMF_LogFile)
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E cat ${tempdir}/PET0.ESMF_LogFile
-    )
+  if(EXISTS ${expdir}/PET0.ESMF_LogFile)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E cat ${expdir}/PET0.ESMF_LogFile)
   endif()
   if(CMD_RESULT)
-    set(MSG "Error running ${CASE}")
-    message(FATAL_ERROR "${MSG}")
+    message(FATAL_ERROR "Error running ${case_name}")
   endif()
+endfunction()
 
-  # Compare output against baseline
-  set(BASELINE_DIR ${MY_BINARY_DIR}/../regression-data/GEOSagcm_GridComp/${CASE})
-  if(NOT EXISTS ${BASELINE_DIR})
-    string(ASCII 27 ESC)
-    set(ORANGE "${ESC}[1;38;5;214m")
-    set(RESET  "${ESC}[0m")
-    message(WARNING "${ORANGE}Baseline directory not found, skipping comparison: ${BASELINE_DIR}${RESET}")
+function(compare_results baseline_dir current_dir)
+  file(GLOB baseline_files ${baseline_dir}/*.nc)
+  foreach(baseline_file IN LISTS baseline_files)
+    get_filename_component(fname ${baseline_file} NAME)
+    message(STATUS "Comparing ${fname}")
+    execute_process(
+      COMMAND cmp ${baseline_file} ${current_dir}/${fname}
+      RESULT_VARIABLE CMP_RESULT
+      OUTPUT_VARIABLE CMP_OUTPUT
+      ERROR_VARIABLE CMP_OUTPUT
+    )
+    if(CMP_RESULT)
+      message(FATAL_ERROR "Files differ: ${fname}\n${CMP_OUTPUT}")
+    endif()
+  endforeach()
+endfunction()
+
+function(run_case case_name regression_data_dir)
+  string(RANDOM LENGTH 24 expdir)
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${expdir}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/${case_name} ${expdir}
+  )
+
+  set(num_procs "6")
+  set(checkpoints_dir ${regression_data_dir}/${case_name}/checkpoints/last)
+
+  run_geos(${num_procs} ${case_name} ${expdir})
+  if (NOT EXISTS ${checkpoints_dir})
+    message(WARNING "Baseline directory [${checkpoints_dir}] not found. Skipping comparison.")
   else()
-    file(GLOB baseline_files ${BASELINE_DIR}/*.nc)
-    foreach(baseline_file IN LISTS baseline_files)
-      get_filename_component(fname ${baseline_file} NAME)
-      message(STATUS "Comparing ${fname}")
-      execute_process(
-        COMMAND cmp ${baseline_file} ${tempdir}/checkpoints/last/${fname}
-        RESULT_VARIABLE CMP_RESULT
-        OUTPUT_VARIABLE CMP_OUTPUT
-        ERROR_VARIABLE CMP_OUTPUT
-      )
-      if(CMP_RESULT)
-        message(FATAL_ERROR "Files differ: ${fname}\n${CMP_OUTPUT}")
-      endif()
-    endforeach()
+    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last)
   endif()
 
   # execute_process(
-  #   COMMAND ${CMAKE_COMMAND} -E rm -rf ${tempdir}
+  #   COMMAND ${CMAKE_COMMAND} -E rm -rf ${expdir}
   # )
-endmacro()
-run_case(${TEST_CASE})
+endfunction()
+
+run_case(${TEST_CASE} ${REGRESSION_DATA_DIR})


### PR DESCRIPTION
## Summary

- Replace `run_case` macro with proper CMake functions (`run_case`, `run_geos`, `compare_results`) for better scoping and reuse
- Enable S3 regression data sync via `esma_sync_data()`, replacing the previously commented-out ad-hoc implementation
- Pass `REGRESSION_DATA_DIR` explicitly into `run_case.cmake` instead of deriving it from a hardcoded relative path
- Scope OpenMPI `MPIEXEC_PREFLAGS` detection inside the per-case loop
- Update baseline comparison path to `checkpoints/last/`
- Remove dead and commented-out code