### PR TITLE
Ability to run coupled model at different dt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GEOS_GcmGridComp.F90)
 
  ecbuild_declare_project()
   esma_add_library(${this}
-    SRCS GEOS_GcmGridComp.F90
+    SRCS GEOS_GcmGridComp.F90 gc2gc.F90
     SUBCOMPONENTS ${alldirs}
     DEPENDENCIES MAPL ESMF::ESMF)
 

--- a/GEOS_GcmGridComp.F90
+++ b/GEOS_GcmGridComp.F90
@@ -13,23 +13,24 @@ module GEOS_GcmGridCompMod
 
 ! !USES:
 
-   use ESMF
-   use MAPL
+  use ESMF
+  use MAPL
 
-   use GEOS_dataatmGridCompMod,  only:  DATAATM_SetServices => SetServices
-   use GEOS_AgcmGridCompMod,     only:  AGCM_SetServices => SetServices
-   use GEOS_mkiauGridCompMod,    only:  AIAU_SetServices => SetServices
-   use DFI_GridCompMod,          only:  ADFI_SetServices => SetServices
+  use GEOS_dataatmGridCompMod,  only:  DATAATM_SetServices => SetServices
+  use GEOS_AgcmGridCompMod,     only:  AGCM_SetServices => SetServices
+  use GEOS_mkiauGridCompMod,    only:  AIAU_SetServices => SetServices
+  use DFI_GridCompMod,          only:  ADFI_SetServices => SetServices
 #ifdef HAS_GIGATRAJ
-   use GEOS_GigatrajGridCompMod, only:  GigaTraj_SetServices => SetServices
+  use GEOS_GigatrajGridCompMod, only:  GigaTraj_SetServices => SetServices
 #endif
 
-   use GEOS_OgcmGridCompMod,     only:  OGCM_SetServices => SetServices
-   use GEOS_WgcmGridCompMod,     only:  WGCM_SetServices => SetServices
-   use MAPL_HistoryGridCompMod,  only:  Hist_SetServices => SetServices
-   use MAPL_HistoryGridCompMod,  only:  HISTORY_ExchangeListWrap
-   use iso_fortran_env
-
+  use GEOS_OgcmGridCompMod,     only:  OGCM_SetServices => SetServices
+  use GEOS_WgcmGridCompMod,     only:  WGCM_SetServices => SetServices
+  use MAPL_HistoryGridCompMod,  only:  Hist_SetServices => SetServices
+  use MAPL_HistoryGridCompMod,  only:  HISTORY_ExchangeListWrap
+  use iso_fortran_env
+  use gc2gc
+  
   implicit none
   private
 
@@ -72,6 +73,9 @@ type T_GCM_STATE
    private
    type (MAPL_LocStreamXFORM) :: XFORM_A2O
    type (MAPL_LocStreamXFORM) :: XFORM_O2A
+   type (T_GC2GC_STATE)       :: a2o_state
+   type (T_GC2GC_STATE)       :: o2a_state
+   type (T_GC2GC_STATE)       :: o2a_frndl ! This should be fixed in MAPL3
    type(ESMF_State)           :: impSKIN ! Ocean thin layer
    type(ESMF_State)           :: expSKIN
    type(ESMF_Alarm)           :: alarmOcn
@@ -169,6 +173,8 @@ contains
     integer                             :: REPLAY_FILE_REFERENCE_TIME
     integer                             :: iDUAL_OCEAN
 
+    type (T_GC2GC_STATE)                :: a2o_state, o2a_state
+    type (T_GC2GC_STATE)                :: o2a_frndl
 !=============================================================================
 
 ! Begin...
@@ -691,6 +697,123 @@ contains
     call ESMF_UserCompSetInternalState ( GC, 'GCM_state',wrap,status )
     VERIFY_(STATUS)
 
+!<<<<< BEGIN OF CONNECT section    
+    ! new part: describe the connections
+    ! the name MAPL is somewhat misleading
+
+    if (.not. seaIceT_extData) then
+       if (DO_CICE_THERMO <= 1) then
+          call a2o_state%set('HI','HSKINI', _RC)
+       endif
+       call a2o_state%set('SI','SSKINI', _RC)
+    endif
+    if (DO_CICE_THERMO == 0) then
+       if (.not. seaIceT_extData) then
+          call a2o_state%set('TI','TSKINI', _RC)
+       endif
+    endif
+
+    if (DO_CICE_THERMO == 1) then
+       call a2o_state%set('TI','TSKINI', _RC)
+       call a2o_state%set('FRACICE','FR', _RC)
+       call a2o_state%set('VOLICE','VOLICE', _RC)
+       call a2o_state%set('VOLSNO','VOLSNO', _RC)
+       call a2o_state%set('ERGICE','ERGICE', _RC)
+       call a2o_state%set('ERGSNO','ERGSNO', _RC)
+       call a2o_state%set('TAUAGE','TAUAGE', _RC)
+       call a2o_state%set('MPOND','VOLPOND', _RC)
+    endif
+
+    if (DO_CICE_THERMO /= 0) then
+       call a2o_state%set('TAUXW','TAUXW', _RC)
+       call a2o_state%set('TAUYW','TAUYW', _RC)
+    else
+       call a2o_state%set('TAUXW','TAUXO', _RC)
+       call a2o_state%set('TAUYW','TAUYO', _RC)
+    endif
+
+    call a2o_state%set('TAUXI','TAUXI', _RC)
+    call a2o_state%set('TAUYI','TAUYI', _RC)
+    call a2o_state%set('PENPAR','PENPAR', _RC)
+    call a2o_state%set('PENPAF','PENPAF', _RC)
+    call a2o_state%set('PENUVR','PENUVR', _RC)
+    call a2o_state%set('PENUVF','PENUVF', _RC)
+    call a2o_state%set('OUSTAR3','OUSTAR3', _RC)
+    call a2o_state%set('PS','PS', _RC)
+    call a2o_state%set('DISCHRG','DISCHARGE', _RC)
+
+    call a2o_state%set('LWFLX','AO_LWFLX', _RC)
+    call a2o_state%set('SHFLX','AO_SHFLX', _RC)
+    call a2o_state%set('QFLUX','AO_QFLUX', _RC)
+    call a2o_state%set('SNOW','AO_SNOW', _RC)
+    call a2o_state%set('RAIN','AO_RAIN', _RC)
+    call a2o_state%set('DRNIR','AO_DRNIR', _RC)
+    call a2o_state%set('DFNIR','AO_DFNIR', _RC)
+    if (DO_CICE_THERMO <= 1) then
+       call a2o_state%set('FRESH','FRESH', _RC)
+       call a2o_state%set('FSALT','FSALT', _RC)
+       call a2o_state%set('FHOCN','FHOCN', _RC)
+    endif
+    call a2o_state%set('PEN_OCN','PEN_OCN', _RC)
+
+    if(DO_OBIO/=0) then
+       call OBIO_A2O(a2o_state, DO_DATA_ATM4OCN, RC)
+    endif
+
+    ! o2a
+    if (DO_CICE_THERMO == 0) then
+       if (.not. seaIceT_extData) then
+          call o2a_frndl%set('TSKINI', 'TI', _RC)
+       endif
+    else
+       call o2a_frndl%set('TSKINI', 'TI', _RC)
+    endif
+
+       if (.not. seaIceT_extData) then
+         if (DO_CICE_THERMO <= 1) then
+            call o2a_frndl%set('HSKINI', 'HI', _RC)
+         endif
+         call o2a_frndl%set('SSKINI', 'SI', _RC)
+       endif
+
+       if (DO_CICE_THERMO == 1) then
+          call o2a_frndl%set('FR', 'FRACICE', _RC)
+          call o2a_frndl%set('VOLICE', 'VOLICE', _RC)
+          call o2a_frndl%set('VOLSNO', 'VOLSNO', _RC)
+          call o2a_frndl%set('ERGICE', 'ERGICE', _RC)
+          call o2a_frndl%set('ERGSNO', 'ERGSNO', _RC)
+          call o2a_frndl%set('TAUAGE', 'TAUAGE', _RC)
+          call o2a_frndl%set('VOLPOND', 'MPOND', _RC)
+       endif
+
+       call o2a_state%set('UW', 'UW', _RC)
+       call o2a_state%set('VW', 'VW', _RC)
+       call o2a_state%set('KPAR', 'KPAR', _RC)
+
+       if (DO_CICE_THERMO == 0) then
+          call o2a_state%set('FRACICE', 'FRACICE', _RC)
+          if (seaIceT_extData) then
+            call o2a_state%set('SEAICETHICKNESS', 'SEAICETHICKNESS', _RC)
+          endif
+       elseif (DO_CICE_THERMO == 1) then
+          call o2a_state%set('TAUXBOT', 'TAUXIBOT', _RC)
+          call o2a_state%set('TAUYBOT', 'TAUYIBOT', _RC)
+       else
+          call o2a_state%set('FRACICE', 'FRACICE', _RC)
+       end if
+
+       call o2a_state%set('UI', 'UI', _RC)
+       call o2a_state%set('VI', 'VI', _RC)
+
+! OGCM export of TS_FOUND and SS_FOUND to SKIN
+!---------------------------------------------
+        call o2a_state%set('TS_FOUND', 'TS_FOUND' , _RC)
+        call o2a_state%set('SS_FOUND', 'SS_FOUND' , _RC)
+        if (DO_CICE_THERMO == 1) then
+           call o2a_state%set('FRZMLT', 'FRZMLT', _RC)
+        end if
+
+!>>>>> END OF CONNECT section    
 
     call MAPL_GenericSetServices    ( GC, RC=STATUS )
     VERIFY_(STATUS)
@@ -718,6 +841,10 @@ contains
     call MAPL_TimerAdd(GC, name="--W2O"         ,RC=STATUS)
     VERIFY_(STATUS)
 
+    gcm_internal_state%a2o_state = a2o_state
+    gcm_internal_state%o2a_state = o2a_state
+! Attention (MAPL3)
+    gcm_internal_state%o2a_frndl = o2a_frndl
 
     RETURN_(ESMF_SUCCESS)
 
@@ -795,6 +922,34 @@ contains
       end subroutine OBIO_TerminateImports
 
   end subroutine SetServices
+
+  subroutine OBIO_A2O(a2o_state, DO_DATA_ATM4OCN, RC)
+
+    type (T_GC2GC_STATE),       intent(inout) :: a2o_state
+    logical,                    intent(IN   ) :: DO_DATA_ATM4OCN
+    integer, optional,          intent(  OUT) :: RC
+    
+    integer                                   :: STATUS
+     
+    call a2o_state%set('UU','UU', _RC)
+    call a2o_state%set('CO2SC','CO2SC', _RC)
+    call a2o_state%set('DUDP','DUDP', _RC)
+    call a2o_state%set('DUWT','DUWT', _RC)
+    call a2o_state%set('DUSD','DUSD', _RC)
+    
+    call a2o_state%set('DRBAND','DRBAND', _RC)
+    call a2o_state%set('DFBAND','DFBAND', _RC)
+
+    if(.not. DO_DATA_ATM4OCN) then
+       call a2o_state%set('BCDP','BCDP', _RC)
+       call a2o_state%set('BCWT','BCWT', _RC)
+       call a2o_state%set('OCDP','OCDP', _RC)
+       call a2o_state%set('OCWT','OCWT', _RC)
+    endif
+
+    _RETURN(ESMF_SUCCESS)
+  end subroutine OBIO_A2O
+
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1469,6 +1624,37 @@ contains
    !===================================
    end if
 
+   call ESMF_ClockGetAlarm(clock, alarmname=trim(GCNAMES(OGCM)) // '_Alarm', &
+                           alarm=GCM_INTERNAL_STATE%alarmOcn, _RC)
+!   call MAPL_GetObjectFromGC ( GCS(OGCM), CMAPL, _RC)
+!   call MAPL_Get(CMAPL, runAlarm=GCM_INTERNAL_STATE%alarmOcn, _RC)
+
+   !NEW CODE
+
+   block
+     integer :: DT, COUPLE_DT
+     type(ESMF_TimeInterval) :: ringInterval, timeStep
+     call ESMF_ClockGet(clock, timestep=timestep, _RC)
+     call ESMF_AlarmGet(GCM_INTERNAL_STATE%alarmOcn, ringInterval=ringInterval, _RC)
+     call ESMF_TimeIntervalGet(timeStep, s=DT, _RC)
+     call ESMF_TimeIntervalGet(ringInterval, s=COUPLE_DT, _RC)
+!DEBUG info
+     if (MAPL_Am_I_root()) then
+        print *,"DEBUG_INFO (dt):",DT, COUPLE_DT
+     end if
+     
+     call gcm_internal_state%a2o_state%set(DT=DT, COUPLE_DT=COUPLE_DT, _RC)
+
+     call gcm_internal_state%o2a_state%set(DT=COUPLE_DT, COUPLE_DT=COUPLE_DT, _RC)
+     call gcm_internal_state%o2a_frndl%set(DT=COUPLE_DT, COUPLE_DT=COUPLE_DT, _RC)
+   end block
+   
+! this need extra work, get a resource, etc
+!   call gcm_internal_state%a2o_state%set(average=.FALSE., _RC)
+   call gcm_internal_state%a2o_state%set(alarm=gcm_internal_state%alarmOcn, _RC)
+
+   !loop over cpld vars (say A2O)
+
 ! This part has some explicit hierarchy built in...
 !--------------------------------------------------------------
 
@@ -1480,6 +1666,27 @@ contains
                               GCM_INTERNAL_STATE%impSKIN, rc=status )
    VERIFY_(STATUS)
 
+   call gcm_internal_state%a2o_state%set( &
+        stateIn=GCM_INTERNAL_STATE%expSkin, stateOut=GIM(OGCM), &
+        name="A2O", _RC)
+
+   call gcm_internal_state%a2o_state%set( &
+        xform=GCM_INTERNAL_STATE%xform_a2o, _RC)
+
+   call gcm_internal_state%o2a_state%set( &
+        stateIn=GEX(OGCM), stateOut=GCM_INTERNAL_STATE%impSKIN, &
+        name="O2A", _RC)
+
+   call gcm_internal_state%o2a_state%set( &
+        xform=GCM_INTERNAL_STATE%xform_o2a, _RC)
+   
+   call gcm_internal_state%o2a_frndl%set( &
+        stateIn=GIM(OGCM), stateOut=GCM_INTERNAL_STATE%expSKIN, &
+        name="O2Afrdnl", _RC)
+
+   call gcm_internal_state%o2a_frndl%set( &
+        xform=GCM_INTERNAL_STATE%xform_o2a, _RC)
+   
    call AllocateExports(GCM_INTERNAL_STATE%expSKIN, &
         [ character(len=8) :: &
         'TAUXO    ', 'TAUYO    ','TAUXI    ', 'TAUYI    ', &
@@ -1529,9 +1736,9 @@ contains
       call AllocateExports_UGD(GEX(OGCM), (/'FRACICE '/), _RC)
    end if
 
-   call ESMF_ClockGetAlarm(clock, alarmname=trim(GCNAMES(OGCM)) // '_Alarm', &
-                           alarm=GCM_INTERNAL_STATE%alarmOcn, rc=status)
-   VERIFY_(STATUS)
+   call gcm_internal_state%a2o_state%g2ginitialize(clock, _RC)
+   call gcm_internal_state%o2a_state%g2ginitialize(clock, _RC)
+   call gcm_internal_state%o2a_frndl%g2ginitialize(clock, _RC)
 
 #ifdef PRINT_STATES
     call WRITE_PARALLEL ( trim(Iam)//": IMPORT State" )
@@ -1732,7 +1939,6 @@ contains
     character(len=ESMF_MAXSTR)    :: record_fname
     character(len=14)             :: DATESTAMP !YYYYMMDD_HHMMz
 
-    integer, dimension(NUM_ICE_CATEGORIES) :: SUBINDEXO, SUBINDEXA
     integer                                :: N
 
     TYPE(ESMF_Alarm)              :: PredictorIsActive
@@ -1774,12 +1980,6 @@ contains
     XFORM_O2A = GCM_INTERNAL_STATE%XFORM_O2A
     impSKIN   = GCM_INTERNAL_STATE%impSKIN
     expSKIN   = GCM_INTERNAL_STATE%expSKIN
-
-    do N=1,NUM_ICE_CATEGORIES
-       SUBINDEXO(N) = N
-      !SUBINDEXA(N) = N+1
-       SUBINDEXA(N) = N
-    enddo
 
 ! Get children and their im/ex states from my generic state.
 !----------------------------------------------------------
@@ -1904,10 +2104,10 @@ contains
                 ! ------------------------------
                 !    Ensure IAU tendencies are zero when running Predictor
                 !    if( MAPL_AM_I_Root() ) print *, 'Zeroing   IAU forcing ...'
-                     call ESMF_GridCompRun ( GCS(AIAU), importState=GIM(AIAU), exportState=GEX(AIAU), clock=clock, phase=2, userRC=status )
-                     VERIFY_(STATUS)
-                     call ESMF_GridCompRun ( GCS(AGCM), importState=GIM(AGCM), exportState=GEX(AGCM), clock=clock, userRC=status )
-                     VERIFY_(STATUS)
+                call ESMF_GridCompRun ( GCS(AIAU), importState=GIM(AIAU), exportState=GEX(AIAU), clock=clock, phase=2, userRC=status )
+                VERIFY_(STATUS)
+                call ESMF_GridCompRun ( GCS(AGCM), importState=GIM(AGCM), exportState=GEX(AGCM), clock=clock, userRC=status )
+                VERIFY_(STATUS)
 
                 if (.not. DUAL_OCEAN) then
                    if(DO_DATASEA /= 0) then
@@ -2097,6 +2297,10 @@ contains
     call ESMF_GridCompRun ( GCS(AGCM), importState=GIM(AGCM), exportState=GEX(AGCM), clock=clock, userRC=status )
     VERIFY_(STATUS)
 
+    call MAPL_TimerOn(MAPL,"--A2O_accmulate"  )
+    call gcm_internal_state%a2o_state%accumulate(clock,_RC)
+    call MAPL_TimerOff(MAPL,"--A2O_accmulate"  )
+
 #ifdef HAS_GIGATRAJ
     ! use agcm export as gigatraj's import
     call ESMF_GridCompRun ( GCS(gigatraj), importState=GEX(AGCM), exportState=GEX(gigatraj), clock=clock, phase=2, userRC=status )
@@ -2166,15 +2370,11 @@ contains
 
     if ( ESMF_AlarmIsRinging(GCM_INTERNAL_STATE%alarmOcn, RC=STATUS) ) then
        VERIFY_(STATUS)
-
+       
 !       time to couple and run ocean
 
 ! Synchronize for Next TimeStep
 ! -----------------------------
-
-       call ESMF_VMBarrier(VM, rc=status)
-       VERIFY_(STATUS)
-
 
        call MAPL_TimerOn(MAPL,"--A2O"  )
 
@@ -2182,114 +2382,15 @@ contains
 ! SURFACE exports to OGCM imports
 ! Example how to do TI, we need to do all of the OCGMimports
 
-! Copy attributes to deal with friendliness
-!------------------------------------------
-       if (.not. seaIceT_extData) then
-         call MAPL_CopyFriendliness(GIM(OGCM),'TI',expSKIN,'TSKINI' ,_RC)
-         call MAPL_CopyFriendliness(GIM(OGCM),'SI',expSKIN,'SSKINI', _RC)
-         if (DO_CICE_THERMO <= 1) then
-            call MAPL_CopyFriendliness(GIM(OGCM),'HI',expSKIN,'HSKINI', _RC)
-         endif
-       endif
-       if (DO_CICE_THERMO == 1) then
-          call MAPL_CopyFriendliness(GIM(OGCM),'FRACICE',expSKIN,'FR',    _RC)
-          call MAPL_CopyFriendliness(GIM(OGCM),'VOLICE',expSKIN,'VOLICE', _RC)
-          call MAPL_CopyFriendliness(GIM(OGCM),'VOLSNO',expSKIN,'VOLSNO', _RC)
-          call MAPL_CopyFriendliness(GIM(OGCM),'ERGICE',expSKIN,'ERGICE', _RC)
-          call MAPL_CopyFriendliness(GIM(OGCM),'ERGSNO',expSKIN,'ERGSNO', _RC)
-          call MAPL_CopyFriendliness(GIM(OGCM),'TAUAGE',expSKIN,'TAUAGE', _RC)
-          call MAPL_CopyFriendliness(GIM(OGCM),'MPOND',expSKIN,'VOLPOND', _RC)
-       endif
 
 ! Do the routing between the atm and ocean's decompositions of the exchage grid
 !------------------------------------------------------------------------------
-       if (.not. seaIceT_extData) then
-         if (DO_CICE_THERMO <= 1) then
-            call DO_A2O(GIM(OGCM),'HI'  ,expSKIN,'HSKINI' , _RC)
-         endif
-         call DO_A2O(GIM(OGCM),'SI'     ,expSKIN,'SSKINI' , _RC)
-       endif
-       if (DO_CICE_THERMO == 0) then
-         if (.not. seaIceT_extData) then
-            call DO_A2O(GIM(OGCM),'TI'  ,expSKIN,'TSKINI' , _RC)
-         endif
-       endif
+       call ESMF_VMBarrier(VM, _RC)
+       call gcm_internal_state%a2o_state%regrid(_RC)
+       call ESMF_VMBarrier(VM, _RC)
 
-       if (DO_CICE_THERMO == 1) then
-          call DO_A2O_SUBTILES_R4R4(GIM(OGCM),'TI'     , SUBINDEXO, &
-               expSKIN  ,'TSKINI' , SUBINDEXO, _RC)
-          call DO_A2O_SUBTILES_R4R8(GIM(OGCM),'FRACICE', SUBINDEXO, &
-               expSKIN  ,'FR'     , SUBINDEXA, _RC)
-          call DO_A2O_SUBTILES_R4R8(GIM(OGCM),'VOLICE' , SUBINDEXO, &
-               expSKIN  ,'VOLICE' , SUBINDEXO, _RC)
-          call DO_A2O_SUBTILES_R4R8(GIM(OGCM),'VOLSNO' , SUBINDEXO, &
-               expSKIN  ,'VOLSNO' , SUBINDEXO, _RC)
-          call DO_A2O_SUBTILES2D_R4R8(GIM(OGCM),'ERGICE' , SUBINDEXO, &
-               expSKIN  ,'ERGICE' , SUBINDEXO, &
-               NUM_ICE_LAYERS,                 _RC)
-          call DO_A2O_SUBTILES2D_R4R8(GIM(OGCM),'ERGSNO' , SUBINDEXO, &
-               expSKIN  ,'ERGSNO' , SUBINDEXO, &
-               NUM_SNOW_LAYERS,                _RC)
-          call DO_A2O_SUBTILES_R4R4(GIM(OGCM),'TAUAGE' , SUBINDEXO, &
-               expSKIN  ,'TAUAGE' , SUBINDEXO, _RC)
-          call DO_A2O_SUBTILES_R4R8(GIM(OGCM),'MPOND'   , SUBINDEXO, &
-               expSKIN  ,'VOLPOND' , SUBINDEXO, _RC)
-       endif
-
-       if (DO_CICE_THERMO /= 0) then
-          call DO_A2O(GIM(OGCM),'TAUXW'  ,expSKIN,'TAUXW'  , RC=STATUS); VERIFY_(STATUS)
-          call DO_A2O(GIM(OGCM),'TAUYW'  ,expSKIN,'TAUYW'  , RC=STATUS); VERIFY_(STATUS)
-       else
-          call DO_A2O(GIM(OGCM),'TAUXW'  ,expSKIN,'TAUXO'  , RC=STATUS); VERIFY_(STATUS)
-          call DO_A2O(GIM(OGCM),'TAUYW'  ,expSKIN,'TAUYO'  , RC=STATUS); VERIFY_(STATUS)
-       endif
-
-       call DO_A2O(GIM(OGCM),'TAUXI'  ,expSKIN,'TAUXI'  , RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'TAUYI'  ,expSKIN,'TAUYI'  , RC=STATUS)
-       VERIFY_(STATUS)
-
-       call DO_A2O(GIM(OGCM),'PENPAR' ,expSKIN,'PENPAR' , RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'PENPAF' ,expSKIN,'PENPAF' , RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'PENUVR' ,expSKIN,'PENUVR' , RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'PENUVF' ,expSKIN,'PENUVF' , RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'OUSTAR3',expSKIN,'OUSTAR3', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'PS'     ,expSKIN,'PS'     , RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'DISCHRG',expSKIN,'DISCHARGE', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'LWFLX',expSKIN,'AO_LWFLX', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'SHFLX',expSKIN,'AO_SHFLX', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'QFLUX',expSKIN,'AO_QFLUX', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'SNOW',expSKIN,'AO_SNOW', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'RAIN',expSKIN,'AO_RAIN', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'DRNIR',expSKIN,'AO_DRNIR', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O(GIM(OGCM),'DFNIR',expSKIN,'AO_DFNIR', RC=STATUS)
-       VERIFY_(STATUS)
-       if (DO_CICE_THERMO <= 1) then
-           call DO_A2O(GIM(OGCM),'FRESH'  ,expSKIN,'FRESH'  , _RC)
-           call DO_A2O(GIM(OGCM),'FSALT'  ,expSKIN,'FSALT'  , _RC)
-           call DO_A2O(GIM(OGCM),'FHOCN'  ,expSKIN,'FHOCN'  , _RC)
-       endif
-       call DO_A2O(GIM(OGCM),'PEN_OCN',expSKIN,'PEN_OCN', RC=STATUS)
-       VERIFY_(STATUS)
-
-       if(DO_OBIO/=0) then
-          call OBIO_A2O(DO_DATA_ATM4OCN, RC)
-       endif
        call MAPL_TimerOff(MAPL,"--A2O"  )
-
+       
 !--
 ! OGCM exports to SURFACE imports
 
@@ -2307,75 +2408,11 @@ contains
 
        call MAPL_TimerOn (MAPL,"--O2A"  )
 
-       if (DO_CICE_THERMO == 0) then
-         if (.not. seaIceT_extData) then
-           call DO_O2A(expSKIN, 'TSKINI'   , GIM(OGCM), 'TI'    , _RC)
-         endif
-       else
-         call DO_O2A_SUBTILES_R4R4(expSKIN  , 'TSKINI'     , SUBINDEXO,  &
-                                   GIM(OGCM), 'TI'         , SUBINDEXO, _RC)
-       endif
-
-       if (.not. seaIceT_extData) then
-         if (DO_CICE_THERMO <= 1) then
-            call DO_O2A(expSKIN, 'HSKINI'   , GIM(OGCM), 'HI'    , _RC)
-         endif
-         call DO_O2A(expSKIN, 'SSKINI'   , GIM(OGCM), 'SI'    , _RC)
-       endif
-
-       if (DO_CICE_THERMO == 1) then
-          call DO_O2A_SUBTILES_R8R4(expSKIN  , 'FR'         , SUBINDEXA,  &
-               GIM(OGCM), 'FRACICE'    , SUBINDEXO, RC=STATUS)
-          VERIFY_(STATUS)
-          call DO_O2A_SUBTILES_R8R4(expSKIN  , 'VOLICE'     , SUBINDEXO,  &
-               GIM(OGCM), 'VOLICE'     , SUBINDEXO, RC=STATUS)
-          VERIFY_(STATUS)
-          call DO_O2A_SUBTILES_R8R4(expSKIN  , 'VOLSNO'     , SUBINDEXO,  &
-               GIM(OGCM), 'VOLSNO'     , SUBINDEXO, RC=STATUS)
-          VERIFY_(STATUS)
-          call DO_O2A_SUBTILES2D_R8R4(expSKIN  , 'ERGICE'     , SUBINDEXO,  &
-               GIM(OGCM), 'ERGICE'     , SUBINDEXO,  &
-               NUM_ICE_LAYERS, RC=STATUS)
-          VERIFY_(STATUS)
-          call DO_O2A_SUBTILES2D_R8R4(expSKIN  , 'ERGSNO'     , SUBINDEXO,  &
-               GIM(OGCM), 'ERGSNO'     , SUBINDEXO,  &
-               NUM_SNOW_LAYERS, RC=STATUS)
-          VERIFY_(STATUS)
-          call DO_O2A_SUBTILES_R4R4(expSKIN  , 'TAUAGE'      , SUBINDEXO,  &
-               GIM(OGCM), 'TAUAGE'      , SUBINDEXO, RC=STATUS)
-          VERIFY_(STATUS)
-          call DO_O2A_SUBTILES_R8R4(expSKIN  , 'VOLPOND'     , SUBINDEXO,  &
-               GIM(OGCM), 'MPOND'       , SUBINDEXO, RC=STATUS)
-          VERIFY_(STATUS)
-       endif
-
-       call DO_O2A(impSKIN, 'UW'       , GEX(OGCM), 'UW'    , _RC)
-       call DO_O2A(impSKIN, 'VW'       , GEX(OGCM), 'VW'    , _RC)
-       call DO_O2A(impSKIN, 'KPAR'     , GEX(OGCM), 'KPAR'  , _RC)
-
-       if (DO_CICE_THERMO == 0) then
-          call DO_O2A(impSKIN, 'FRACICE'  , GEX(OGCM), 'FRACICE', _RC)
-          if (seaIceT_extData) then
-            call DO_O2A(impSKIN, 'SEAICETHICKNESS'  , GEX(OGCM), 'SEAICETHICKNESS', _RC)
-          endif
-       elseif (DO_CICE_THERMO == 1) then
-          call DO_O2A(impSKIN, 'TAUXBOT'  , GEX(OGCM), 'TAUXIBOT', _RC)
-          call DO_O2A(impSKIN, 'TAUYBOT'  , GEX(OGCM), 'TAUYIBOT', _RC)
-       else
-          call DO_O2A_SUBTILES_R4R4(impSKIN,   'FRACICE'  ,   SUBINDEXO,    &
-                                    GEX(OGCM), 'FRACICE'  ,   SUBINDEXO,  _RC)
-       end if
-
-       call DO_O2A(impSKIN, 'UI'       , GEX(OGCM), 'UI'    , _RC)
-       call DO_O2A(impSKIN, 'VI'       , GEX(OGCM), 'VI'    , _RC)
-
-! OGCM export of TS_FOUND and SS_FOUND to SKIN
-!---------------------------------------------
-        call DO_O2A(impSKIN, 'TS_FOUND' , GEX(OGCM), 'TS_FOUND' , _RC)
-        call DO_O2A(impSKIN, 'SS_FOUND' , GEX(OGCM), 'SS_FOUND' , _RC)
-        call DO_O2A(impSKIN, 'FRZMLT'   , GEX(OGCM), 'FRZMLT'   , _RC)
-
-        call ESMF_AlarmRingerOff(GCM_INTERNAL_STATE%alarmOcn, _RC)
+       call ESMF_VMBarrier(VM, _RC)
+       call gcm_internal_state%o2a_state%regrid(_RC)
+       call gcm_internal_state%o2a_frndl%regrid(_RC)
+       call ESMF_VMBarrier(VM, _RC)
+       call ESMF_AlarmRingerOff(GCM_INTERNAL_STATE%alarmOcn, _RC)
 
        call MAPL_TimerOff(MAPL,"--O2A"  )
 
@@ -2486,380 +2523,6 @@ contains
      RETURN_(ESMF_SUCCESS)
 
    end subroutine RUN_WAVES
-
-   subroutine OBIO_A2O(DO_DATA_ATM4OCN, RC)
-
-     logical,                    intent(IN   ) ::  DO_DATA_ATM4OCN
-     integer, optional,          intent(  OUT) ::  RC
-
-     integer                                   :: STATUS
-     integer          :: k
-
-     call DO_A2O(GIM(OGCM),'UU'     ,expSKIN,'UU'     , RC=STATUS)
-     VERIFY_(STATUS)
-     call DO_A2O(GIM(OGCM),'CO2SC'  ,expSKIN,'CO2SC'  , RC=STATUS)
-     VERIFY_(STATUS)
-
-     call DO_A2O_UGD(GIM(OGCM), 'DUDP', expSKIN, 'DUDP', RC=STATUS)
-     VERIFY_(STATUS)
-     call DO_A2O_UGD(GIM(OGCM), 'DUWT', expSKIN, 'DUWT', RC=STATUS)
-     VERIFY_(STATUS)
-     call DO_A2O_UGD(GIM(OGCM), 'DUSD', expSKIN, 'DUSD', RC=STATUS)
-     VERIFY_(STATUS)
-
-     call DO_A2O_UGD(GIM(OGCM), 'DRBAND', expSKIN, 'DRBAND', RC=STATUS)
-     VERIFY_(STATUS)
-     call DO_A2O_UGD(GIM(OGCM), 'DFBAND', expSKIN, 'DFBAND', RC=STATUS)
-     VERIFY_(STATUS)
-
-     if(.not. DO_DATA_ATM4OCN) then
-       call DO_A2O_UGD(GIM(OGCM), 'BCDP', expSKIN, 'BCDP', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O_UGD(GIM(OGCM), 'BCWT', expSKIN, 'BCWT', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O_UGD(GIM(OGCM), 'OCDP', expSKIN, 'OCDP', RC=STATUS)
-       VERIFY_(STATUS)
-       call DO_A2O_UGD(GIM(OGCM), 'OCWT', expSKIN, 'OCWT', RC=STATUS)
-       VERIFY_(STATUS)
-
-     endif
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine OBIO_A2O
-
-   subroutine DO_A2O(STATEO,NAMEO,STATEA,NAMEA,RC)
-     type(ESMF_State)          , intent(INOUT) ::  STATEO
-     type(ESMF_State)          , intent(INOUT) ::  STATEA
-     character(len=*)          , intent(IN   ) ::  NAMEO
-     character(len=*)          , intent(IN   ) ::  NAMEA
-     integer, optional,          intent(  OUT) ::  RC
-
-     character(len=ESMF_MAXSTR), parameter :: IAm="DO_A2O"
-     integer                               :: STATUS
-
-     real,    pointer :: ptrA(:) => null()
-     real,    pointer :: ptrO(:) => null()
-
-     call MAPL_GetPointer(STATEO, ptrO, NAMEO, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call MAPL_GetPointer(STATEA, ptrA, NAMEA, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-     if (associated(ptrO) .and. associated(ptrA)) then
-        call MAPL_LocStreamTransform( ptrO, XFORM_A2O, ptrA, RC=STATUS )
-        VERIFY_(STATUS)
-     end if
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine DO_A2O
-
-   subroutine DO_A2O_UGD(STATEO,NAMEO,STATEA,NAMEA,RC)
-     type(ESMF_State)          , intent(INOUT) ::  STATEO
-     type(ESMF_State)          , intent(INOUT) ::  STATEA
-     character(len=*)          , intent(IN   ) ::  NAMEO
-     character(len=*)          , intent(IN   ) ::  NAMEA
-     integer, optional,          intent(  OUT) ::  RC
-
-     character(len=ESMF_MAXSTR), parameter :: IAm="DO_A2O_UGD"
-     integer                               :: STATUS
-     integer                               :: N
-
-     real,    pointer :: ptrA(:,:) => null()
-     real,    pointer :: ptrO(:,:) => null()
-
-     call MAPL_GetPointer(STATEO, ptrO, NAMEO, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call MAPL_GetPointer(STATEA, ptrA, NAMEA, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-     if (associated(ptrO) .and. associated(ptrA)) then
-        do N = 1, size(ptrA,2)
-           call MAPL_LocStreamTransform( ptrO(:,N), XFORM_A2O, ptrA(:,N), RC=STATUS )
-           VERIFY_(STATUS)
-        end do
-     end if
-
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine DO_A2O_UGD
-
-   subroutine DO_O2A(STATEA,NAMEA,STATEO,NAMEO,RC)
-     type(ESMF_State)          , intent(INOUT) ::  STATEA
-     type(ESMF_State)          , intent(INOUT) ::  STATEO
-     character(len=*)          , intent(IN   ) ::  NAMEA
-     character(len=*)          , intent(IN   ) ::  NAMEO
-     integer, optional,          intent(  OUT) ::  RC
-
-     character(len=ESMF_MAXSTR), parameter :: IAm="DO_O2A"
-     integer                               :: STATUS
-
-     real,    pointer :: ptrA(:) => null()
-     real,    pointer :: ptrO(:) => null()
-
-     call MAPL_GetPointer(STATEO, ptrO, NAMEO, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call MAPL_GetPointer(STATEA, ptrA, NAMEA, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-     if (associated(ptrO) .and. associated(ptrA)) then
-        call MAPL_LocStreamTransform( ptrA, XFORM_O2A, ptrO, RC=STATUS )
-        VERIFY_(STATUS)
-     end if
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine DO_O2A
-
-   subroutine DO_A2O_SUBTILES_R4R4(STATEO,NAMEO,SUBINDEXO,STATEA,NAMEA,SUBINDEXA,RC)
-     type(ESMF_State)          , intent(INOUT) ::  STATEO
-     type(ESMF_State)          , intent(INOUT) ::  STATEA
-     character(len=*)          , intent(IN   ) ::  NAMEO
-     character(len=*)          , intent(IN   ) ::  NAMEA
-     integer                   , intent(IN   ) ::  SUBINDEXO(:)
-     integer                   , intent(IN   ) ::  SUBINDEXA(:)
-     integer, optional,          intent(  OUT) ::  RC
-
-     character(len=ESMF_MAXSTR), parameter :: IAm="DO_A2O_SUBTILES_R4R4"
-     integer                               :: STATUS
-
-     real,                       pointer :: ptrA(:,:) => null()
-     real,                       pointer :: ptrO(:,:) => null()
-     integer                             :: N, DIMSO, DIMSA
-
-     DIMSO = size(SUBINDEXO)
-     DIMSA = size(SUBINDEXA)
-     _ASSERT(DIMSO == DIMSA,'needs informative message')
-
-     call MAPL_GetPointer(STATEO, ptrO, NAMEO, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call MAPL_GetPointer(STATEA, ptrA, NAMEA, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-     if (associated(ptrO) .and. associated(ptrA)) then
-        do N=1,DIMSO
-         call MAPL_LocStreamTransform( ptrO(:,SUBINDEXO(N)), XFORM_A2O, &
-                                       ptrA(:,SUBINDEXA(N)), RC=STATUS )
-         VERIFY_(STATUS)
-        enddo
-     end if
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine DO_A2O_SUBTILES_R4R4
-
-   subroutine DO_A2O_SUBTILES_R4R8(STATEO,NAMEO,SUBINDEXO,STATEA,NAMEA,SUBINDEXA,RC)
-     type(ESMF_State)          , intent(INOUT) ::  STATEO
-     type(ESMF_State)          , intent(INOUT) ::  STATEA
-     character(len=*)          , intent(IN   ) ::  NAMEO
-     character(len=*)          , intent(IN   ) ::  NAMEA
-     integer                   , intent(IN   ) ::  SUBINDEXO(:)
-     integer                   , intent(IN   ) ::  SUBINDEXA(:)
-     integer, optional,          intent(  OUT) ::  RC
-
-     character(len=ESMF_MAXSTR), parameter :: IAm="DO_A2O_SUBTILES_R4R8"
-     integer                               :: STATUS
-
-     real(kind=ESMF_KIND_R8),    pointer :: ptrA(:,:) => null()
-     real,                       pointer :: ptrO(:,:) => null()
-     integer                             :: N, DIMSO, DIMSA
-
-     DIMSO = size(SUBINDEXO)
-     DIMSA = size(SUBINDEXA)
-     _ASSERT(DIMSO == DIMSA,'needs informative message')
-
-     call MAPL_GetPointer(STATEO, ptrO, NAMEO, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call MAPL_GetPointer(STATEA, ptrA, NAMEA, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-     if (associated(ptrO) .and. associated(ptrA)) then
-        do N=1,DIMSO
-         call MAPL_LocStreamTransform( ptrO(:,SUBINDEXO(N)), XFORM_A2O, &
-                                       ptrA(:,SUBINDEXA(N)), RC=STATUS )
-         VERIFY_(STATUS)
-        enddo
-     end if
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine DO_A2O_SUBTILES_R4R8
-
-   subroutine DO_A2O_SUBTILES2D_R4R8(STATEO,NAMEO,SUBINDEXO,STATEA,NAMEA,SUBINDEXA, &
-                                     DIMS, RC)
-     type(ESMF_State)          , intent(INOUT) ::  STATEO
-     type(ESMF_State)          , intent(INOUT) ::  STATEA
-     character(len=*)          , intent(IN   ) ::  NAMEO
-     character(len=*)          , intent(IN   ) ::  NAMEA
-     integer                   , intent(IN   ) ::  SUBINDEXO(:)
-     integer                   , intent(IN   ) ::  SUBINDEXA(:)
-     integer                   , intent(IN   ) ::  DIMS
-     integer, optional,          intent(  OUT) ::  RC
-
-     character(len=ESMF_MAXSTR), parameter :: IAm="DO_A2O_SUBTILES2D_R4R8"
-     integer                               :: STATUS
-
-     real(kind=ESMF_KIND_R8),    pointer :: ptrA(:,:,:) => null()
-     real,                       pointer :: ptrO(:,:,:) => null()
-     integer                             :: N, K, DIMSO, DIMSA
-
-
-     DIMSO = size(SUBINDEXO)
-     DIMSA = size(SUBINDEXA)
-     _ASSERT(DIMSO == DIMSA,'needs informative message')
-
-     call MAPL_GetPointer(STATEO, ptrO, NAMEO, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call MAPL_GetPointer(STATEA, ptrA, NAMEA, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-     if (associated(ptrO) .and. associated(ptrA)) then
-        do N=1,DIMSO
-           do K=1,DIMS
-             call MAPL_LocStreamTransform( ptrO(:,K,SUBINDEXO(N)), XFORM_A2O, &
-                                           ptrA(:,K,SUBINDEXA(N)), RC=STATUS )
-             VERIFY_(STATUS)
-           enddo
-        enddo
-     end if
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine DO_A2O_SUBTILES2D_R4R8
-
-   subroutine DO_O2A_SUBTILES_R4R4(STATEA,NAMEA,SUBINDEXA,STATEO,NAMEO,SUBINDEXO,RC)
-     type(ESMF_State)          , intent(INOUT) ::  STATEA
-     type(ESMF_State)          , intent(INOUT) ::  STATEO
-     character(len=*)          , intent(IN   ) ::  NAMEA
-     character(len=*)          , intent(IN   ) ::  NAMEO
-     integer                   , intent(IN   ) ::  SUBINDEXO(:)
-     integer                   , intent(IN   ) ::  SUBINDEXA(:)
-     integer, optional,          intent(  OUT) ::  RC
-
-     character(len=ESMF_MAXSTR), parameter :: IAm="DO_O2A_SUBTILES_R4R4"
-     integer                               :: STATUS
-
-     real,                       pointer :: ptrA(:,:) => null()
-     real,                       pointer :: ptrO(:,:) => null()
-     integer                             :: N, DIMSO, DIMSA
-
-     DIMSO = size(SUBINDEXO)
-     DIMSA = size(SUBINDEXA)
-     _ASSERT(DIMSO == DIMSA,'needs informative message')
-
-     call MAPL_GetPointer(STATEO, ptrO, NAMEO, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call MAPL_GetPointer(STATEA, ptrA, NAMEA, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-     if (associated(ptrO) .and. associated(ptrA)) then
-        do N=1,DIMSO
-           call MAPL_LocStreamTransform( ptrA(:, SUBINDEXA(N)), XFORM_O2A, &
-                                         ptrO(:, SUBINDEXO(N)), RC=STATUS )
-           VERIFY_(STATUS)
-        enddo
-     end if
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine DO_O2A_SUBTILES_R4R4
-
-   subroutine DO_O2A_SUBTILES_R8R4(STATEA,NAMEA,SUBINDEXA,STATEO,NAMEO,SUBINDEXO,RC)
-     type(ESMF_State)          , intent(INOUT) ::  STATEA
-     type(ESMF_State)          , intent(INOUT) ::  STATEO
-     character(len=*)          , intent(IN   ) ::  NAMEA
-     character(len=*)          , intent(IN   ) ::  NAMEO
-     integer                   , intent(IN   ) ::  SUBINDEXO(:)
-     integer                   , intent(IN   ) ::  SUBINDEXA(:)
-     integer, optional,          intent(  OUT) ::  RC
-
-     character(len=ESMF_MAXSTR), parameter :: IAm="DO_O2A_SUBTILES_R8R4"
-     integer                               :: STATUS
-
-     real(kind=ESMF_KIND_R8),    pointer :: ptrA(:,:) => null()
-     real,                       pointer :: ptrO(:,:) => null()
-     integer                             :: N, DIMSO, DIMSA
-
-     DIMSO = size(SUBINDEXO)
-     DIMSA = size(SUBINDEXA)
-     _ASSERT(DIMSO == DIMSA,'needs informative message')
-
-     call MAPL_GetPointer(STATEO, ptrO, NAMEO, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call MAPL_GetPointer(STATEA, ptrA, NAMEA, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-     if (associated(ptrO) .and. associated(ptrA)) then
-        do N=1,DIMSO
-           call MAPL_LocStreamTransform( ptrA(:, SUBINDEXA(N)), XFORM_O2A, &
-                                         ptrO(:, SUBINDEXO(N)), RC=STATUS )
-           VERIFY_(STATUS)
-        enddo
-     end if
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine DO_O2A_SUBTILES_R8R4
-
-   subroutine DO_O2A_SUBTILES2D_R8R4(STATEA,NAMEA,SUBINDEXA,STATEO,NAMEO,SUBINDEXO, &
-                                     DIMS, RC)
-     type(ESMF_State)          , intent(INOUT) ::  STATEA
-     type(ESMF_State)          , intent(INOUT) ::  STATEO
-     character(len=*)          , intent(IN   ) ::  NAMEA
-     character(len=*)          , intent(IN   ) ::  NAMEO
-     integer                   , intent(IN   ) ::  SUBINDEXO(:)
-     integer                   , intent(IN   ) ::  SUBINDEXA(:)
-     integer                   , intent(IN   ) ::  DIMS
-     integer, optional,          intent(  OUT) ::  RC
-
-     character(len=ESMF_MAXSTR), parameter :: IAm="DO_O2A_SUBTILES2D_R8R4"
-     integer                               :: STATUS
-
-     real(kind=ESMF_KIND_R8),    pointer :: ptrA(:,:,:) => null()
-     real,                       pointer :: ptrO(:,:,:) => null()
-     integer                             :: N, K, DIMSO, DIMSA
-
-     DIMSO = size(SUBINDEXO)
-     DIMSA = size(SUBINDEXA)
-     _ASSERT(DIMSO == DIMSA,'needs informative message')
-
-     call MAPL_GetPointer(STATEO, ptrO, NAMEO, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call MAPL_GetPointer(STATEA, ptrA, NAMEA, notFoundOK=.true., RC=STATUS)
-     VERIFY_(STATUS)
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-     if (associated(ptrO) .and. associated(ptrA)) then
-        do N=1,DIMSO
-          do K=1,DIMS
-            call MAPL_LocStreamTransform( ptrA(:,K,SUBINDEXA(N)), XFORM_O2A, &
-                                          ptrO(:,K,SUBINDEXO(N)), RC=STATUS )
-            VERIFY_(STATUS)
-          enddo
-        enddo
-     end if
-     call ESMF_VMBarrier(VM, rc=status)
-     VERIFY_(STATUS)
-
-     RETURN_(ESMF_SUCCESS)
-   end subroutine DO_O2A_SUBTILES2D_R8R4
 
    subroutine DO_A2W(SRC,DST,NAME,RC)
      implicit none
@@ -3042,5 +2705,7 @@ contains
 !ALT we could have a finalize method to release memory
 ! for example call ESMF_FieldRegridRelease(routeHandle, rc=status)
 
+
 end module GEOS_GcmGridCompMod
+
 

--- a/GEOSogcm_GridComp/GEOS_OgcmGridComp.F90
+++ b/GEOSogcm_GridComp/GEOS_OgcmGridComp.F90
@@ -90,6 +90,7 @@ module GEOS_OgcmGridCompMod
   type T_OGCM_STATE
      private
      logical :: useInterp = .false.
+     type(ESMF_Clock)  :: clock
   end type T_OGCM_STATE
 
 ! Wrapper for extracting internal state
@@ -1128,7 +1129,11 @@ contains
     type(ESMF_State)                    :: SURFST
 
     type (ESMF_StateItem_Flag) :: itemType
-
+    type (MAPL_MetaComp    ), pointer   :: CMAPL => null()
+    real :: DT
+    type (ESMF_TimeInterval) :: timestep
+    type (ESMF_Time) :: currTime
+    
 !=============================================================================
 
 ! Begin... 
@@ -1163,13 +1168,24 @@ contains
     call MAPL_Get(MAPL, GCS = GCS, RC=STATUS )
     VERIFY_(STATUS)
 
+! Initialize the PrivateState/clock. First the time...
+!-----------------------------------------------
+    call MAPL_GetObjectFromGC ( GCS(OCEAN), CMAPL, _RC)
+    call MAPL_GetResource(CMAPL, DT, Label="RUN_DT:", _RC)             ! Get AGCM Heartbeat
+    call MAPL_GetResource(CMAPL, DT, Label="OCEAN_DT:", DEFAULT=DT, _RC) ! set Default OCEAN_DT to AGCM Heartbeat
+
+    CALL ESMF_TimeIntervalSet(timeStep, S=NINT(DT), _RC)
+    call ESMF_ClockGet(CLOCK, currTIME=currTime, _RC)
+
+    ogcm_internal_state%clock = &
+         ESMF_ClockCreate(NAME = TRIM(OCEAN_NAME)//"Clock", &
+         timeStep=timeStep, startTime=currTime, _RC)
 ! Call Initialize for every Child
 !--------------------------------
 
     call MAPL_TimerOff(MAPL,"TOTAL"     )
     call MAPL_TimerOn(MAPL,"InitChild") 
-    call MAPL_GenericInitialize ( GC, IMPORT, EXPORT, CLOCK,  RC=STATUS)
-    VERIFY_(STATUS)
+    call MAPL_GenericInitialize ( GC, IMPORT, EXPORT, CLOCK, _RC)
     call MAPL_TimerOff(MAPL,"InitChild")
     call MAPL_TimerOn (MAPL,"TOTAL"     )
 
@@ -1512,6 +1528,9 @@ contains
     integer :: PHASE
     integer :: PHASE_
     integer, allocatable :: CHLD(:)
+    integer :: NUM
+    type (ESMF_TimeInterval) :: timestep
+    type (ESMF_Time) :: currTime, myTime, endTime
 
 !=============================================================================
 
@@ -1531,6 +1550,11 @@ contains
 
     call MAPL_GetObjectFromGC ( GC, MAPL, RC=STATUS)
     VERIFY_(STATUS)
+
+! Check the clocks to set set-up the "run-to" time
+!-------------------------------------------------
+
+    call ESMF_ClockGet( CLOCK, currTime=endTime, _RC)
 
 ! Start Total timer
 !------------------
@@ -1636,6 +1660,7 @@ contains
 ! Verify that the saltwater ice variables are friendly to seaice
 !---------------------------------------------------------------
 
+#ifdef ENFORCE_SEAICE_FRIENDLY
     if (.not. seaIceT_extData) then
       call ESMF_StateGet (IMPORT, 'TI', FIELD, _RC)
       call ESMF_AttributeGet  (FIELD, NAME="FriendlyToSEAICE", VALUE=FRIENDLY, _RC)
@@ -1695,6 +1720,7 @@ contains
        VERIFY_(STATUS)
        _ASSERT(FRIENDLY,'needs informative message')
     end if
+#endif
     
 ! Children's Imports
 !-------------------
@@ -2037,51 +2063,6 @@ contains
 
     call MAPL_TimerOff(MAPL,"TOTAL"     )
 
-    if (.not. DUAL_OCEAN) then
-       call MAPL_GenericRunChildren(GC, IMPORT, EXPORT, CLOCK, RC=STATUS)
-       VERIFY_(STATUS)
-    else
-       if (PHASE == 1) then
-          ! corrector
-          ! run explicitly phase 1 of all the children
-          allocate(CHLD(4), stat=status)
-          VERIFY_(STATUS)
-          CHLD = (/OBIO,ORAD,SEAICE,OCEAN/)
-          DO N=1, size(CHLD)
-             ID = CHLD(N)
-             if (ID <= 0) cycle
-             call ESMF_GridCompRun( GCS(ID), importState=GIM(ID), &
-                  exportState=GEX(ID), clock=CLOCK, phase=1, userRC=STATUS )
-             VERIFY_(STATUS)
-             call MAPL_GenericRunCouplers( MAPL, CHILD=ID, CLOCK=CLOCK, RC=STATUS )
-             VERIFY_(STATUS)
-          END DO
-          deallocate(CHLD)
-
-       else
-       ! run explicitly the children excluding "real" seaice (ocean has the data part inside ocean)
-          allocate(CHLD(4), stat=status)
-          VERIFY_(STATUS)
-          CHLD = (/OBIO,ORAD,SEAICE,OCEAN/)
-          DO N=1, size(CHLD)
-             ID = CHLD(N)
-             if (ID <= 0) cycle
-             if (ID /= OCEAN .and. ID /= SEAICE) then
-                phase_ = 1
-             else
-                phase_ = phase
-             end if
-             call ESMF_GridCompRun( GCS(ID), importState=GIM(ID), &
-                  exportState=GEX(ID), clock=CLOCK, phase=phase_, userRC=STATUS )
-             VERIFY_(STATUS)
-             call MAPL_GenericRunCouplers( MAPL, CHILD=ID, CLOCK=CLOCK, RC=STATUS )
-             VERIFY_(STATUS)
-          END DO
-          deallocate(CHLD)
-
-       end if
-    end if
-
     call MAPL_TimerOn (MAPL,"TOTAL"     )
 
     call ESMF_UserCompGetInternalState(gc, 'OGCM_state', wrap, status)
@@ -2090,30 +2071,103 @@ contains
 
     useInterp = ogcm_internal_state%useInterp
 
-    if (.not. seaIceT_extData) then
-      call MAPL_LocStreamTransform( ExchGrid, SI     ,  SIO   , _RC)
-      if (DO_CICE_THERMO <= 1) then  
-         call MAPL_LocStreamTransform( ExchGrid, HI     ,  HIO   , _RC)
-      endif
-    endif
+    call ESMF_ClockGet( Ogcm_Internal_State%CLOCK, currTime=myTime, _RC)
 
-    ! call Run2 of SEAICE to do ice nudging 
-    if (dual_ocean) then
-        if(PHASE==1) then
+    if (myTime > EndTime) then
+       call ESMF_ClockSet(Ogcm_Internal_State%Clock,direction=ESMF_DIRECTION_REVERSE, _RC)
+       do
+         call ESMF_ClockAdvance(Ogcm_Internal_State%Clock, _RC)
+         call ESMF_ClockGet(Ogcm_Internal_State%Clock,currTime=currTime, _RC)
+         if (currTime==endTime) exit
+       enddo
+       call ESMF_ClockSet(Ogcm_Internal_State%Clock, direction=ESMF_DIRECTION_FORWARD, _RC)
+       call ESMF_ClockGet(Ogcm_Internal_State%CLOCK, currTime=myTime, _RC)
+    end if
+
+    NUM = 0
+    do while ( MyTime <= endTime ) ! Time to run
+    !============================BEGIN-of-local-time-loop
+       if (MAPL_Am_I_root()) then
+          print *,"OGCM: doing ocean sub-stepping, STEP",num+1
+       end if
+       if (.not. DUAL_OCEAN) then
+          call MAPL_GenericRunChildren(GC, IMPORT, EXPORT, Ogcm_Internal_State%CLOCK, RC=STATUS)
+          VERIFY_(STATUS)
+       else
+          if (PHASE == 1) then
+             ! corrector
+             ! run explicitly phase 1 of all the children
+             allocate(CHLD(4), stat=status)
+             VERIFY_(STATUS)
+             CHLD = (/OBIO,ORAD,SEAICE,OCEAN/)
+             DO N=1, size(CHLD)
+                ID = CHLD(N)
+                if (ID <= 0) cycle
+                call ESMF_GridCompRun( GCS(ID), importState=GIM(ID), &
+                     exportState=GEX(ID), clock=Ogcm_Internal_State%CLOCK, phase=1, userRC=STATUS )
+                VERIFY_(STATUS)
+                call MAPL_GenericRunCouplers( MAPL, CHILD=ID, CLOCK=Ogcm_Internal_State%CLOCK, RC=STATUS )
+                VERIFY_(STATUS)
+             END DO
+             deallocate(CHLD)
+
+          else
+             ! run explicitly the children excluding "real" seaice (ocean has the data part inside ocean)
+             allocate(CHLD(4), stat=status)
+             VERIFY_(STATUS)
+             CHLD = (/OBIO,ORAD,SEAICE,OCEAN/)
+             DO N=1, size(CHLD)
+                ID = CHLD(N)
+                if (ID <= 0) cycle
+                if (ID /= OCEAN .and. ID /= SEAICE) then
+                   phase_ = 1
+                else
+                   phase_ = phase
+                end if
+                call ESMF_GridCompRun( GCS(ID), importState=GIM(ID), &
+                     exportState=GEX(ID), clock=Ogcm_Internal_State%CLOCK, phase=phase_, userRC=STATUS )
+                VERIFY_(STATUS)
+                call MAPL_GenericRunCouplers( MAPL, CHILD=ID, CLOCK=Ogcm_Internal_State%CLOCK, RC=STATUS )
+                VERIFY_(STATUS)
+             END DO
+             deallocate(CHLD)
+
+          end if
+       end if
+
+       ! call Run2 of SEAICE to do ice nudging 
+       if (dual_ocean) then
+          if(PHASE==1) then
              ! phase 3 is corrector stage same as phase 1
              call ESMF_GridCompRun( GCS(SEAICE), importState=GIM(SEAICE), &
-                  exportState=GEX(SEAICE), clock=CLOCK, phase=3, userRC=STATUS )
+                  exportState=GEX(SEAICE), clock=Ogcm_Internal_State%CLOCK, phase=3, userRC=STATUS )
              VERIFY_(STATUS)
-             call MAPL_GenericRunCouplers( MAPL, CHILD=SEAICE, CLOCK=CLOCK, RC=STATUS )
+             call MAPL_GenericRunCouplers( MAPL, CHILD=SEAICE, CLOCK=Ogcm_Internal_State%CLOCK, RC=STATUS )
              VERIFY_(STATUS)
-        else
+          else
              ! phase 4 predictor stage same as phase 2
              call ESMF_GridCompRun( GCS(SEAICE), importState=GIM(SEAICE), &
-                  exportState=GEX(SEAICE), clock=CLOCK, phase=4, userRC=STATUS )
+                  exportState=GEX(SEAICE), clock=Ogcm_Internal_State%CLOCK, phase=4, userRC=STATUS )
              VERIFY_(STATUS)
-             call MAPL_GenericRunCouplers( MAPL, CHILD=SEAICE, CLOCK=CLOCK, RC=STATUS )
+             call MAPL_GenericRunCouplers( MAPL, CHILD=SEAICE, CLOCK=Ogcm_Internal_State%CLOCK, RC=STATUS )
              VERIFY_(STATUS)
-        endif
+          endif
+       endif
+       ! Bump the time in the internal state
+       !------------------------------------
+
+       call ESMF_ClockAdvance( Ogcm_Internal_State%clock, _RC)
+       call ESMF_ClockGet    ( Ogcm_Internal_State%clock, currTime= myTime , _RC)
+
+       NUM = NUM + 1
+    !============================END-of-local-time-loop
+    end do  ! time to run
+
+    if (.not. seaIceT_extData) then
+       call MAPL_LocStreamTransform( ExchGrid, SI     ,  SIO   , _RC)
+       if (DO_CICE_THERMO <= 1) then  
+          call MAPL_LocStreamTransform( ExchGrid, HI     ,  HIO   , _RC)
+       endif
     endif
 
     if (DO_CICE_THERMO == 0) then  

--- a/gc2gc.F90
+++ b/gc2gc.F90
@@ -82,9 +82,7 @@ contains
        ! get rank,typekind to use the appropriate overload
        call ESMF_FieldGet(field, rank=rank, typekind=tk, _RC)
 
-       _ASSERT(tk==ESMF_TYPEKIND_R4, &
-            "Currently the averaging coupler supports only R4. Var: "//&
-            trim(this%vars(n)%vIn))
+       _ASSERT(tk==ESMF_TYPEKIND_R4, "Currently the averaging coupler supports only R4. Var: "//trim(this%vars(n)%vIn))
 
        select case (rank)
        case (1)

--- a/gc2gc.F90
+++ b/gc2gc.F90
@@ -1,0 +1,336 @@
+#include "MAPL_Generic.h"
+module gc2gc
+  use ESMF
+  use MAPL
+  use MAPL_GenericCplCompMod
+
+  implicit none
+
+  type T_CVARS
+     character(len=ESMF_MAXSTR) :: vIn, vOut
+  end type T_CVARS
+
+  type T_GC2GC_STATE
+     private
+     character(len=ESMF_MAXSTR) :: name
+     type (MAPL_LocStreamXFORM) :: XFORM
+     integer :: nvars
+     integer :: DT, COUPLE_DT
+     logical :: average=.false.
+     logical :: alreadyPrinted=.false.
+     type(T_CVARS), pointer :: vars(:) => null()
+     type(ESMF_State) :: StateIn, StateOut, StateTmp
+     type(ESMF_CplComp) :: ccs
+     type(ESMF_Alarm) :: alarm
+   contains
+     procedure :: g2ginitialize
+     procedure :: accumulate
+     procedure :: regrid
+     procedure, private :: MAPL_ConnectSetName
+     procedure, private :: MAPL_ConnectSetXform
+     procedure, private :: MAPL_ConnectSetVars
+     procedure, private :: MAPL_ConnectSetDt
+     procedure, private :: MAPL_ConnectSetAverage
+     procedure, private :: MAPL_ConnectSetAlarm
+     generic :: set => MAPL_ConnectSetName
+     generic :: set => MAPL_ConnectSetXform
+     generic :: set => MAPL_ConnectSetVars
+     generic :: set => MAPL_ConnectSetDt
+     generic :: set => MAPL_ConnectSetAverage
+     generic :: set => MAPL_ConnectSetAlarm
+  end type T_GC2GC_STATE
+
+  public T_GC2GC_STATE
+
+contains
+  subroutine g2ginitialize(this, clock, rc)
+    class (T_GC2GC_STATE), intent(inout) :: this
+    type(ESMF_Clock), intent(inout) :: clock
+    integer, optional, intent(out) :: rc
+
+    integer :: status
+    integer :: n, k, rank, dims
+    type (MAPL_VarSpec), pointer :: SSPEC(:)
+    type (ESMF_Field) :: field, fieldCopy
+    type (ESMF_TypeKind_flag) :: tk
+    character (len=ESMF_MAXSTR), allocatable  :: itemNameList(:)
+
+    _RETURN_UNLESS(this%average)
+
+    ! create couplers as needed
+    this%CCS = ESMF_CplCompCreate (                  &
+         NAME = this%name, &
+         contextFlag = ESMF_CONTEXT_PARENT_VM,              &
+         _RC )
+    this%stateTmp = ESMF_StateCreate(name='TmpInOut',_RC)
+
+    ! fill the export state of the coupler
+    call ESMF_StateGet(this%stateIn, ITEMCOUNT=N, _RC)
+    allocate(itemNameList(N), _STAT)
+
+    call ESMF_StateGet(this%stateIn, ITEMNAMELIST=itemNamelist, _RC)
+
+    NULLIFY(SSPEC)
+    k=0
+    do n=1,size(this%vars)
+       if (.not. any(itemNameList==this%vars(n)%vIn)) cycle
+       k = k+1
+
+       call ESMF_StateGet(this%stateIn, itemName=this%vars(n)%vIn, field=field, _RC)
+       fieldCopy = MAPL_FieldCreate(field, name=this%vars(n)%vIn, doCopy=.true.,_RC)
+       call MAPL_StateAdd(this%stateTmp, field=fieldCopy, _RC)
+       ! get rank,typekind to use the appropriate overload
+       call ESMF_FieldGet(field, rank=rank, typekind=tk, _RC)
+
+       _ASSERT(tk==ESMF_TYPEKIND_R4, &
+            "Currently the averaging coupler supports only R4. Var: "//&
+            trim(this%vars(n)%vIn))
+
+       select case (rank)
+       case (1)
+          DIMS = MAPL_DimsTileOnly
+       case (2)
+          DIMS = MAPL_DimsHorzOnly
+          ! we are "lying". this is TileOnly + ungridded dims (but the coupler does not care)
+       case (3)
+          ! we are "lying". this is TileOnly + ungridded dims (but the coupler does not care)
+          DIMS = MAPL_DimsHorzVert
+       case default
+          _FAIL('unsupported rank')
+       end select
+
+       call MAPL_VarSpecCreateInList(SSPEC,   &
+            SHORT_NAME = this%vars(n)%vIn,                          &
+            DIMS       = DIMS,                                &
+            ACCMLT_INTERVAL= this%DT,                          &
+            COUPLE_INTERVAL= this%COUPLE_DT,                         &
+            _RC)
+
+       if (MAPL_AM_I_ROOT()) then
+          print *,'DEBUG:g2gini:',trim(this%vars(n)%vIn),&
+               this%DT, this%COUPLE_DT, this%average, trim(this%name)
+       end if
+
+    end do
+    deallocate(itemNameList, _STAT)
+
+    if (MAPL_AM_I_Root()) then
+       print *, "DEBUG: Averaging the following ",K," vars:"
+!       call MAPL_VarSpecPrint(sspec, _RC)
+    end if
+
+!         CCSetServ
+    call ESMF_CplCompSetServices (this%CCS, &
+         GenericCplSetServices, _RC )
+
+    call MAPL_CplCompSetVarSpecs(this%CCS, &
+                                      SSPEC,&
+                                      SSPEC,_RC)
+    
+    call MAPL_CplCompSetAlarm(this%CCS, this%alarm, _RC)
+    
+    call ESMF_CplCompInitialize (this%CCS, &
+         importState=this%stateIn, & 
+         exportState=this%stateTmp, &
+         clock=CLOCK, userRc=status)
+    _VERIFY(status)
+
+    _RETURN(ESMF_SUCCESS)
+  end subroutine g2ginitialize
+
+  subroutine accumulate(this, clock, rc)
+    class (T_GC2GC_STATE), intent(inout) :: this
+    type(ESMF_Clock), intent(inout) :: clock
+    integer, optional, intent(out) :: rc
+
+    integer :: status
+
+    _RETURN_UNLESS(this%average)
+
+    call ESMF_CplCompRun(this%ccs, importState=this%stateIn, &
+         exportState=this%stateTmp, clock=clock, userRc=status)
+    _VERIFY(status)
+
+    _RETURN(ESMF_SUCCESS)
+  end subroutine accumulate
+
+  subroutine regrid(this, rc)
+    class (T_GC2GC_STATE), intent(inout) :: this
+    integer, optional, intent(out) :: rc
+
+    integer :: status
+    integer :: n, k, m, rank
+    real, pointer :: ptr1In(:)
+    real, pointer :: ptr1Out(:)
+    real, pointer :: ptr2In(:,:)
+    real, pointer :: ptr2Out(:,:)
+    real, pointer :: ptr3In(:,:,:)
+    real, pointer :: ptr3Out(:,:,:)
+    type (ESMF_Field) :: field
+!    type (ESMF_TypeKind_flag) :: tk
+    type (ESMF_State) :: StateIn
+    character (len=ESMF_MAXSTR), allocatable  :: itemNameListIn(:)
+    character (len=ESMF_MAXSTR), allocatable  :: itemNameListOut(:)
+    logical :: skip
+    
+    stateIn = this%stateIn
+    if (this%average) stateIn = this%stateTmp
+
+    !??? VM barrier???
+
+    call ESMF_StateGet(this%stateOut, ITEMCOUNT=N, _RC)
+    allocate(itemNameListOut(N), _STAT)
+    call ESMF_StateGet(this%stateOut, ITEMNAMELIST=itemNamelistOut, _RC)
+
+    call ESMF_StateGet(stateIn, ITEMCOUNT=N, _RC)
+    allocate(itemNameListIn(N), _STAT)
+    call ESMF_StateGet(stateIn, ITEMNAMELIST=itemNamelistIn, _RC)
+
+    do n=1,size(this%vars)
+       ! we might need to check the field is in the state. If not, it might be Ok
+       skip = .false.
+       if (.not. any(itemNameListIn==this%vars(n)%vIn)) skip=.true.
+       if (.not. any(itemNameListOut==this%vars(n)%vOut)) skip=.true.
+       if (skip) cycle
+
+       if (.not. this%alreadyPrinted) then
+          if (MAPL_Am_I_Root()) then
+             print *, "DEBUG: var "//trim(this%vars(n)%vIn),&
+                  "  "//trim(this%name)
+          end if
+       end if
+
+       call ESMF_StateGet(stateIn, this%vars(n)%vIn, field, _RC)
+       ! get rank,typekind to use the appropriate overload
+       call ESMF_FieldGet(field, rank=rank, _RC)
+       select case (rank)
+          case (1)
+             call MAPL_GetPointer(this%stateOut, ptr1out, this%vars(n)%Vout, notFoundOK=.true., _RC)
+             call MAPL_GetPointer(stateIn, ptr1in, this%vars(n)%Vin, notFoundOK=.true., _RC)       
+             if (associated(ptr1Out) .and. associated(ptr1In)) then
+                call MAPL_LocStreamTransform( ptr1Out, &
+                     this%XFORM, ptr1In, _RC )
+             end if
+          case (2)
+             call MAPL_GetPointer(this%STATEout, ptr2out, this%vars(n)%Vout, notFoundOK=.true., _RC)
+             call MAPL_GetPointer(stateIn, ptr2in, this%vars(n)%Vin, notFoundOK=.true., _RC)
+
+             if (associated(ptr2Out) .and. associated(ptr2In)) then
+                do K=1,size(ptr2Out,2)
+                   call MAPL_LocStreamTransform( ptr2Out(:,K), &
+                        this%XFORM, ptr2In(:,K), _RC )
+                enddo
+             end if
+          case (3)
+             call MAPL_GetPointer(this%STATEout, ptr3out, this%vars(n)%Vout, notFoundOK=.true., _RC)
+             call MAPL_GetPointer(stateIn, ptr3in, this%vars(n)%Vin, notFoundOK=.true., _RC)
+
+             if (associated(ptr3Out) .and. associated(ptr3In)) then
+                do M=1,size(ptr3Out,3)
+                   do K=1,size(ptr3Out,2)
+                      call MAPL_LocStreamTransform( ptr3Out(:,K,M), &
+                           this%XFORM, ptr3In(:,K,M), _RC )
+                   enddo
+                enddo
+             end if
+       case default
+          _FAIL("Unsupported rank")
+       end select
+    end do
+    if (.not. this%alreadyPrinted) this%alreadyPrinted = .true.
+    deallocate(itemNameListIn, itemNameListOut)
+    _RETURN(ESMF_SUCCESS)
+
+  end subroutine regrid
+
+  subroutine MAPL_ConnectSetVars(this, varOut, varIn, rc)
+    class (T_GC2GC_STATE), intent(INOUT) :: this
+    character(len=*), intent(IN) :: varIn, varOut
+    integer, optional, intent(OUT) :: rc
+
+    integer :: status, I
+    type (T_CVARS), pointer :: TMP(:)
+
+    I = 0
+    if (associated(this%vars)) I = size(this%vars)
+
+    allocate(TMP(I+1),_STAT)
+
+    TMP(1:I) = this%vars
+    if(I>0) deallocate(this%vars)
+
+    TMP(I+1)%Vin =  varIn
+    TMP(I+1)%VOut =  varOut
+
+    !      call move_alloc(from=tmp, to=this%vars)
+    this%vars => tmp
+    _RETURN(ESMF_SUCCESS)
+  end subroutine MAPL_ConnectSetVars
+
+  subroutine MAPL_ConnectSetXform(this, xform, rc)
+    class (T_GC2GC_STATE), intent(INOUT) :: this
+    type (MAPL_LocStreamXform), intent(IN) :: xform
+    integer, optional, intent(OUT) :: rc
+
+    this%xform = xform
+
+    _RETURN(ESMF_SUCCESS)
+  end subroutine MAPL_ConnectSetXform
+
+  subroutine MAPL_ConnectSetName(this, stateIn, stateOut, name, rc)
+    class (T_GC2GC_STATE), intent(INOUT) :: this
+    type(ESMF_State), intent(IN) :: stateIn, stateOut
+    character(len=*), optional, intent(IN) :: name
+    integer, optional, intent(OUT) :: rc
+
+    integer :: status
+
+    this%name = ''
+    this%stateIn = stateIn
+    this%stateOut = stateOut
+    if (present(name)) this%name = name
+
+    _RETURN(ESMF_SUCCESS)
+  end subroutine MAPL_ConnectSetName
+
+  subroutine MAPL_ConnectSetDt(this, Dt, Couple_Dt, rc)
+    class (T_GC2GC_STATE), intent(INOUT) :: this
+    integer, intent(IN) :: dt, couple_dt
+    integer, optional, intent(OUT) :: rc
+
+    integer :: status
+    
+    this%dt = dt
+    this%couple_dt = couple_dt
+
+    this%average = dt/=couple_dt
+    
+    _RETURN(ESMF_SUCCESS)
+  end subroutine MAPL_ConnectSetDt
+
+  subroutine MAPL_ConnectSetAverage(this, average, rc)
+    class (T_GC2GC_STATE), intent(INOUT) :: this
+    logical, intent(IN) :: average
+    integer, optional, intent(OUT) :: rc
+
+    integer :: status
+    
+    this%average = average
+    
+    _RETURN(ESMF_SUCCESS)
+  end subroutine MAPL_ConnectSetAverage
+
+  subroutine MAPL_ConnectSetAlarm(this, alarm, rc)
+    class (T_GC2GC_STATE), intent(INOUT) :: this
+    type(ESMF_Alarm), intent(IN) :: alarm
+    integer, optional, intent(OUT) :: rc
+
+    integer :: status
+    
+    this%alarm = alarm
+    
+    _RETURN(ESMF_SUCCESS)
+  end subroutine MAPL_ConnectSetAlarm
+
+end module gc2gc
+


### PR DESCRIPTION
This add ability to couple the atmosphere and the ocean at different time intervals, and to run the ocean at different time-step from the global clock's heartbeat.

Note that this PR requires also the changes to the GEOS_OceanGridComp repository on the feature/oceanDt.rc31 branch. 

These changes are 0-diff against standard AMIP and coupled configurations