### PR TITLE
fix(gwd/regression): move data download from configure time to ctest fixture

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/CMakeLists.txt
@@ -14,17 +14,34 @@ endif()
 
 # Sync regression test data from S3
 set(GWD_PATH GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp)
-set(REGRESSION_DATA_DIR ${CMAKE_BINARY_DIR}/regression-data/${GWD_PATH})
-if (NOT EXISTS ${REGRESSION_DATA_DIR})
-  message(STATUS "Syncing regression data from S3: ${GWD_PATH}")
-  esma_sync_data(
-    TARGET sync_regression_data_gwd
-    URI "s3://gmao-usw2-si-team/regression-data/${GWD_PATH}"
-    DESTINATION "${REGRESSION_DATA_DIR}"
-    CREDENTIALS_URL "https://llvsm4u7ij.execute-api.us-east-1.amazonaws.com/credentials"
-    ALL
-  )
+if(DEFINED ENV{LOCAL_REGRESSION_DATA_DIR} AND NOT "$ENV{LOCAL_REGRESSION_DATA_DIR}" STREQUAL "")
+  set(REGRESSION_DATA_DIR "$ENV{LOCAL_REGRESSION_DATA_DIR}/${GWD_PATH}")
+else()
+  set(REGRESSION_DATA_DIR ${CMAKE_BINARY_DIR}/regression-data/${GWD_PATH})
 endif()
+
+set(SYNC_WORK_DIR "${CMAKE_BINARY_DIR}/regression-data/sync_work/gwd")
+
+# Locate the cmake script used internally by esma_sync_data()
+find_file(ESMA_SYNC_DATA_SCRIPT
+  NAMES esma_sync_data_script.cmake
+  PATHS ${CMAKE_MODULE_PATH}
+  NO_DEFAULT_PATH
+  REQUIRED
+)
+
+# Fixture test: sync regression data from S3 at ctest (NOT configure) time
+add_test(
+  NAME gwd/sync_data
+  COMMAND ${CMAKE_COMMAND}
+    "-DLOCAL_DIR=${REGRESSION_DATA_DIR}"
+    "-DWORK_DIR=${SYNC_WORK_DIR}"
+    "-DESMA_SYNC_DATA_SCRIPT=${ESMA_SYNC_DATA_SCRIPT}"
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/sync_data.cmake
+)
+set_tests_properties(gwd/sync_data PROPERTIES
+  FIXTURES_SETUP gwd_regression_data
+)
 
 # Regression tests
 foreach(TEST_CASE ${TEST_CASES})
@@ -42,5 +59,6 @@ foreach(TEST_CASE ${TEST_CASES})
   set_tests_properties("${TEST_CASE}" PROPERTIES
     LABELS "REGRESSION"
     ENVIRONMENT "${LD_PATH}=${CMAKE_BINARY_DIR}/lib:$ENV{${LD_PATH}}"
+    FIXTURES_REQUIRED gwd_regression_data
   )
 endforeach()

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/sync_data.cmake
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/sync_data.cmake
@@ -1,0 +1,21 @@
+# sync_data.cmake
+# Downloads GWD regression data from S3.
+# Required inputs (via -D): LOCAL_DIR, WORK_DIR, ESMA_SYNC_DATA_SCRIPT
+
+if(DEFINED ENV{LOCAL_REGRESSION_DATA_DIR} AND NOT "$ENV{LOCAL_REGRESSION_DATA_DIR}" STREQUAL "")
+  message(STATUS "LOCAL_REGRESSION_DATA_DIR is set -- skipping S3 sync")
+  return()
+endif()
+
+if(EXISTS "${LOCAL_DIR}")
+  message(STATUS "Regression data already present: ${LOCAL_DIR} -- skipping sync")
+  return()
+endif()
+
+set(AWS_CLI "aws")
+set(S3_URI "s3://gmao-usw2-si-team/regression-data/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp")
+set(API_KEY_ENV "AWS_API_KEY_GMAO_SITEAM_S3")
+set(CREDENTIALS_URL "https://llvsm4u7ij.execute-api.us-east-1.amazonaws.com/credentials")
+set(REQUIRED FALSE)
+
+include("${ESMA_SYNC_DATA_SCRIPT}")


### PR DESCRIPTION
## Summary

Previously, GWD regression data was synced from S3 via `esma_sync_data()` during cmake configuration, which meant a network call on every re-configure even when data was already present, and made it impossible to configure offline.

This follows the pattern established for GOCART2G and FVdycoreCubed regression tests.

## Changes

- Remove the configure-time `esma_sync_data()` call.
- Add `LOCAL_REGRESSION_DATA_DIR` support so developers can point at a local copy of the data and skip the S3 sync entirely.
- Locate `esma_sync_data_script.cmake` once at configure time via `find_file()`, passing the path as a `-D` argument to the fixture.
- Register `gwd/sync_data` as a `FIXTURES_SETUP` ctest test that runs `sync_data.cmake` only when `ctest` is invoked.
- Add `FIXTURES_REQUIRED gwd_regression_data` to every regression test so ctest enforces the correct ordering automatically.
- Add `sync_data.cmake` using the shared `esma_sync_data_script` include with the two standard early-exit guards (`LOCAL_REGRESSION_DATA_DIR` set, or `LOCAL_DIR` already exists).
