### PR TITLE
regression(GWD): run on a single OpenMP thread

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/CMakeLists.txt
@@ -58,7 +58,7 @@ foreach(TEST_CASE ${TEST_CASES})
   )
   set_tests_properties("${TEST_CASE}" PROPERTIES
     LABELS "REGRESSION"
-    ENVIRONMENT "${LD_PATH}=${CMAKE_BINARY_DIR}/lib:$ENV{${LD_PATH}}"
+    ENVIRONMENT "${LD_PATH}=${CMAKE_BINARY_DIR}/lib:$ENV{${LD_PATH}};OMP_NUM_THREADS=1"
     FIXTURES_REQUIRED gwd_regression_data
   )
 endforeach()


### PR DESCRIPTION
Related issue: https://github.com/GEOS-ESM/MAPL/issues/5197

## Problem

The GWD regression tests were not pinning `OMP_NUM_THREADS`, allowing the test process to inherit whatever thread count the environment happens to provide. This can cause non-deterministic results and spurious failures on machines with many cores.

## Fix

Set `OMP_NUM_THREADS=1` in the `ENVIRONMENT` property of each GWD regression test case in `CMakeLists.txt`, ensuring the tests always run single-threaded.