### PR TITLE
V12 tuning and GWD updates

### DIFF
--- a/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
@@ -1074,19 +1074,23 @@ contains
 ! Set internal connections between the childrens IMPORTS and EXPORTS
 ! ------------------------------------------------------------------
 
-    call MAPL_AddConnectivity ( GC,                                                        &
-         SRC_NAME  = (/'U            ','V            ','TH           ','T            ',    &
-                       'ZLE          ','PS           ','TA           ','QA           ',    &
-                       'US           ','VS           ','WSPD_STABLE300M ',                 &
-                       'SPEED        ','DZ           ','PLE          ','W            ',    &
-                       'PREF         ','TROPP_BLENDED','S            ','PLK          ',    &
-                       'PV           ','TROPK_BLENDED','OMEGA        ','PKE          '/),  &
-         DST_NAME  = (/'U     ','V     ','TH    ','T     ',                                &
-                       'ZLE   ','PS    ','TA    ','QA    ',                                &
-                       'UA    ','VA    ','WSPD_STABLE300M',                                &
-                       'SPEED ','DZ    ','PLE   ','W     ',                                &
-                       'PREF  ','TROPP ','S     ','PLK   ',                                &
-                       'PV    ','TROPK ','OMEGA ','PKE   '/),                              &
+    ! Set the length of the character array constructor to
+    ! the length of the longest string in the array
+    call MAPL_AddConnectivity ( GC, &
+         SRC_NAME  = [character(len=15) :: &
+            'U',     'V',             'TH',              'T',    &
+            'ZLE',   'PS',            'TA',              'QA',   &
+            'US',    'VS',            'WSPD_STABLE300M',         &
+            'SPEED', 'DZ',            'PLE',             'W',    &
+            'PREF',  'TROPP_BLENDED', 'S',               'PLK',  &
+            'PV',    'TROPK_BLENDED', 'OMEGA',           'PKE'], &
+         DST_NAME  = [character(len=15) :: &
+             'U',     'V',     'TH',              'T',    &
+             'ZLE',   'PS',    'TA',              'QA',   &
+             'UA',    'VA',    'WSPD_STABLE300M',         &
+             'SPEED', 'DZ',    'PLE',             'W',    &
+             'PREF',  'TROPP', 'S',               'PLK',  &
+             'PV',    'TROPK', 'OMEGA',           'PKE'], &
          DST_ID = PHYS,                                                                    &
          SRC_ID = SDYN,                                                                    &
          RC=STATUS  )
@@ -1623,9 +1627,9 @@ contains
    real, pointer, dimension(:,:)       :: TQV    => null()
    real, pointer, dimension(:,:)       :: TQI    => null()
    real, pointer, dimension(:,:)       :: TQL    => null()
-   real, pointer, dimension(:,:)       :: TQR    => null()                
-   real, pointer, dimension(:,:)       :: TQS    => null()                
-   real, pointer, dimension(:,:)       :: TQG    => null()                
+   real, pointer, dimension(:,:)       :: TQR    => null()
+   real, pointer, dimension(:,:)       :: TQS    => null()
+   real, pointer, dimension(:,:)       :: TQG    => null()
    real, pointer, dimension(:,:)       :: TOX    => null()
    real, pointer, dimension(:,:)       :: TROPP1 => null()
    real, pointer, dimension(:,:)       :: TROPP2 => null()
@@ -2668,11 +2672,11 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
     VERIFY_(STATUS)
     call MAPL_GetPointer ( EXPORT, TQL   , 'TQL'   , rc=STATUS )
     VERIFY_(STATUS)
-    call MAPL_GetPointer ( EXPORT, TQR   , 'TQR'   , rc=STATUS )          
+    call MAPL_GetPointer ( EXPORT, TQR   , 'TQR'   , rc=STATUS )
     VERIFY_(STATUS)
-    call MAPL_GetPointer ( EXPORT, TQS   , 'TQS'   , rc=STATUS )          
+    call MAPL_GetPointer ( EXPORT, TQS   , 'TQS'   , rc=STATUS )
     VERIFY_(STATUS)
-    call MAPL_GetPointer ( EXPORT, TQG   , 'TQG'   , rc=STATUS )          
+    call MAPL_GetPointer ( EXPORT, TQG   , 'TQG'   , rc=STATUS )
     VERIFY_(STATUS)
     call MAPL_GetPointer ( EXPORT, QLTOT , 'QLTOT' , rc=STATUS )
     VERIFY_(STATUS)
@@ -2828,7 +2832,7 @@ REPLAYING: if ( DO_PREDICTOR .and. (rplMode == "Regular") ) then
 ! Rain
 ! ------------
        if(NAMES(K)=='QRAIN') then
-          call FILL_Friendly   ( Q,DP,QFILL,QINT ) 
+          call FILL_Friendly   ( Q,DP,QFILL,QINT )
           if(associated(QRFILL))           QRFILL = QRFILL      + QFILL
           if(associated(QTFILL))           QTFILL = QTFILL      + QFILL
           if(associated(DQRDTPHYINT)) DQRDTPHYINT = DQRDTPHYINT + QFILL

--- a/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
@@ -1077,13 +1077,13 @@ contains
     call MAPL_AddConnectivity ( GC,                                                        &
          SRC_NAME  = (/'U            ','V            ','TH           ','T            ',    &
                        'ZLE          ','PS           ','TA           ','QA           ',    &
-                       'US           ','VS           ',                                    &
+                       'US           ','VS           ','WSPD_STABLE300M ',                 &
                        'SPEED        ','DZ           ','PLE          ','W            ',    &
                        'PREF         ','TROPP_BLENDED','S            ','PLK          ',    &
                        'PV           ','TROPK_BLENDED','OMEGA        ','PKE          '/),  &
          DST_NAME  = (/'U     ','V     ','TH    ','T     ',                                &
                        'ZLE   ','PS    ','TA    ','QA    ',                                &
-                       'UA    ','VA    ',                                                  &
+                       'UA    ','VA    ','WSPD_STABLE300M',                                &
                        'SPEED ','DZ    ','PLE   ','W     ',                                &
                        'PREF  ','TROPP ','S     ','PLK   ',                                &
                        'PV    ','TROPK ','OMEGA ','PKE   '/),                              &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -379,10 +379,10 @@ contains
       call MAPL_GetResource( MAPL, NCAR_BKG_GW_DC,      Label="NCAR_BKG_GW_DC:",      default=2.5,    _RC)
       call MAPL_GetResource( MAPL, NCAR_BKG_FCRIT2,     Label="NCAR_BKG_FCRIT2:",     default=1.0,    _RC)
       call MAPL_GetResource( MAPL, NCAR_BKG_WAVELENGTH, Label="NCAR_BKG_WAVELENGTH:", default=1.e5,   _RC)
-      call MAPL_GetResource( MAPL, NCAR_TR_EFF,         Label="NCAR_TR_EFF:",         default=1.0,    _RC)
+      call MAPL_GetResource( MAPL, NCAR_TR_EFF,         Label="NCAR_TR_EFF:",         default=0.75,   _RC)
       call MAPL_GetResource( MAPL, NCAR_ET_EFF,         Label="NCAR_ET_EFF:",         default=1.0,    _RC)
-      call MAPL_GetResource( MAPL, NCAR_ET_TAUBGND,     Label="NCAR_ET_TAUBGND:",     default=6.4,    _RC)
-      call MAPL_GetResource( MAPL, NCAR_ET_USE_DQCDT,   Label="NCAR_ET_USE_DQCDT:",   default=.FALSE., _RC)
+      call MAPL_GetResource( MAPL, NCAR_ET_TAUBGND,     Label="NCAR_ET_TAUBGND:",     default=10.0,   _RC)
+      call MAPL_GetResource( MAPL, NCAR_ET_USE_DQCDT,   Label="NCAR_ET_USE_DQCDT:",   default=.TRUE., _RC)
       call MAPL_GetResource( MAPL, NCAR_BKG_TNDMAX,     Label="NCAR_BKG_TNDMAX:",     default=250.0,  _RC)
       NCAR_BKG_TNDMAX = NCAR_BKG_TNDMAX/86400.0
       ! Beres DeepCu
@@ -685,7 +685,9 @@ contains
          !call MAPL_TimerOn(MAPL,"-INTR_NCAR")
          if ( (self%NCAR_EFFGWORO /= 0.0) .OR. (self%NCAR_EFFGWBKG /= 0.0) ) then
             DO L=1, LM
-               TMP3D(:,:,L) = (1.0-CNV_FRC)*(DQLDT(:,:,L)+DQIDT(:,:,L))
+               ! Raising the mask to the 4th power aggressively suppresses 
+               ! tendencies in regions with even modest CNV_FRC values
+               TMP3D(:,:,L) = ((1.0-CNV_FRC)**4) * (DQLDT(:,:,L)+DQIDT(:,:,L))
             END DO
             if(associated(DQCDT_LS)) DQCDT_LS = TMP3D
             thread = MAPL_get_current_thread()

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -260,6 +260,7 @@ contains
     real    :: NCAR_ET_EFF     ! Frontal region efficiency factor
     real    :: NCAR_ET_TAUBGND ! Extratropical background frontal forcing
     logical :: NCAR_ET_USE_DQCDT
+    logical :: NCAR_ET_USE_SPEED
     logical :: NCAR_DC_BERES
     integer :: GEOS_PGWV
     real :: NCAR_EFFGWBKG
@@ -379,10 +380,18 @@ contains
       call MAPL_GetResource( MAPL, NCAR_BKG_GW_DC,      Label="NCAR_BKG_GW_DC:",      default=2.5,    _RC)
       call MAPL_GetResource( MAPL, NCAR_BKG_FCRIT2,     Label="NCAR_BKG_FCRIT2:",     default=1.0,    _RC)
       call MAPL_GetResource( MAPL, NCAR_BKG_WAVELENGTH, Label="NCAR_BKG_WAVELENGTH:", default=1.e5,   _RC)
-      call MAPL_GetResource( MAPL, NCAR_TR_EFF,         Label="NCAR_TR_EFF:",         default=0.75,   _RC)
+      call MAPL_GetResource( MAPL, NCAR_TR_EFF,         Label="NCAR_TR_EFF:",         default=0.625,  _RC)
       call MAPL_GetResource( MAPL, NCAR_ET_EFF,         Label="NCAR_ET_EFF:",         default=1.0,    _RC)
-      call MAPL_GetResource( MAPL, NCAR_ET_TAUBGND,     Label="NCAR_ET_TAUBGND:",     default=10.0,   _RC)
+
       call MAPL_GetResource( MAPL, NCAR_ET_USE_DQCDT,   Label="NCAR_ET_USE_DQCDT:",   default=.TRUE., _RC)
+      call MAPL_GetResource( MAPL, NCAR_ET_USE_SPEED,   Label="NCAR_ET_USE_SPEED:",   default=.TRUE., _RC)
+
+      ! 1. Default to classic rigid latitude tuning
+      NCAR_ET_TAUBGND = 6.4 
+      ! 2. Set baselines for independent runs
+      if (NCAR_ET_USE_DQCDT .or. NCAR_ET_USE_SPEED) NCAR_ET_TAUBGND = 6.75
+      call MAPL_GetResource( MAPL, NCAR_ET_TAUBGND,     Label="NCAR_ET_TAUBGND:",     default=NCAR_ET_TAUBGND, _RC)
+
       call MAPL_GetResource( MAPL, NCAR_BKG_TNDMAX,     Label="NCAR_BKG_TNDMAX:",     default=250.0,  _RC)
       NCAR_BKG_TNDMAX = NCAR_BKG_TNDMAX/86400.0
       ! Beres DeepCu
@@ -397,7 +406,7 @@ contains
                                     self%workspaces(thread)%beres_dc_desc, &
                                     NCAR_BKG_PGWV, NCAR_BKG_GW_DC, NCAR_BKG_FCRIT2, &
                                     NCAR_BKG_WAVELENGTH, NCAR_DC_BERES_SRC_LEVEL, &
-                                    1000.0, .TRUE., NCAR_TR_EFF, NCAR_ET_EFF, NCAR_ET_TAUBGND, NCAR_ET_USE_DQCDT, &
+                                    1000.0, .TRUE., NCAR_TR_EFF, NCAR_ET_EFF, NCAR_ET_TAUBGND, NCAR_ET_USE_DQCDT, NCAR_ET_USE_SPEED, &
                                     NCAR_BKG_TNDMAX, NCAR_DC_BERES, &
                                     IM*JM_thread, LATS(:,bounds(thread+1)%min:bounds(thread+1)%max))
           end do
@@ -407,7 +416,7 @@ contains
                               self%workspaces(0)%beres_dc_desc, &
                               NCAR_BKG_PGWV, NCAR_BKG_GW_DC, NCAR_BKG_FCRIT2, &
                               NCAR_BKG_WAVELENGTH, NCAR_DC_BERES_SRC_LEVEL, &
-                              1000.0, .TRUE., NCAR_TR_EFF, NCAR_ET_EFF, NCAR_ET_TAUBGND, NCAR_ET_USE_DQCDT, &
+                              1000.0, .TRUE., NCAR_TR_EFF, NCAR_ET_EFF, NCAR_ET_TAUBGND, NCAR_ET_USE_DQCDT, NCAR_ET_USE_SPEED, &
                               NCAR_BKG_TNDMAX, NCAR_DC_BERES, &
                               IM*JM, LATS )
       endif
@@ -696,7 +705,7 @@ contains
                  workspace%beres_dc_desc, &
                  workspace%beres_band, workspace%oro_band, workspace%rdg_band, &
                  PLE,       T,          U,          V,                   &
-                 HT_dc,                 TMP3D,                           &
+                 HT_dc,     TMP3D,      WSPD_STABLE300M,                 &
                  SGH,       MXDIS,      HWDTH,      CLNGT,  ANGLL,       &
                  ANIXY,     GBXAR_TMP,  KWVRDG,     EFFRDG, PREF,        &
                  PMID,      PDEL,       RPDEL,      PILN,   ZM,    LATS, &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GWD_StateSpecs.rc
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GWD_StateSpecs.rc
@@ -20,23 +20,24 @@ category: IMPORT
 #-------------------------------------------------------------------------------------------------------
 #  VARIABLE    | DIMENSIONS  |          Additional Metadata
 #-------------------------------------------------------------------------------------------------------
- NAME    | ALIAS | UNITS   | DIMS | VLOC | RESTART | LONG NAME
+ NAME      | ALIAS | UNITS   | DIMS | VLOC | RESTART | LONG NAME
 #-------------------------------------------------------------------------------------------------------
- PLE     |       | Pa          | xyz  | E    | SKIP    | air_pressure
- T       |       | K           | xyz  | C    | SKIP    | air_temperature
- Q       |       | kg kg-1     | xyz  | C    | SKIP    | specific_humidity
- U       |       | m s-1       | xyz  | C    | SKIP    | eastward_wind
- V       |       | m s-1       | xyz  | C    | SKIP    | northward_wind
- PHIS    |       | m+2 s-2     | xy   | N    | SKIP    | surface geopotential height
- SGH     |       | m           | xy   | N    | SKIP    | standard_deviation_of_topography
- VARFLT  |       | m+2         | xy   | N    | SKIP    | variance_of_the_filtered_topography
- PREF    |       | Pa          |   z  | E    | SKIP    | reference_air_pressure
- AREA    |       | m^2         | xy   | N    | SKIP    | grid_box_area
+ PLE       |       | Pa          | xyz  | E    | SKIP    | air_pressure
+ T         |       | K           | xyz  | C    | SKIP    | air_temperature
+ Q         |       | kg kg-1     | xyz  | C    | SKIP    | specific_humidity
+ U         |       | m s-1       | xyz  | C    | SKIP    | eastward_wind
+ V         |       | m s-1       | xyz  | C    | SKIP    | northward_wind
+ PHIS      |       | m+2 s-2     | xy   | N    | SKIP    | surface geopotential height
+ SGH       |       | m           | xy   | N    | SKIP    | standard_deviation_of_topography
+ VARFLT    |       | m+2         | xy   | N    | SKIP    | variance_of_the_filtered_topography
+ PREF      |       | Pa          |   z  | E    | SKIP    | reference_air_pressure
+ AREA      |       | m^2         | xy   | N    | SKIP    | grid_box_area
+ WSPD_STABLE300M | | m s-1       | xy   | N    | SKIP    | max_wind_speed_in_stable_cold_surface_layer
 #-from-moist-
- DTDT_DC | HT_dc | K s-1       | xyz  | C    |         | T tendency due to deep convection
- DQLDT   |       | kg kg-1 s-1 | xyz  | C    |         | total_liq_water_tendency_due_to_moist
- DQIDT   |       | kg kg-1 s-1 | xyz  | C    |         | total_ice_water_tendency_due_to_moist
- CNV_FRC |       | 1           | xy   | N    |         | convective_fraction
+ DTDT_DC   | HT_dc | K s-1       | xyz  | C    |         | T tendency due to deep convection
+ DQLDT     |       | kg kg-1 s-1 | xyz  | C    |         | total_liq_water_tendency_due_to_moist
+ DQIDT     |       | kg kg-1 s-1 | xyz  | C    |         | total_ice_water_tendency_due_to_moist
+ CNV_FRC   |       | 1           | xy   | N    |         | convective_fraction
 
 category: EXPORT
 #-------------------------------------------------------------------------------------------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_convect.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_convect.F90
@@ -47,6 +47,7 @@ type :: BeresSourceDesc
    ! Efficiency TR:ET function
    real, allocatable :: effbck(:)
    logical :: et_bkg_dqcdt_forcing
+   logical :: et_bkg_speed_forcing
 end type BeresSourceDesc
 
 
@@ -57,7 +58,7 @@ contains
 !------------------------------------
 subroutine gw_beres_init (file_name, band, desc, pgwv, gw_dc, fcrit2, wavelength, &
                           spectrum_source, min_hdepth, storm_shift, eff_tr, eff_et, &
-                          tau_et, et_use_dqcdt, tndmax, &
+                          tau_et, et_use_dqcdt, et_use_speed, tndmax, &
                           active, ncol, lats)
 #include <netcdf.inc>
 
@@ -69,7 +70,7 @@ subroutine gw_beres_init (file_name, band, desc, pgwv, gw_dc, fcrit2, wavelength
   integer, intent(in) :: pgwv, ncol
   real, intent(in) :: gw_dc, fcrit2, wavelength
   real, intent(in) :: spectrum_source, min_hdepth, eff_tr, eff_et, tau_et, tndmax
-  logical, intent(in) :: storm_shift, active, et_use_dqcdt
+  logical, intent(in) :: storm_shift, active, et_use_dqcdt, et_use_speed
   real, intent(in) :: lats(ncol)
 
   ! Stuff for Beres convective gravity wave source.
@@ -178,24 +179,30 @@ subroutine gw_beres_init (file_name, band, desc, pgwv, gw_dc, fcrit2, wavelength
     enddo
     cw = cw*(sum(cw4)/sum(cw)) 
     desc%et_bkg_dqcdt_forcing = et_use_dqcdt
+    desc%et_bkg_speed_forcing = et_use_speed
     do i=1,ncol
       ! include forced background stress in extra tropics
       ! Determine the background stress at c=0
-      ! Include dependence on latitude:
-       latdeg = lats(i)*rad2deg
-       if (desc%et_bkg_dqcdt_forcing) then
+       if (desc%et_bkg_dqcdt_forcing .or. desc%et_bkg_speed_forcing) then
           flat_gw = 0.05 ! weak background forcing
+          ! Scale the extratropical stress to account for changes in tropical efficiency
+          ! (e.g., if tau_et=8.0, eff_et=1.0, eff_tr=0.625, tau_et_scaled becomes 12.8)
+          desc%taubck(i,:) = tau_et*(eff_et/eff_tr)*0.001*flat_gw*cw
+         ! efficiency function (now constant based on QBO tuning)
+          desc%effbck(i) = eff_tr
        else
+         ! Include dependence on latitude:
+          latdeg = lats(i)*rad2deg
           if (ABS(latdeg) <  60.) then
             flat_gw =  max(0.15,0.50*exp(-((abs(latdeg)-60.)/23.)**2))
           elseif (ABS(latdeg) >= 60.) then
             flat_gw =           0.50*exp(-((abs(latdeg)-60.)/70.)**2)
           endif
+          desc%taubck(i,:) = tau_et*0.001*flat_gw*cw
+         ! efficiency function
+          desc%effbck(i) = eff_tr*cos(lats(i))**2 + &
+                           eff_et*sin(lats(i))**2
        endif
-       desc%taubck(i,:) = tau_et*0.001*flat_gw*cw
-      ! efficiency function
-       desc%effbck(i) = eff_tr*cos(lats(i))**2 + &
-                        eff_et*sin(lats(i))**2
     enddo
     deallocate( cw, cw4 )
   end if
@@ -205,7 +212,7 @@ end subroutine gw_beres_init
 !------------------------------------
 subroutine gw_beres_src(ncol, pver, band, desc, pint, u, v, &
      netdt, zm, src_level, tend_level, tau, ubm, ubi, xv, yv, &
-     c, hdepth, maxq0, lats, dqcdt)
+     c, hdepth, maxq0, dqcdt, speed)
 !-----------------------------------------------------------------------
 ! Driver for multiple gravity wave drag parameterization.
 !
@@ -239,8 +246,6 @@ subroutine gw_beres_src(ncol, pver, band, desc, pint, u, v, &
   real, intent(in) :: netdt(:,:)
   ! Midpoint altitudes.
   real, intent(in) :: zm(ncol,pver)
-  ! latitudes.
-  real, intent(in) :: lats(ncol)
 
   ! Indices of top gravity wave source level and lowest level where wind
   ! tendencies are allowed.
@@ -260,8 +265,9 @@ subroutine gw_beres_src(ncol, pver, band, desc, pint, u, v, &
   ! Heating depth [m] and maximum heating in each column.
   real, intent(out) :: hdepth(ncol), maxq0(ncol)
 
-  ! Condensate tendency due to large-scale (kg kg-1 s-1)
+  ! Frontal and Jet proxy inputs
   real, intent(in) :: dqcdt(ncol,pver)  ! Condensate tendency due to large-scale (kg kg-1 s-1)
+  real, intent(in) :: speed(ncol)       ! Katabatic proxy: Max wind speed in lowest 300m stable layer (m s-1)
 
 !---------------------------Local Storage-------------------------------
   ! Column and level indices.
@@ -272,6 +278,7 @@ subroutine gw_beres_src(ncol, pver, band, desc, pint, u, v, &
 
   ! Maximum heating rate.
   real(GW_PRC) :: q0(ncol)
+  real(GW_PRC) :: moist_mult, dry_mult, phys_mult
 
   ! Bottom/top heating range index.
   integer  :: boti(ncol), topi(ncol)
@@ -472,7 +479,36 @@ subroutine gw_beres_src(ncol, pver, band, desc, pint, u, v, &
      else
 
         tau(i,:,:) = 0.0
-        if (.not. desc%et_bkg_dqcdt_forcing) then
+        if (desc%et_bkg_dqcdt_forcing .or. desc%et_bkg_speed_forcing) then
+          ! -----------------------------------------------------------------
+          ! Frontal Detection via Combined Physical Proxies
+          ! 1. DQCDT_LS captures the wet, lifting cores of the storm tracks.
+          ! 2. SPEED    captures dry katabatic winds and broad, windy storm flanks.
+          ! -----------------------------------------------------------------
+          ! Proxy 1: The Moist Condensate (Precipitation)
+           if (desc%et_bkg_dqcdt_forcing) then
+               q0(i) = 0.0
+               do k = desc%k(i), 1, -1
+                 if (dqcdt(i,k) > q0(i)) q0(i) = dqcdt(i,k)
+               end do
+               ! Scale moist multiplier (using the optimized * 5.e8 factor)
+               moist_mult = MAX(1.0, MIN(10.0,q0(i) * 5.e8))
+           else
+               moist_mult = 1.0
+           endif
+          ! Proxy 2: The Dry Wind (Katabatic winds)
+           if (desc%et_bkg_speed_forcing) then
+               ! A baseline     5 m/s wind yields a 1.0x multiplier (no extra drag).
+               ! A linear 5 to 25 m/s ramp (1 - 20)x
+               ! A howling    +25 m/s katabatic wind yields 20.0x drag.
+               dry_mult = MAX(1.0, MIN(20.0,1.0 + (speed(i) - 5.0) * (19.0 / 20.0)))
+           else
+               dry_mult = 1.0
+           endif
+           phys_mult = MAX(1.0, moist_mult+dry_mult-1.0)
+           tau(i,:,desc%k(i)+1) = desc%taubck(i,:) * phys_mult
+           topi(i) = desc%k(i)
+        else
           ! use latitudinal dependence
           ! include forced background stress in extra tropical large-scale systems
           ! Set the phase speeds and wave numbers in the direction of the source wind.
@@ -480,21 +516,8 @@ subroutine gw_beres_src(ncol, pver, band, desc, pint, u, v, &
           ! stress is the same as (c-u).
            tau(i,:,desc%k(i)+1) = desc%taubck(i,:)
            topi(i) = desc%k(i)
-        else
-          ! Find largest condensate change level, for frontal detection
-          ! Using POSITIVE tendencies which correctly align with precipitation fronts
-           q0(i) = 0.0
-           do k = desc%k(i), 1, -1 ! tend-level to the surface [avoid convective overlap]
-             if (dqcdt(i,k) > q0(i)) then ! Find largest positive DQCDT tendency
-                q0(i) = dqcdt(i,k)
-             endif
-           end do
-          ! include forced background stress in extra tropical large-scale systems
-          ! Using 1.e-8 so that values of 100-1000 (scaled) provide 10x multiplier
-           tau(i,:,desc%k(i)+1) = desc%taubck(i,:) * MIN(10.0,MAX(1.0,q0(i)/1.e-8))
-           topi(i) = desc%k(i)
         endif
-
+ 
      endif
 
   enddo
@@ -520,8 +543,8 @@ subroutine gw_beres_ifc( band, &
    ncol, pver, dt, effgw_dp,  &
    u, v, t, pref, pint, delp, rdelp, piln, &
    zm, zi, nm, ni, rhoi, kvtt,  &
-   netdt,desc,lats, alpha, &
-   utgw,vtgw,ttgw,flx_heat,dqcdt)
+   netdt,desc, alpha, &
+   utgw,vtgw,ttgw,flx_heat,dqcdt,speed)
 
    type(BeresSourceDesc), intent(inout) :: desc
    type(GWBand), intent(in) :: band         ! I hate this variable  ... it just hides information from view
@@ -546,7 +569,6 @@ subroutine gw_beres_ifc( band, &
    real,         intent(in) :: rhoi(ncol,pver+1) ! Interface density (kg m-3).
    real,         intent(in) :: kvtt(ncol,pver+1) ! Molecular thermal diffusivity.
 
-   real,         intent(in) :: lats(ncol)      ! latitudes
    real,         intent(in) :: alpha(:)
 
    real,         intent(out) :: utgw(ncol,pver)       ! zonal wind tendency
@@ -555,6 +577,7 @@ subroutine gw_beres_ifc( band, &
    real,         intent(inout) :: flx_heat(ncol)        ! Energy change
 
    real,         intent(in) :: dqcdt(ncol,pver)  ! Condensate tendency due to large-scale (kg kg-1 s-1)
+   real,         intent(in) :: speed(ncol)       ! max_wind_speed_in_stable_cold_surface_layer_to_300m (m s-1)
 
    !---------------------------Local storage-------------------------------
 
@@ -613,7 +636,8 @@ subroutine gw_beres_ifc( band, &
      ! Determine wave sources for Beres deep scheme
      call gw_beres_src(ncol, pver, band, desc, pint, &
           u, v, netdt, zm, src_level, tend_level, tau, &
-          ubm, ubi, xv, yv, c, hdepth, maxq0, lats, dqcdt=dqcdt)
+          ubm, ubi, xv, yv, c, hdepth, maxq0, &
+          dqcdt=dqcdt, speed=speed)
 
      ! Solve for the drag profile with convective sources.
      call gw_drag_prof(ncol, pver, band, pint, delp, rdelp, & 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_convect.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_convect.F90
@@ -184,7 +184,7 @@ subroutine gw_beres_init (file_name, band, desc, pgwv, gw_dc, fcrit2, wavelength
       ! Include dependence on latitude:
        latdeg = lats(i)*rad2deg
        if (desc%et_bkg_dqcdt_forcing) then
-          flat_gw = 0.15
+          flat_gw = 0.05 ! weak background forcing
        else
           if (ABS(latdeg) <  60.) then
             flat_gw =  max(0.15,0.50*exp(-((abs(latdeg)-60.)/23.)**2))
@@ -482,7 +482,7 @@ subroutine gw_beres_src(ncol, pver, band, desc, pint, u, v, &
            topi(i) = desc%k(i)
         else
           ! Find largest condensate change level, for frontal detection
-          ! condensate tendencies from microphysics will be negative
+          ! Using POSITIVE tendencies which correctly align with precipitation fronts
            q0(i) = 0.0
            do k = desc%k(i), 1, -1 ! tend-level to the surface [avoid convective overlap]
              if (dqcdt(i,k) > q0(i)) then ! Find largest positive DQCDT tendency
@@ -490,10 +490,8 @@ subroutine gw_beres_src(ncol, pver, band, desc, pint, u, v, &
              endif
            end do
           ! include forced background stress in extra tropical large-scale systems
-          ! Set the phase speeds and wave numbers in the direction of the source wind.
-          ! Set the source stress magnitude (positive only, note that the sign of the 
-          ! stress is the same as (c-u).
-           tau(i,:,desc%k(i)+1) = desc%taubck(i,:) * MIN(10.0,MAX(1.0,abs(q0(i)/1.e-9)))
+          ! Using 1.e-8 so that values of 100-1000 (scaled) provide 10x multiplier
+           tau(i,:,desc%k(i)+1) = desc%taubck(i,:) * MIN(10.0,MAX(1.0,q0(i)/1.e-8))
            topi(i) = desc%k(i)
         endif
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
@@ -58,7 +58,7 @@ contains
   subroutine gw_intr_ncar(pcols,      pver,         dt,         nrdg,                &    
           beres_dc_desc, beres_band,   oro_band, rdg_band,                           &
           pint_dev,      t_dev,         u_dev,        v_dev,                         &
-          ht_dc_dev,     dqcdt_dev,                                                  &
+          ht_dc_dev,     dqcdt_dev,     speed_dev,                                   &
           sgh_dev,       mxdis_dev,     hwdth_dev,    clngt_dev,  angll_dev,         &
           anixy_dev,     gbxar_dev,     kwvrdg_dev,   effrdg_dev, pref_dev,          & 
           pmid_dev,      pdel_dev,      rpdel_dev,    lnpint_dev, zm_dev,  rlat_dev, &
@@ -92,6 +92,7 @@ contains
     real,    intent(in   ) :: v_dev(pcols,pver)        ! meridional wind at layers
     real,    intent(in   ) :: ht_dc_dev(pcols,pver)    ! DeepCu heating in layers
     real,    intent(in   ) :: dqcdt_dev(pcols,pver)    ! Condensate tendencies due to large-scale
+    real,    intent(in   ) :: speed_dev(pcols,pver)    ! max_wind_speed_in_stable_cold_surface_layer_to_300m
     real,    intent(in   ) :: sgh_dev(pcols)           ! standard deviation of orography
 !++jtb 01/25/21 New topo vars
     real,    intent(in   ) :: mxdis_dev(pcols,nrdg)     ! obstacle/ridge height 
@@ -211,8 +212,8 @@ contains
        pdel_dev , rpdel_dev, lnpint_dev, &
        zm_dev, zi, &
        nm, ni, rhoi, kvtt,  &
-       ht_dc_dev,beres_dc_desc,rlat_dev, alpha, &
-       utgw, vtgw, ttgw, flx_heat, dqcdt_dev)
+       ht_dc_dev,beres_dc_desc, alpha, &
+       utgw, vtgw, ttgw, flx_heat, dqcdt_dev, speed_dev)
        dudt_gwd_dev = dudt_gwd_dev + utgw
        dvdt_gwd_dev = dvdt_gwd_dev + vtgw
        dtdt_gwd_dev = dtdt_gwd_dev + ttgw

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
@@ -50,53 +50,56 @@ module GEOSmoist_Process_Library
    ! In anvil/convective clouds
    real, parameter :: aT_ICE_ALL = 243.66
    real, parameter :: aT_ICE_MAX = 265.66
-   real, parameter :: aICEFRPWR  = 2.0
-   ! Over Land Ice SRF_TYPE == 4
-   real, parameter :: liT_ICE_ALL = 233.16
-   real, parameter :: liT_ICE_MAX = 258.16
-   real, parameter :: liICEFRPWR  = 6.0
-   ! Over Ice SRF_TYPE == 3
-   real, parameter :: iT_ICE_ALL = 236.16
-   real, parameter :: iT_ICE_MAX = 261.16
-   real, parameter :: iICEFRPWR  = 4.0
-   ! Over Snow SRF_TYPE = 2
-   real, parameter :: sT_ICE_ALL = 235.16
-   real, parameter :: sT_ICE_MAX = 260.16
-   real, parameter :: sICEFRPWR  = 6.0
-   ! Over Land     SRF_TYPE = 1
+   real, parameter :: aT_ICE_PWR = 2.0
+   ! Over Land Ice SRF_TYPE == 4 (Antarctica / Greenland)
+   ! OLD: 233.16 / 258.16 / 6.0
+   real, parameter :: liT_ICE_ALL = 245.16  ! 100% ice at -28C (was -40C)
+   real, parameter :: liT_ICE_MAX = 268.16  ! Ice starts at -5C (was -15C)
+   real, parameter :: liT_ICE_PWR = 1.5     ! Linear-quadratic transition (was 6.0)
+   ! Over Ice SRF_TYPE == 3 (Arctic Sea Ice)
+   ! OLD: 236.16 / 261.16 / 4.0
+   real, parameter :: iT_ICE_ALL = 246.16   ! 100% ice at -27C (was -37C)
+   real, parameter :: iT_ICE_MAX = 268.16   ! Ice starts at -5C (was -12C)
+   real, parameter :: iT_ICE_PWR = 1.5      ! (was 4.0)
+   ! Over Snow SRF_TYPE = 2 (Winter high-latitude land)
+   ! OLD: 235.16 / 260.16 / 6.0
+   real, parameter :: sT_ICE_ALL = 245.16   ! 100% ice at -28C (was -38C)
+   real, parameter :: sT_ICE_MAX = 268.16   ! Ice starts at -5C (was -13C)
+   real, parameter :: sT_ICE_PWR = 1.5      ! (was 6.0)
+   ! Over Land SRF_TYPE = 1 (Keep default or lower power slightly)
    real, parameter :: lT_ICE_ALL = 240.16
    real, parameter :: lT_ICE_MAX = 262.16
-   real, parameter :: lICEFRPWR  = 2.0
+   real, parameter :: lT_ICE_PWR = 1.5      ! (was 2.0)
    ! Over Oceans   SRF_TYPE = 0
    real, parameter :: oT_ICE_ALL = 238.16
    real, parameter :: oT_ICE_MAX = 263.16
-   real, parameter :: oICEFRPWR  = 3.0
+   real, parameter :: oT_ICE_PWR = 3.0
 
    ! Jason constants
    ! In anvil/convective clouds
    real, parameter :: JaT_ICE_ALL = 245.16
    real, parameter :: JaT_ICE_MAX = 261.16
-   real, parameter :: JaICEFRPWR  = 2.0
+   real, parameter :: JaT_ICE_PWR = 2.0
    ! Over Land Ice SRF_TYPE == 4
    real, parameter :: JliT_ICE_ALL = 236.16
    real, parameter :: JliT_ICE_MAX = 261.16
-   real, parameter :: JliICEFRPWR  = 5.0
+   real, parameter :: JliT_ICE_PWR = 5.0
    ! Over Ice SRF_TYPE == 3
    real, parameter :: JiT_ICE_ALL = 236.16
    real, parameter :: JiT_ICE_MAX = 261.16
-   real, parameter :: JiICEFRPWR  = 5.0
+   real, parameter :: JiT_ICE_PWR = 5.0
    ! Over Snow SRF_TYPE = 2
    real, parameter :: JsT_ICE_ALL = 236.16
    real, parameter :: JsT_ICE_MAX = 261.16 
-   real, parameter :: JsICEFRPWR  = 5.0
+   real, parameter :: JsT_ICE_PWR = 5.0
    ! Over Land     SRF_TYPE = 1
    real, parameter :: JlT_ICE_ALL = 239.16
    real, parameter :: JlT_ICE_MAX = 261.16
-   real, parameter :: JlICEFRPWR  = 2.0
+   real, parameter :: JlT_ICE_PWR = 2.0
    ! Over Oceans   SRF_TYPE = 0
    real, parameter :: JoT_ICE_ALL = 238.16
    real, parameter :: JoT_ICE_MAX = 263.16
-   real, parameter :: JoICEFRPWR  = 4.0
+   real, parameter :: JoT_ICE_PWR = 4.0
 
    logical :: USE_BERGERON = .FALSE.
    logical :: USE_AEROSOL_NN = .TRUE.
@@ -655,7 +658,7 @@ module GEOSmoist_Process_Library
          end if
          ICEFRCT_C = MIN(ICEFRCT_C,1.00)
          ICEFRCT_C = MAX(ICEFRCT_C,0.00)
-         ICEFRCT_C = ICEFRCT_C**aICEFRPWR
+         ICEFRCT_C = ICEFRCT_C**aT_ICE_PWR
 
          ! ------------------------------------------------------------------
          ! 2. Grid-Scale / Mesh Cloud Ice Fraction (ICEFRCT_M)
@@ -672,7 +675,7 @@ module GEOSmoist_Process_Library
            end if
            ICEFRCT_M = MIN(ICEFRCT_M,1.00)
            ICEFRCT_M = MAX(ICEFRCT_M,0.00) 
-           ICEFRCT_M = ICEFRCT_M**JiICEFRPWR
+           ICEFRCT_M = ICEFRCT_M**JiT_ICE_PWR
          case (SRF_TYPE_LAND)
            ! Over Land (SRF_TYPE == 1)
            ICEFRCT_M  = 0.00
@@ -683,7 +686,7 @@ module GEOSmoist_Process_Library
            end if
            ICEFRCT_M = MIN(ICEFRCT_M,1.00)
            ICEFRCT_M = MAX(ICEFRCT_M,0.00)
-           ICEFRCT_M = ICEFRCT_M**JlICEFRPWR
+           ICEFRCT_M = ICEFRCT_M**JlT_ICE_PWR
          case (SRF_TYPE_OCEAN)
            ! Over Oceans (SRF_TYPE == 0)
            ICEFRCT_M  = 0.00
@@ -694,7 +697,7 @@ module GEOSmoist_Process_Library
            end if
            ICEFRCT_M = MIN(ICEFRCT_M,1.00)
            ICEFRCT_M = MAX(ICEFRCT_M,0.00)
-           ICEFRCT_M = ICEFRCT_M**JoICEFRPWR
+           ICEFRCT_M = ICEFRCT_M**JoT_ICE_PWR
          case default
            ! You should not be here
            print *, 'ICE_FRACTION_SC: Unknown SRF_TYPE = ',SRF_TYPE
@@ -715,7 +718,7 @@ module GEOSmoist_Process_Library
          else if ( TEMP <= aT_ICE_MAX ) then
             ICEFRCT_C = SIN( 0.5*MAPL_PI*( 1.00 - ( TEMP - aT_ICE_ALL ) / ( aT_ICE_MAX - aT_ICE_ALL ) ) )
          end if
-         ICEFRCT_C = MAX(0.00, MIN(1.00, ICEFRCT_C)) ** aICEFRPWR
+         ICEFRCT_C = MAX(0.00, MIN(1.00, ICEFRCT_C)) ** aT_ICE_PWR
 
          ! ------------------------------------------------------------------
          ! 2. Grid-Scale / Mesh Cloud Ice Fraction (ICEFRCT_M)
@@ -725,23 +728,23 @@ module GEOSmoist_Process_Library
          case (SRF_TYPE_LANDICE)
               t_all_loc = liT_ICE_ALL
               t_max_loc = liT_ICE_MAX
-              pwr_loc   = liICEFRPWR
+              pwr_loc   = liT_ICE_PWR
          case (SRF_TYPE_ICE)
               t_all_loc = iT_ICE_ALL
               t_max_loc = iT_ICE_MAX
-              pwr_loc   = iICEFRPWR
+              pwr_loc   = iT_ICE_PWR
          case (SRF_TYPE_SNOW)
               t_all_loc = sT_ICE_ALL
               t_max_loc = sT_ICE_MAX
-              pwr_loc   = sICEFRPWR
+              pwr_loc   = sT_ICE_PWR
          case (SRF_TYPE_LAND)
               t_all_loc = lT_ICE_ALL
               t_max_loc = lT_ICE_MAX
-              pwr_loc   = lICEFRPWR
+              pwr_loc   = lT_ICE_PWR
          case (SRF_TYPE_OCEAN)
               t_all_loc = oT_ICE_ALL
               t_max_loc = oT_ICE_MAX
-              pwr_loc   = oICEFRPWR
+              pwr_loc   = oT_ICE_PWR
          case default
            ! You should not be here
            print *, 'ICE_FRACTION_SC: Unknown SRF_TYPE = ',SRF_TYPE

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
@@ -52,24 +52,22 @@ module GEOSmoist_Process_Library
    real, parameter :: aT_ICE_MAX = 265.66
    real, parameter :: aT_ICE_PWR = 2.0
    ! Over Land Ice SRF_TYPE == 4 (Antarctica / Greenland)
-   ! OLD: 233.16 / 258.16 / 6.0
-   real, parameter :: liT_ICE_ALL = 245.16  ! 100% ice at -28C (was -40C)
-   real, parameter :: liT_ICE_MAX = 268.16  ! Ice starts at -5C (was -15C)
-   real, parameter :: liT_ICE_PWR = 1.5     ! Linear-quadratic transition (was 6.0)
+   real, parameter :: liT_ICE_ALL = 233.16
+   real, parameter :: liT_ICE_MAX = 258.16
+   real, parameter :: liT_ICE_PWR = 6.0
    ! Over Ice SRF_TYPE == 3 (Arctic Sea Ice)
    ! OLD: 236.16 / 261.16 / 4.0
-   real, parameter :: iT_ICE_ALL = 246.16   ! 100% ice at -27C (was -37C)
-   real, parameter :: iT_ICE_MAX = 268.16   ! Ice starts at -5C (was -12C)
-   real, parameter :: iT_ICE_PWR = 1.5      ! (was 4.0)
+   real, parameter :: iT_ICE_ALL = 236.16
+   real, parameter :: iT_ICE_MAX = 261.16
+   real, parameter :: iT_ICE_PWR = 4.0
    ! Over Snow SRF_TYPE = 2 (Winter high-latitude land)
-   ! OLD: 235.16 / 260.16 / 6.0
-   real, parameter :: sT_ICE_ALL = 245.16   ! 100% ice at -28C (was -38C)
-   real, parameter :: sT_ICE_MAX = 268.16   ! Ice starts at -5C (was -13C)
-   real, parameter :: sT_ICE_PWR = 1.5      ! (was 6.0)
-   ! Over Land SRF_TYPE = 1 (Keep default or lower power slightly)
+   real, parameter :: sT_ICE_ALL = 235.16
+   real, parameter :: sT_ICE_MAX = 260.16
+   real, parameter :: sT_ICE_PWR = 6.0
+   ! Over Land SRF_TYPE = 1
    real, parameter :: lT_ICE_ALL = 240.16
    real, parameter :: lT_ICE_MAX = 262.16
-   real, parameter :: lT_ICE_PWR = 1.5      ! (was 2.0)
+   real, parameter :: lT_ICE_PWR = 2.0
    ! Over Oceans   SRF_TYPE = 0
    real, parameter :: oT_ICE_ALL = 238.16
    real, parameter :: oT_ICE_MAX = 263.16

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_mp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_mp.F90
@@ -4919,15 +4919,7 @@ subroutine pwbf (ks, ke, dts, qa, qv, ql, qr, qi, qs, qg, dp, tz, cvm, te8, den,
     real :: tc, tin, sink, dqdt, qsw, qsi, qim, tmp, fac_wbf
 
     real :: tau_wbf_eff
-    real, parameter :: wbf_coarse_mult = 2.5 ! How much slower WBF is at 50km vs 2km
-
-    ! Change from parameter to variable
-    real :: pwbf_qi_crt_eff, ramp_factor
-    
-    ! Linear ramp parameters (tc = Tfreezing - T)
-    real, parameter :: tc_warm = 5.0   ! Start ramping down at -5C
-    real, parameter :: tc_cold = 20.0  ! Fully ramped down at -20C
-    real, parameter :: min_scale = 0.25 ! Minimum scale factor (25% of default)
+    real, parameter :: wbf_coarse_mult = 9.0 ! How much slower WBF is at 50km vs 2km
 
     if (.not. do_wbf) return
 
@@ -4957,25 +4949,8 @@ subroutine pwbf (ks, ke, dts, qa, qv, ql, qr, qi, qs, qg, dp, tz, cvm, te8, den,
            (qi (k) .gt. qcmin .or. tc .gt. 15.0) .and. &
             qv (k) .gt. qsi) then
 
-            ! --- Smooth Linear Temperature Ramp ---
-            if (tc .le. tc_warm) then
-                ramp_factor = 1.0
-            else if (tc .ge. tc_cold) then
-                ramp_factor = min_scale
-            else
-                ramp_factor = 1.0 - (1.0 - min_scale) * ((tc - tc_warm) / (tc_cold - tc_warm))
-            endif
-            ! 1. Dynamically shrink the threshold (forces ice to precipitate as snow)
-            pwbf_qi_crt_eff = pwbf_qi_crt * ramp_factor
-            ! 2. Dynamically accelerate the timescale (shorter tau = faster QL destruction)
-            ! At tc_cold, this drops tau_wbf to 60s and completely removes the coarse multiplier bias
-            tau_wbf_eff = tau_wbf * (wbf_coarse_mult * (1.0 - onemsig) + onemsig) * ramp_factor
-            ! 3. Final timescale factor
-            fac_wbf = 1. - exp (- dts / tau_wbf_eff)
-            ! --------------------------------------
-
             sink = min (fac_wbf * ql (k), tc / icpk (k))
-            qim = pwbf_qi_crt_eff / den (k)
+            qim = pwbf_qi_crt / den (k)
             tmp = min (sink, dim (qim, qi (k)))
             mppfw = mppfw + sink * dp (k) * convt
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_mp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_mp.F90
@@ -4919,7 +4919,15 @@ subroutine pwbf (ks, ke, dts, qa, qv, ql, qr, qi, qs, qg, dp, tz, cvm, te8, den,
     real :: tc, tin, sink, dqdt, qsw, qsi, qim, tmp, fac_wbf
 
     real :: tau_wbf_eff
-    real, parameter :: wbf_coarse_mult = 9.0 ! How much slower WBF is at 50km vs 2km
+    real, parameter :: wbf_coarse_mult = 2.5 ! How much slower WBF is at 50km vs 2km
+
+    ! Change from parameter to variable
+    real :: pwbf_qi_crt_eff, ramp_factor
+    
+    ! Linear ramp parameters (tc = Tfreezing - T)
+    real, parameter :: tc_warm = 5.0   ! Start ramping down at -5C
+    real, parameter :: tc_cold = 20.0  ! Fully ramped down at -20C
+    real, parameter :: min_scale = 0.25 ! Minimum scale factor (25% of default)
 
     if (.not. do_wbf) return
 
@@ -4944,11 +4952,30 @@ subroutine pwbf (ks, ke, dts, qa, qv, ql, qr, qi, qs, qg, dp, tz, cvm, te8, den,
         ! heterogeneity and allow WBF to operate in large-scale updrafts
         ! when the environment is supersaturated with respect to ice (qv > qsi)
         ! and there is both liquid and ice present 
-        if (tc .gt. 0. .and. ql (k) .gt. qcmin .and. qi (k) .gt. qcmin .and. &
+        ! Bypassed qi > qcmin constraint for colder temperatures to ensure initiation
+        if (tc .gt. 0. .and. ql (k) .gt. qcmin .and. &
+           (qi (k) .gt. qcmin .or. tc .gt. 15.0) .and. &
             qv (k) .gt. qsi) then
 
+            ! --- Smooth Linear Temperature Ramp ---
+            if (tc .le. tc_warm) then
+                ramp_factor = 1.0
+            else if (tc .ge. tc_cold) then
+                ramp_factor = min_scale
+            else
+                ramp_factor = 1.0 - (1.0 - min_scale) * ((tc - tc_warm) / (tc_cold - tc_warm))
+            endif
+            ! 1. Dynamically shrink the threshold (forces ice to precipitate as snow)
+            pwbf_qi_crt_eff = pwbf_qi_crt * ramp_factor
+            ! 2. Dynamically accelerate the timescale (shorter tau = faster QL destruction)
+            ! At tc_cold, this drops tau_wbf to 60s and completely removes the coarse multiplier bias
+            tau_wbf_eff = tau_wbf * (wbf_coarse_mult * (1.0 - onemsig) + onemsig) * ramp_factor
+            ! 3. Final timescale factor
+            fac_wbf = 1. - exp (- dts / tau_wbf_eff)
+            ! --------------------------------------
+
             sink = min (fac_wbf * ql (k), tc / icpk (k))
-            qim = pwbf_qi_crt / den (k)
+            qim = pwbf_qi_crt_eff / den (k)
             tmp = min (sink, dim (qim, qi (k)))
             mppfw = mppfw + sink * dp (k) * convt
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSland_GridComp/GEOScatch_GridComp/GEOS_CatchGridComp.F90
@@ -3620,7 +3620,7 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
       ENDIF
       D0T  = D0_BY_ZVEG*ZVG
 
-      DZE  = max(DZ - D0T, 10.)
+      DZE  = max(DZ - D0T, min(0.5*DZ,10.0))  ! was previously capped at 10m [problematic for L137/L181 with thinner surface layers]
 
       if(associated(Z0 )) Z0  = Z0T(:,N)
       if(associated(D0 )) D0  = D0T

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOS_SuperdynGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOS_SuperdynGridComp.F90
@@ -362,6 +362,12 @@ integer ::          ADV = -1
     VERIFY_(STATUS)
 
     call MAPL_AddExportSpec ( GC   ,                               &
+         SHORT_NAME = 'WSPD_STABLE300M',                           &
+         CHILD_ID   = DYN,                                         &
+                                                        RC=STATUS  )
+    VERIFY_(STATUS)
+
+    call MAPL_AddExportSpec ( GC   ,                               &
          SHORT_NAME = 'TROPP_BLENDED',                             &
          CHILD_ID   = DYN,                                         &
                                                         RC=STATUS  )


### PR DESCRIPTION
**Zero-diff for v11 config (default); Non-zero-diff for v12 config**

This pull request introduces enhancements to the NCAR gravity wave drag (GWD) parameterization, particularly improving the representation of extratropical drag by incorporating a new physical proxy based on low-level wind speed. The changes add a new field, `WSPD_STABLE300M`, as a katabatic wind proxy, and allow the drag parameterization to use both condensate tendencies and wind speed for detecting and scaling background drag. Several interfaces and resource defaults are updated to support this new functionality.

**Enhancements to GWD Physical Proxies:**

* Added a new field, `WSPD_STABLE300M`, representing the maximum wind speed in the lowest 300m stable layer, to the import state and connectivity mapping (`GWD_StateSpecs.rc`, `GEOS_AgcmGridComp.F90`) [[1]](diffhunk://#diff-8630754f7d2519d5a58c8a404f464145f5cd4887912b8987f2d2be6be4d952c6R35) [[2]](diffhunk://#diff-b3a183a120e4a1c7dafd7f2f8165401153785f5e018415e88e8b0231573a8a32L1080-R1086).
* Updated the GWD driver and associated subroutines to pass and utilize `WSPD_STABLE300M` as a physical proxy for katabatic wind forcing (`GEOS_GwdGridComp.F90`, `gw_convect.F90`, `gw_drag.F90`) [[1]](diffhunk://#diff-d5301d64d25d9b023d8fce9f9e1770db89bb9f2672a118b45ca3d87daaa2567dL697-R708) [[2]](diffhunk://#diff-434101b3e007558781ad2e41e5d9d82b8db35c7aeb8086d7e31bb32fd2d6b9abL263-R270) [[3]](diffhunk://#diff-5fcb18a8ce622e4913def988e150658acc1b927aa11b2dbf4a9bcc3b1d6f3fa2L61-R61).

**Parameterization and Tuning Updates:**

* Introduced new resource `NCAR_ET_USE_SPEED` to control use of wind speed proxy, and set the default for `NCAR_ET_USE_DQCDT` to `.TRUE.`; updated the logic for setting the baseline extratropical background stress (`NCAR_ET_TAUBGND`) based on active proxies.
* Changed the default value of `NCAR_TR_EFF` from 1.0 to 0.625 for improved tuning.

**Refinements to Physical Masking and Scaling:**

* Modified the masking of large-scale tendencies (`DQLDT`, `DQIDT`) to use a 4th power mask for more aggressive suppression in regions with convection (`GEOS_GwdGridComp.F90`).
* Updated the background drag logic in `gw_beres_src` to combine moist (condensate tendency) and dry (wind speed) multipliers, providing a more physically-based and tunable drag scaling.

**Interface and Structural Updates:**

* Extended relevant data structures and subroutine interfaces to include the new proxy and control flags, ensuring consistent propagation throughout the GWD codebase (`gw_convect.F90`, `gw_drag.F90`) [[1]](diffhunk://#diff-434101b3e007558781ad2e41e5d9d82b8db35c7aeb8086d7e31bb32fd2d6b9abR50) [[2]](diffhunk://#diff-434101b3e007558781ad2e41e5d9d82b8db35c7aeb8086d7e31bb32fd2d6b9abL60-R61) [[3]](diffhunk://#diff-5fcb18a8ce622e4913def988e150658acc1b927aa11b2dbf4a9bcc3b1d6f3fa2R95).

These changes collectively improve the physical realism and tunability of the extratropical GWD scheme, especially in scenarios with strong katabatic winds or storm tracks.