### PR TITLE
Fix ISSM type

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOS_LandIceGridComp.F90
@@ -10,11 +10,11 @@ module GEOS_LandiceGridCompMod
 ! !MODULE: GEOS_LandiceGridCompMod -- Implements slab landice tiles.
 
 ! !==========================================================================
-! An improved version over the slab landice 
+! An improved version over the slab landice
 
 ! TODO :
 
-! - Add multiple elevation classes support to account for ice sheet topo changes   
+! - Add multiple elevation classes support to account for ice sheet topo changes
 
 ! - Add more layers for a more realistic treatment of ice energy budget
 
@@ -30,7 +30,7 @@ module GEOS_LandiceGridCompMod
   use StieglitzSnow, only:                       &
        snowrt      => StieglitzSnow_snowrt,      &
        SNOW_ALBEDO => StieglitzSnow_snow_albedo, &
-       TRID        => StieglitzSnow_trid,        & 
+       TRID        => StieglitzSnow_trid,        &
        MINSWE      => StieglitzSnow_MINSWE,      &
        cpw         => StieglitzSnow_CPW,         &
        N_CONSTIT,                                &
@@ -43,11 +43,11 @@ module GEOS_LandiceGridCompMod
   use MAPL
   use GEOS_UtilsMod
   use DragCoefficientsMod
-  
+
 #ifdef HAVE_ISSM
   use GEOS_IssmGridCompMod,   only : IssmSetServices  => SetServices
   use GEOS_IssmGridCompMod,   only : T_ISSM_TILE_STATE
-  use GEOS_IssmGridCompMod,   only : ISSM_TILE_WRAP
+  use GEOS_IssmGridCompMod,   only : T_ISSM_TILE_WRAP
 #endif
 
   implicit none
@@ -61,11 +61,11 @@ module GEOS_LandiceGridCompMod
   integer, parameter :: NUM_SNOICE_LAYERS = NUM_SNOW_LAYERS+NUM_ICE_LAYERS
   real,    parameter :: rad_to_deg      = 180.0 / 3.1415926
 
- 
+
   ! snowrt related constants
-  ! will move these to a global module later 
+  ! will move these to a global module later
   real,    parameter :: ALHE     = MAPL_ALHL   ! J/kg  @15C
-  real,    parameter :: ALHM     = MAPL_ALHF   ! J/kg 
+  real,    parameter :: ALHM     = MAPL_ALHF   ! J/kg
   real,    parameter :: TF       = MAPL_TICE   ! K
   real,    parameter :: RHOW     = MAPL_RHOWTR ! kg/m^3
 
@@ -73,11 +73,11 @@ module GEOS_LandiceGridCompMod
   real,    parameter :: RHOICE   = 917.        ! kg/m^3  pure ice density
   real,    parameter :: MAXSNDZ  = 15.0        ! m
   real,    parameter :: BIG      = 1.e10
-  real,    parameter :: condice  = 2.25        ! @ 0 C [W/m/K] 
+  real,    parameter :: condice  = 2.25        ! @ 0 C [W/m/K]
   real,    parameter :: MINFRACSNO = 1.e-20    ! mininum sno/ice fraction for
                                                ! heat diffusion of ice layers to take effect
   real,    parameter :: LWCTOP     = 1.        ! top thickness to compute LWC. 1m taken from
-                                               ! Fettweis et al 2011  
+                                               ! Fettweis et al 2011
   real,    parameter :: VISMAX    = 0.96       ! parameter for snow_albedo
   real,    parameter :: NIRMAX    = 0.68       ! parameter for snow_albedo
   real,    parameter :: SLOPE     = 1.0        ! parameter for snow_albedo
@@ -87,15 +87,15 @@ module GEOS_LandiceGridCompMod
           AWTVDR = 0.00318, &! visible, direct  ! for history and
           AWTIDR = 0.00182, &! near IR, direct  ! diagnostics
           AWTVDF = 0.63282, &! visible, diffuse
-          AWTIDF = 0.36218   ! near IR, diffuse  
+          AWTIDF = 0.36218   ! near IR, diffuse
 
 
   !real,    dimension(NUM_SNOW_LAYERS), parameter   :: DZMAX = (/0.08, 0.12, big/)
   real,    dimension(NUM_SNOW_LAYERS), parameter   :: DZMAX = (/0.08, 0.08, 0.08 &
-             , 0.15, 0.25, big, big, big, big, big, big, big, big, big, big/)         
+             , 0.15, 0.25, big, big, big, big, big, big, big, big, big, big/)
   real,    dimension(NUM_ICE_LAYERS), parameter   :: DZMAXI = (/0.08, 0.08, 0.08 &
-             , 0.15, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 4.0/)         
-  
+             , 0.15, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 4.0/)
+
 
 
   integer,    parameter :: TAR_PE     = 43
@@ -109,7 +109,7 @@ module GEOS_LandiceGridCompMod
   integer ::     ISSM
 
 ! !DESCRIPTION:
-! 
+!
 !   {\tt GEOS\_Landice} is a light-weight gridded component that updates
 !      the landice tiles
 !
@@ -130,10 +130,10 @@ module GEOS_LandiceGridCompMod
     type(ESMF_GridComp), intent(INOUT) :: GC  ! gridded component
     integer, optional                  :: RC  ! return code
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !                This version uses the MAPL\_GenericSetServices, which sets
 !                the Initialize and Finalize services, as well as allocating
-!   our instance of a generic state and putting it in the 
+!   our instance of a generic state and putting it in the
 !   gridded component (GC). Here we only need to set the run method and
 !   add the state variable specifications (also generic) to our instance
 !   of the generic state. This is the way our true state variables get into
@@ -151,7 +151,7 @@ module GEOS_LandiceGridCompMod
     integer                                 :: STATUS
     character(len=ESMF_MAXSTR)              :: COMP_NAME
     character(len=ESMF_MAXSTR)              :: SURFRC
-    type(ESMF_Config)                       :: SCF 
+    type(ESMF_Config)                       :: SCF
 
 !=============================================================================
 
@@ -178,12 +178,12 @@ module GEOS_LandiceGridCompMod
 ! -----------------------
    !add initialize method for child (ISSM)
    call MAPL_GetResource (MAPL, DO_ISSM, label='DO_ISSM:', DEFAULT=0, __RC__ )
-   
+
 #ifndef HAVE_ISSM
    DO_ISSM=0
 #endif
-   
-   call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE, Initialize, RC=STATUS ) 
+
+   call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE, Initialize, RC=STATUS )
    VERIFY_(STATUS)
 
 
@@ -246,7 +246,7 @@ module GEOS_LandiceGridCompMod
         VLOCATION  = MAPL_VLocationNone,           &
         RC=STATUS  )
      VERIFY_(STATUS)
-   end if 
+   end if
 #endif
 
      call MAPL_AddExportSpec(GC,                             &
@@ -417,7 +417,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'EVPICE_GL'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
@@ -426,7 +426,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'SUBLIM'                    ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -435,7 +435,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'SNOMAS_GL'                 ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
 
@@ -445,7 +445,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'SNOWMASS'                  ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -644,7 +644,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'SMELT'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -653,7 +653,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'IMELT'                     ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -662,7 +662,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'SNOWALB'                   ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -671,7 +671,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'SNICEALB'                   ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -680,7 +680,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'MELTWTR'                   ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -689,7 +689,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'MELTWTRCONT'               ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -698,7 +698,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'LWC'               ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -707,7 +707,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'RUNOFF'                    ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -734,7 +734,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'Z0'                        ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC,                    &
@@ -743,7 +743,7 @@ module GEOS_LandiceGridCompMod
     SHORT_NAME         = 'Z0H'                       ,&
     DIMS               = MAPL_DimsTileOnly           ,&
     VLOCATION          = MAPL_VLocationNone          ,&
-                                           RC=STATUS  ) 
+                                           RC=STATUS  )
   VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                    &
@@ -842,7 +842,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'EVAPOUT'                   ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
@@ -851,7 +851,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'SHOUT'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
@@ -860,7 +860,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'HLWUP'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                     ,&
@@ -869,7 +869,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'LWNDSRF'                   ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                     ,&
@@ -878,7 +878,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'SWNDSRF'                   ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
@@ -887,7 +887,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'HLATN'                     ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
@@ -896,7 +896,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'DNICFLX'                   ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
@@ -905,7 +905,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'GHSNOW'                    ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC,                     &
@@ -914,7 +914,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'GHTSKIN'                   ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddExportSpec(GC                         ,&
@@ -923,7 +923,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'ITY'                       ,&
         DIMS               = MAPL_DimsTileOnly           ,&
         VLOCATION          = MAPL_VLocationNone          ,&
-                                               RC=STATUS  ) 
+                                               RC=STATUS  )
      VERIFY_(STATUS)
 
   call MAPL_AddExportSpec(GC                  ,&
@@ -932,83 +932,83 @@ module GEOS_LandiceGridCompMod
        SHORT_NAME         = 'RMELTDU001'                ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
-       RC=STATUS  ) 
+       RC=STATUS  )
   VERIFY_(STATUS)
-  
+
   call MAPL_AddExportSpec(GC                  ,&
        LONG_NAME          = 'flushed_out_dust_mass_flux_from_the_bottom_layer_bin_2',&
        UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RMELTDU002'                ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
-       RC=STATUS  ) 
+       RC=STATUS  )
   VERIFY_(STATUS)
-  
+
   call MAPL_AddExportSpec(GC                  ,&
        LONG_NAME          = 'flushed_out_dust_mass_flux_from_the_bottom_layer_bin_3',&
        UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RMELTDU003'                ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
-       RC=STATUS  ) 
+       RC=STATUS  )
   VERIFY_(STATUS)
-  
+
   call MAPL_AddExportSpec(GC                  ,&
        LONG_NAME          = 'flushed_out_dust_mass_flux_from_the_bottom_layer_bin_4',&
        UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RMELTDU004'                ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
-       RC=STATUS  ) 
+       RC=STATUS  )
   VERIFY_(STATUS)
-  
+
   call MAPL_AddExportSpec(GC                  ,&
        LONG_NAME          = 'flushed_out_dust_mass_flux_from_the_bottom_layer_bin_5',&
        UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RMELTDU005'                ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
-       RC=STATUS  ) 
+       RC=STATUS  )
   VERIFY_(STATUS)
-  
+
   call MAPL_AddExportSpec(GC                  ,&
        LONG_NAME          = 'flushed_out_black_carbon_mass_flux_from_the_bottom_layer_bin_1',&
        UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RMELTBC001'                ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
-       RC=STATUS  ) 
+       RC=STATUS  )
   VERIFY_(STATUS)
-  
+
   call MAPL_AddExportSpec(GC                  ,&
        LONG_NAME          = 'flushed_out_black_carbon_mass_flux_from_the_bottom_layer_bin_2',&
        UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RMELTBC002'                ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
-       RC=STATUS  ) 
+       RC=STATUS  )
   VERIFY_(STATUS)
-  
+
   call MAPL_AddExportSpec(GC                  ,&
        LONG_NAME          = 'flushed_out_organic_carbon_mass_flux_from_the_bottom_layer_bin_1',&
        UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RMELTOC001'                ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
-       RC=STATUS  ) 
+       RC=STATUS  )
   VERIFY_(STATUS)
-  
+
   call MAPL_AddExportSpec(GC                  ,&
        LONG_NAME          = 'flushed_out_organic_carbon_mass_flux_from_the_bottom_layer_bin_2',&
        UNITS              = 'kg m-2 s-1'                ,&
        SHORT_NAME         = 'RMELTOC002'                ,&
        DIMS               = MAPL_DimsTileOnly           ,&
        VLOCATION          = MAPL_VLocationNone          ,&
-       RC=STATUS  ) 
+       RC=STATUS  )
   VERIFY_(STATUS)
 
 !  !Internal state:
-#ifdef HAVE_ISSM  
+#ifdef HAVE_ISSM
    if (DO_ISSM==1) then
      call MAPL_AddInternalSpec(GC,                                &
         SHORT_NAME         = 'ICESMB_ISSM',                       &
@@ -1016,10 +1016,10 @@ module GEOS_LandiceGridCompMod
         UNITS              = 'kg m-2 s-1',                        &
         DIMS               = MAPL_DimsTileOnly,                   &
         VLOCATION          = MAPL_VLocationNone,                  &
-		  RESTART            = MAPL_RestartOptional,                & 
+		  RESTART            = MAPL_RestartOptional,                &
         DEFAULT            = 0.0 ,                                &
                                                     RC=STATUS  )
-   end if 
+   end if
 #endif
 
      call MAPL_AddInternalSpec(GC,                           &
@@ -1139,7 +1139,7 @@ module GEOS_LandiceGridCompMod
           VLOCATION          = MAPL_VLocationNone,                   &
           RESTART            = MAPL_RestartOptional,                 &
           FRIENDLYTO         = trim(COMP_NAME),                      &
-                                                          RC=STATUS  ) 
+                                                          RC=STATUS  )
         VERIFY_(STATUS)
 
         call MAPL_AddInternalSpec(GC,                                &
@@ -1151,7 +1151,7 @@ module GEOS_LandiceGridCompMod
           RESTART            = MAPL_RestartOptional,                 &
           VLOCATION          = MAPL_VLocationNone,                   &
           FRIENDLYTO         = trim(COMP_NAME),                      &
-                                                          RC=STATUS  ) 
+                                                          RC=STATUS  )
         VERIFY_(STATUS)
 
         call MAPL_AddInternalSpec(GC,                                &
@@ -1163,7 +1163,7 @@ module GEOS_LandiceGridCompMod
           VLOCATION          = MAPL_VLocationNone,                   &
           RESTART            = MAPL_RestartOptional,                 &
           FRIENDLYTO         = trim(COMP_NAME),                      &
-                                                          RC=STATUS  ) 
+                                                          RC=STATUS  )
         VERIFY_(STATUS)
 
         call MAPL_AddInternalSpec(GC,                                &
@@ -1175,7 +1175,7 @@ module GEOS_LandiceGridCompMod
           VLOCATION          = MAPL_VLocationNone,                   &
           RESTART            = MAPL_RestartOptional,                 &
           FRIENDLYTO         = trim(COMP_NAME),                      &
-                                                          RC=STATUS  ) 
+                                                          RC=STATUS  )
         VERIFY_(STATUS)
 
         call MAPL_AddInternalSpec(GC,                                &
@@ -1187,7 +1187,7 @@ module GEOS_LandiceGridCompMod
           VLOCATION          = MAPL_VLocationNone,                   &
           RESTART            = MAPL_RestartOptional,                 &
           FRIENDLYTO         = trim(COMP_NAME),                      &
-                                                          RC=STATUS  ) 
+                                                          RC=STATUS  )
         VERIFY_(STATUS)
 
         call MAPL_AddInternalSpec(GC,                                 &
@@ -1199,7 +1199,7 @@ module GEOS_LandiceGridCompMod
           VLOCATION          = MAPL_VLocationNone,                    &
           RESTART            = MAPL_RestartOptional,                  &
           FRIENDLYTO         = trim(COMP_NAME),                       &
-                                                          RC=STATUS  ) 
+                                                          RC=STATUS  )
         VERIFY_(STATUS)
 
         call MAPL_AddInternalSpec(GC,                                 &
@@ -1211,7 +1211,7 @@ module GEOS_LandiceGridCompMod
           VLOCATION          = MAPL_VLocationNone,                    &
           RESTART            = MAPL_RestartOptional,                  &
           FRIENDLYTO         = trim(COMP_NAME),                       &
-                                                          RC=STATUS  ) 
+                                                          RC=STATUS  )
         VERIFY_(STATUS)
 
         call MAPL_AddInternalSpec(GC,                                  &
@@ -1223,7 +1223,7 @@ module GEOS_LandiceGridCompMod
           VLOCATION          = MAPL_VLocationNone,                     &
           RESTART            = MAPL_RestartOptional,                   &
           FRIENDLYTO         = trim(COMP_NAME),                        &
-                                                          RC=STATUS  ) 
+                                                          RC=STATUS  )
         VERIFY_(STATUS)
 
         call MAPL_AddInternalSpec(GC,                                  &
@@ -1235,7 +1235,7 @@ module GEOS_LandiceGridCompMod
           VLOCATION          = MAPL_VLocationNone,                     &
           RESTART            = MAPL_RestartOptional,                   &
           FRIENDLYTO         = trim(COMP_NAME),                        &
-                                                          RC=STATUS  ) 
+                                                          RC=STATUS  )
         VERIFY_(STATUS)
 
      end if
@@ -1268,7 +1268,7 @@ module GEOS_LandiceGridCompMod
         SHORT_NAME         = 'DRPAR'                             ,&
         DIMS               = MAPL_DimsTileOnly                   ,&
         VLOCATION          = MAPL_VLocationNone                  ,&
-                                                       RC=STATUS  ) 
+                                                       RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC                         ,&
@@ -1277,7 +1277,7 @@ module GEOS_LandiceGridCompMod
          SHORT_NAME         = 'DFPAR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
          VLOCATION          = MAPL_VLocationNone            ,&
-                                                  RC=STATUS  ) 
+                                                  RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC                         ,&
@@ -1286,7 +1286,7 @@ module GEOS_LandiceGridCompMod
          SHORT_NAME         = 'DRNIR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
          VLOCATION          = MAPL_VLocationNone            ,&
-                                                  RC=STATUS  ) 
+                                                  RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC                         ,&
@@ -1295,7 +1295,7 @@ module GEOS_LandiceGridCompMod
          SHORT_NAME         = 'DFNIR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
          VLOCATION          = MAPL_VLocationNone            ,&
-                                                  RC=STATUS  ) 
+                                                  RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC                         ,&
@@ -1304,7 +1304,7 @@ module GEOS_LandiceGridCompMod
          SHORT_NAME         = 'DRUVR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
          VLOCATION          = MAPL_VLocationNone            ,&
-                                                  RC=STATUS  ) 
+                                                  RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC                         ,&
@@ -1313,7 +1313,7 @@ module GEOS_LandiceGridCompMod
          SHORT_NAME         = 'DFUVR'                       ,&
          DIMS               = MAPL_DimsTileOnly             ,&
          VLOCATION          = MAPL_VLocationNone            ,&
-                                                  RC=STATUS  ) 
+                                                  RC=STATUS  )
      VERIFY_(STATUS)
 
      call MAPL_AddImportSpec(GC,                             &
@@ -1498,9 +1498,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_DUDP/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'dust_wet_depos_conv_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1508,9 +1508,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_DUSV/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'dust_wet_depos_ls_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1518,9 +1518,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_DUWT/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'dust_gravity_sett_all_bins',  &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1528,9 +1528,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_DUSD/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'black_carbon_dry_depos_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1538,9 +1538,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_BCDP/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'black_carbon_wet_depos_conv_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1548,9 +1548,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_BCSV/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'black_carbon_wet_depos_ls_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1558,9 +1558,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_BCWT/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
- 
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'black_carbon_gravity_sett_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1568,9 +1568,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_BCSD/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'organic_carbon_dry_depos_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1578,9 +1578,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_OCDP/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'organic_carbon_wet_depos_conv_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1588,9 +1588,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_OCSV/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'organic_carbon_wet_depos_ls_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1598,9 +1598,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_OCWT/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'organic_carbon_gravity_sett_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1608,9 +1608,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_OCSD/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'sulfate_dry_depos_all_bins',  &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1618,9 +1618,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_SUDP/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'sulfate_wet_depos_conv_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1628,9 +1628,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_SUSV/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'sulfate_wet_depos_ls_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1638,9 +1638,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_SUWT/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'sulfate_gravity_sett_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1648,9 +1648,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_SUSD/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'sea_salt_dry_depos_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1658,9 +1658,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_SSDP/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'sea_salt_wet_depos_conv_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1668,9 +1668,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_SSSV/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'sea_salt_wet_depos_ls_scav_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1678,9 +1678,9 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_SSWT/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
-    
+
     call MAPL_AddImportSpec(GC,                              &
          LONG_NAME          = 'sea_salt_gravity_sett_all_bins', &
          UNITS              = 'kg m-2 s-1',                  &
@@ -1688,19 +1688,19 @@ module GEOS_LandiceGridCompMod
          DIMS               = MAPL_DimsTileOnly,             &
          UNGRIDDED_DIMS     = (/NUM_SSSD/),                  &
          VLOCATION          = MAPL_VLocationNone,            &
-         RC=STATUS  ) 
+         RC=STATUS  )
     VERIFY_(STATUS)
 
 !EOS
-#ifdef HAVE_ISSM    
+#ifdef HAVE_ISSM
     if (DO_ISSM==1) then
-      ! Add ISSM child gridcomp    
+      ! Add ISSM child gridcomp
       ISSM  = MAPL_AddChild(GC, NAME='ISSM', SS=IssmSetServices, RC=STATUS)
-      VERIFY_(STATUS)   
-      
+      VERIFY_(STATUS)
+
       call MAPL_TerminateImport(GC, CHILD = ISSM,   RC=STATUS)
       VERIFY_(STATUS)
-    end if 
+    end if
 #endif
 
 ! Set the Profiling timers
@@ -1710,7 +1710,7 @@ module GEOS_LandiceGridCompMod
     VERIFY_(STATUS)
     call MAPL_TimerAdd(GC,    name="RUN2"  ,RC=STATUS)
     VERIFY_(STATUS)
-  
+
 ! Set generic init and final methods
 ! ----------------------------------
 
@@ -1719,7 +1719,7 @@ module GEOS_LandiceGridCompMod
 
 
     RETURN_(ESMF_SUCCESS)
-  
+
   end subroutine SetServices
 
 
@@ -1727,70 +1727,70 @@ module GEOS_LandiceGridCompMod
 
 
   subroutine Initialize ( GC, IMPORT, EXPORT, CLOCK, RC )
-  ! this is for ISSM to have access to to the tile locstream 
+  ! this is for ISSM to have access to to the tile locstream
 
    ! !ARGUMENTS:
-   
-       type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+
+       type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component
        type(ESMF_State),    intent(inout) :: IMPORT ! Import state
        type(ESMF_State),    intent(inout) :: EXPORT ! Export state
        type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
        integer, optional,   intent(  out) :: RC     ! Error code
-   
+
    ! !DESCRIPTION: The Initialize method of the Landice Gridded Component.
-   
+
    !EOP
-   
+
    ! ErrLog Variables
-   
-       character(len=ESMF_MAXSTR)              :: IAm 
+
+       character(len=ESMF_MAXSTR)              :: IAm
        integer                                 :: STATUS
        character(len=ESMF_MAXSTR)              :: COMP_NAME
-       
+
    ! Local derived type aliases
-   
+
        type (MAPL_MetaComp    ), pointer       :: MAPL
-       type (MAPL_MetaComp    ), pointer       :: CHILD_MAPL 
+       type (MAPL_MetaComp    ), pointer       :: CHILD_MAPL
        type (MAPL_LocStream       )            :: LOCSTREAM
        type (ESMF_Config          )            :: CF
        type (ESMF_GridComp        ), pointer   :: GCS(:)
        character(len=ESMF_MAXSTR),   pointer   :: gcnames(:)
-     
+
        integer                                 :: I
 #ifdef HAVE_ISSM
        type(T_ISSM_TILE_STATE), pointer        :: issm_tile_state
-       type(ISSM_TILE_WRAP)                    :: issm_tile_wrap
-       real, pointer, dimension(:)             :: ICESURF 
+       type(T_ISSM_TILE_WRAP)                  :: issm_tile_wrap
+       real, pointer, dimension(:)             :: ICESURF
        real, pointer, dimension(:)             :: ICETHICK
        real, pointer, dimension(:)             :: ICEVEL
 #endif
        integer                                 :: nt_local
        integer                                 :: DO_ISSM
-       real                                    :: LANDICE_DT                     
-        
+       real                                    :: LANDICE_DT
+
    !=============================================================================
-   
-   ! Begin... 
-   
+
+   ! Begin...
+
    ! Get the target components name and set-up traceback handle.
    ! -----------------------------------------------------------
-   
+
        call ESMF_GridCompGet ( GC, name=COMP_NAME, RC=STATUS )
        VERIFY_(STATUS)
        Iam = trim(COMP_NAME) // "Initialize"
-   
+
    ! Get my internal MAPL_Generic state
    !-----------------------------------
-   
+
        call MAPL_GetObjectFromGC ( GC, MAPL, RC=STATUS)
        VERIFY_(STATUS)
-   
+
        call MAPL_TimerOn(MAPL,"INITIALIZE", RC=STATUS ); VERIFY_(STATUS)
        call MAPL_TimerOn(MAPL,"TOTAL", RC=STATUS ); VERIFY_(STATUS)
-   
+
    ! Get the landice tilegrid and the child components
-   !----------------------------------------------- 
-   
+   !-----------------------------------------------
+
        call MAPL_Get (MAPL, LOCSTREAM=LOCSTREAM, GCS=GCS, GCNAMES=gcnames, RC=STATUS )
        VERIFY_(STATUS)
        call MAPL_LocStreamGet(locstream, NT_LOCAL=nt_local, rc=STATUS)
@@ -1801,10 +1801,10 @@ module GEOS_LandiceGridCompMod
        ! get model timestep, overwrite with component-specific timestep if found
        call MAPL_GetResource (MAPL, LANDICE_DT, label='RUN_DT:',_RC)
        call MAPL_GetResource (MAPL, LANDICE_DT, label='DT:',default=LANDICE_DT,_RC)
-       
+
        ! get ISSM flag
        call MAPL_GetResource (MAPL, DO_ISSM, label='DO_ISSM:', DEFAULT=0, __RC__ )
-   
+
 #ifndef HAVE_ISSM
        DO_ISSM=0
 #endif
@@ -1831,7 +1831,7 @@ module GEOS_LandiceGridCompMod
        end do
 #endif
        call MAPL_TimerOff(MAPL,"TOTAL", RC=STATUS ); VERIFY_(STATUS)
-   
+
    ! Call Initialize for every Child
    !--------------------------------
        call MAPL_GenericInitialize ( GC, IMPORT, EXPORT, CLOCK,  RC=STATUS)
@@ -1839,19 +1839,19 @@ module GEOS_LandiceGridCompMod
 
 #ifdef HAVE_ISSM
       if (DO_ISSM==1) then
-       ! initialize exports to restart values set by ISSM GridComp's Initialize, 
+       ! initialize exports to restart values set by ISSM GridComp's Initialize,
        ! because ISSM typically has a multi-day timestep and exports will remain empty otherwise
        call MAPL_GetPointer(EXPORT,ICESURF , 'ICESURF',alloc=.true., RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(EXPORT,ICETHICK ,'ICETHICK',alloc=.true., RC=STATUS); VERIFY_(STATUS)
        call MAPL_GetPointer(EXPORT,ICEVEL ,'ICEVEL',alloc=.true., RC=STATUS); VERIFY_(STATUS)
-	   
+
        if(associated(ICESURF))  ICESURF = issm_tile_state%ICESURF_TILE
        if(associated(ICETHICK)) ICETHICK = issm_tile_state%ICETHICK_TILE
        if(associated(ICEVEL))   ICEVEL = issm_tile_state%ICEVEL_TILE
-	   end if 
-#endif   
+	   end if
+#endif
        call MAPL_TimerOff(MAPL,"INITIALIZE", RC=STATUS ); VERIFY_(STATUS)
-   
+
        RETURN_(ESMF_SUCCESS)
      end subroutine Initialize
 
@@ -1864,7 +1864,7 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
 
   !ARGUMENTS:
 
-  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component
   type(ESMF_State),    intent(inout) :: IMPORT ! Import state
   type(ESMF_State),    intent(inout) :: EXPORT ! Export state
   type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
@@ -1930,9 +1930,9 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
    real, pointer, dimension(:)    :: UU
    real, pointer, dimension(:)    :: UWINDLMTILE
    real, pointer, dimension(:)    :: VWINDLMTILE
-   real, pointer, dimension(:)    :: DZ     
+   real, pointer, dimension(:)    :: DZ
    real, pointer, dimension(:)    :: TA
-   real, pointer, dimension(:)    :: QA     
+   real, pointer, dimension(:)    :: QA
    real, pointer, dimension(:)    :: PS
 
    integer                        :: N
@@ -1983,7 +1983,7 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
    integer                        :: CHOOSEZ0
 !=============================================================================
 
-! Begin... 
+! Begin...
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -2233,10 +2233,10 @@ subroutine RUN1 ( GC, IMPORT, EXPORT, CLOCK, RC )
     CM(:,N)  = VKM
     CH(:,N)  = VKH
     CQ(:,N)  = VKH
-      
+
     CN = (MAPL_KARMAN/ALOG(DZ/Z0(:,N) + 1.0)) * (MAPL_KARMAN/ALOG(DZ/Z0(:,N) + 1.0))
     ZT = Z0(:,N)
-    ZQ = Z0(:,N)  
+    ZQ = Z0(:,N)
     RE = 0.
     UUU = UU
     UCN = 0.
@@ -2339,19 +2339,19 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
 
   !ARGUMENTS:
 
-  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component 
+  type(ESMF_GridComp), intent(inout) :: GC     ! Gridded component
   type(ESMF_State),    intent(inout) :: IMPORT ! Import state
   type(ESMF_State),    intent(inout) :: EXPORT ! Export state
   type(ESMF_Clock),    intent(inout) :: CLOCK  ! The clock
   integer, optional,   intent(  out) :: RC     ! Error code:
 
-  !DESCRIPTION: 
+  !DESCRIPTION:
 !  Periodically refreshes the ozone mixing ratios.
 
 !EOP
 
    type(MAPL_MetaComp), pointer       :: CHILD_MAPL ! MAPL state for ISSM
-   type(ESMF_Alarm)                   :: ISSM_ALARM ! run alarm for ISSM component 
+   type(ESMF_Alarm)                   :: ISSM_ALARM ! run alarm for ISSM component
 
 
 ! ErrLog Variables
@@ -2377,13 +2377,13 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
 
   type (ESMF_GridComp  ), pointer     :: GCS(:)
   character(len=ESMF_MAXSTR), pointer :: gcnames(:)
-#ifdef HAVE_ISSM    
+#ifdef HAVE_ISSM
   type(T_ISSM_TILE_STATE), pointer    :: issm_tile_state
-  type(ISSM_TILE_WRAP)                :: issm_tile_wrap
+  type(T_ISSM_TILE_WRAP)              :: issm_tile_wrap
 #endif
 !=============================================================================
 
-! Begin... 
+! Begin...
 
 ! Get the target components name and set-up traceback handle.
 ! -----------------------------------------------------------
@@ -2403,7 +2403,7 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
 #ifndef HAVE_ISSM
     DO_ISSM=0
 #endif
-    
+
 ! Start Total timer
 !------------------
 
@@ -2419,7 +2419,7 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
          ORBIT     = ORBIT,                      &
          TILELATS  = LATS,                       &
          TILELONS  = LONS,                       &
-         !TILETYPES = TILETYPES,                  &     
+         !TILETYPES = TILETYPES,                  &
          RUNALARM  = ALARM,                      &
                                        RC=STATUS )
     VERIFY_(STATUS)
@@ -2444,7 +2444,7 @@ subroutine RUN2 ( GC, IMPORT, EXPORT, CLOCK, RC )
 
    call MAPL_TimerOff(MAPL,"RUN2")
    call MAPL_TimerOff(MAPL,"TOTAL")
-   
+
    RETURN_(ESMF_SUCCESS)
 
 contains
@@ -2453,7 +2453,7 @@ contains
 
    subroutine LANDICECORE(RC)
    integer, optional, intent(OUT) :: RC
-     
+
 !  Locals
 
    character(len=ESMF_MAXSTR)     :: IAm
@@ -2471,10 +2471,10 @@ contains
    real, pointer, dimension(:  )  :: ICETHICK
    real, pointer, dimension(:  )  :: ICEVEL
    real, pointer, dimension(:  )  :: EMISS
-   real, pointer, dimension(:  )  :: ALBVF 
-   real, pointer, dimension(:  )  :: ALBVR 
-   real, pointer, dimension(:  )  :: ALBNF 
-   real, pointer, dimension(:  )  :: ALBNR 
+   real, pointer, dimension(:  )  :: ALBVF
+   real, pointer, dimension(:  )  :: ALBVR
+   real, pointer, dimension(:  )  :: ALBNF
+   real, pointer, dimension(:  )  :: ALBNR
    real, pointer, dimension(:  )  :: DELTS
    real, pointer, dimension(:  )  :: DELQS
    real, pointer, dimension(:  )  :: TST
@@ -2503,11 +2503,11 @@ contains
    real, pointer, dimension(:,:)  :: DRHOS0
    real, pointer, dimension(:,:)  :: WESNEX
    real, pointer, dimension(:  )  :: WESNEXT
-   real, pointer, dimension(:  )  :: WESC 
-   real, pointer, dimension(:  )  :: SDSC 
-   real, pointer, dimension(:  )  :: WEPRE 
+   real, pointer, dimension(:  )  :: WESC
+   real, pointer, dimension(:  )  :: SDSC
+   real, pointer, dimension(:  )  :: WEPRE
    real, pointer, dimension(:  )  :: SDPRE
-   real, pointer, dimension(:  )  :: SD1PC 
+   real, pointer, dimension(:  )  :: SD1PC
    real, pointer, dimension(:,:)  :: WEPERC
    real, pointer, dimension(:,:)  :: WEREP
    real, pointer, dimension(:  )  :: WEBOT
@@ -2653,8 +2653,8 @@ contains
    real,    allocatable           :: LAI     (:)
    real,    allocatable           :: GRN     (:)
    real,    allocatable           :: MODISFAC(:)
-   real,    allocatable           :: SNOVR(:), SNONR(:), SNOVF(:), SNONF(:) 
-   real,    allocatable           :: LNDVR(:), LNDNR(:), LNDVF(:), LNDNF(:) 
+   real,    allocatable           :: SNOVR(:), SNONR(:), SNOVF(:), SNONF(:)
+   real,    allocatable           :: LNDVR(:), LNDNR(:), LNDVF(:), LNDNF(:)
    real,    allocatable           :: VSUVR   (:)
    real,    allocatable           :: VSUVF   (:)
    real,    allocatable           :: SWNETSNOW(:)
@@ -2662,9 +2662,9 @@ contains
    real,    allocatable           :: FHGND   (:)
    real,    allocatable           :: DRHO0   (:,:)
    real,    allocatable           :: EXCS    (:,:)
-   real,    allocatable           :: WESNSC(:), SNDZSC(:), WESNPREC(:),   & 
-                                     SNDZPREC(:),  SNDZ1PERC(:) 
-   real,    allocatable           :: WESNPERC(:,:), WESNDENS(:,:), WESNREPAR(:,:) 
+   real,    allocatable           :: WESNSC(:), SNDZSC(:), WESNPREC(:),   &
+                                     SNDZPREC(:),  SNDZ1PERC(:)
+   real,    allocatable           :: WESNPERC(:,:), WESNDENS(:,:), WESNREPAR(:,:)
    real,    allocatable           :: WESNBOT(:)
    real,    allocatable           :: LANDICELT(:)
    real,    allocatable           :: RCONSTIT(:,:,:)
@@ -2760,7 +2760,7 @@ contains
 #ifdef HAVE_ISSM
 if (DO_ISSM==1) then
    call MAPL_GetPointer(INTERNAL,ICESMB_IN , 'ICESMB_ISSM',alloc=.true., RC=STATUS); VERIFY_(STATUS)
-end if    
+end if
 #endif
    call MAPL_GetPointer(INTERNAL,TS   , 'TS'     , RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(INTERNAL,QS   , 'QS'     , RC=STATUS); VERIFY_(STATUS)
@@ -2792,9 +2792,9 @@ if (DO_ISSM==1) then
    call MAPL_GetPointer(EXPORT,ICESURF , 'ICESURF',alloc=.true., RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT,ICETHICK ,'ICETHICK',alloc=.true., RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT,ICEVEL ,'ICEVEL',alloc=.true., RC=STATUS); VERIFY_(STATUS)
-end if    
+end if
 #endif
-   
+
    call MAPL_GetPointer(EXPORT,ICESMB  , 'ICESMB',alloc=.true., RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT,EMISS  , 'EMIS'   , RC=STATUS); VERIFY_(STATUS)
    call MAPL_GetPointer(EXPORT,ALBVF  , 'ALBVF'  , RC=STATUS); VERIFY_(STATUS)
@@ -2884,20 +2884,20 @@ end if
     NT = size(ALW)
 
     ! initialize running mean ICESMB and number of steps since last ISSM solve
-#ifdef HAVE_ISSM	
+#ifdef HAVE_ISSM
     if(DO_ISSM==1) then
         if (.not. associated(ICESMB_ISSM)) then
             allocate(ICESMB_ISSM(NT),STAT=STATUS)
             VERIFY_(STATUS)
 
             ! initialize from restart:
-            if (associated(ICESMB_IN)) then 
-               ICESMB_ISSM(:) = ICESMB_IN(:) 
+            if (associated(ICESMB_IN)) then
+               ICESMB_ISSM(:) = ICESMB_IN(:)
             else
                ICESMB_ISSM(:) = 0
-            end if 
-	     end if 	
-        
+            end if
+	     end if
+
         ! get number of timesteps from issm tile internal state
         call MAPL_Get (MAPL, GCS=GCS, GCNAMES=GCNAMES, RC=STATUS )
 		  VERIFY_(STATUS)
@@ -2906,34 +2906,34 @@ end if
              call ESMF_UserCompGetInternalState(GCS(N), 'ISSM_TILES', issm_tile_wrap, status)
              VERIFY_(STATUS)
              issm_tile_state =>issm_tile_wrap%ptr
-             ISSM_NSTEPS = issm_tile_state%ISSM_NSTEPS 
+             ISSM_NSTEPS = issm_tile_state%ISSM_NSTEPS
           end if
-        end do         
-	 end if 
+        end do
+	 end if
 #endif
-		
+
     allocate(MLT (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(DTS (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(DQS (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(SHF (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(LHF (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(SHD (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(LHD (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(CFT (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(CFQ (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(SWN (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(DIF (NT), STAT=STATUS)
-    VERIFY_(STATUS)                
+    VERIFY_(STATUS)
     allocate(ULW (NT), STAT=STATUS)
     VERIFY_(STATUS)
 
@@ -2962,70 +2962,70 @@ end if
     allocate(HLWO(NT)  , STAT=STATUS)
     VERIFY_(STATUS)
     allocate(EVAPO(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(LHFO(NT)  , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(SHFO(NT)  , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(ZTH(NT)   , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(SLR(NT)   , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(EVAPI(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(DEVAPDT(NT), STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(ITYPE(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(LAI(NT)   , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(GRN(NT)   , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(MODISFAC(NT), STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(SNOVR(NT), SNONR(NT), SNOVF(NT), SNONF(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(LNDVR(NT), LNDNR(NT), LNDVF(NT), LNDNF(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(VSUVR(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(VSUVF(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(SWNETSNOW(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(RADDN(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(FHGND(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
     allocate(DRHO0(NT,NUM_SNOW_LAYERS)    , STAT=STATUS)
     VERIFY_(STATUS)
     allocate(EXCS(NT,NUM_SNOW_LAYERS)     , STAT=STATUS)
     VERIFY_(STATUS)
-    allocate(WESNSC(NT), SNDZSC(NT), WESNPREC(NT),   & 
-             SNDZPREC(NT),  SNDZ1PERC(NT),           & 
+    allocate(WESNSC(NT), SNDZSC(NT), WESNPREC(NT),   &
+             SNDZPREC(NT),  SNDZ1PERC(NT),           &
              WESNBOT(NT),                            &
-             STAT=STATUS) 
+             STAT=STATUS)
     VERIFY_(STATUS)
     allocate(WESNPERC(NT,NUM_SNOW_LAYERS),            &
              WESNDENS(NT,NUM_SNOW_LAYERS),            &
              WESNREPAR(NT,NUM_SNOW_LAYERS),           &
-             STAT=STATUS) 
+             STAT=STATUS)
     VERIFY_(STATUS)
     allocate(LANDICELT(NT) , STAT=STATUS)
-    VERIFY_(STATUS) 
+    VERIFY_(STATUS)
 
     allocate(WESNN  (NUM_SNOW_LAYERS,NT))
-    VERIFY_(STATUS)  
+    VERIFY_(STATUS)
     allocate(HTSNN  (NUM_SNOW_LAYERS,NT))
-    VERIFY_(STATUS)  
+    VERIFY_(STATUS)
     allocate(SNDZN  (NUM_SNOW_LAYERS,NT))
-    VERIFY_(STATUS)  
+    VERIFY_(STATUS)
     allocate(RCONSTIT(NT, NUM_SNOW_LAYERS, N_CONSTIT) , STAT=STATUS)
-    VERIFY_(STATUS)  
+    VERIFY_(STATUS)
     allocate(TOTDEPOS(NT, N_CONSTIT) , STAT=STATUS)
-    VERIFY_(STATUS)  
+    VERIFY_(STATUS)
     allocate(RMELT(NT, N_CONSTIT) , STAT=STATUS)
-    VERIFY_(STATUS)      
+    VERIFY_(STATUS)
 
     call ESMF_VMGetCurrent(VM,                                RC=STATUS)
     VERIFY_(STATUS)
@@ -3034,23 +3034,23 @@ end if
     call ESMF_VMGet(VM, localPet=mype, rc=status)
     VERIFY_(STATUS)
 
-    if(associated(EVAPOUT ))  EVAPOUT  = 0.0 
+    if(associated(EVAPOUT ))  EVAPOUT  = 0.0
     if(associated(SUBLIM  ))  SUBLIM   = 0.0
-    if(associated(SHOUT   ))  SHOUT    = 0.0 
-    if(associated(HLATN   ))  HLATN    = 0.0 
-    if(associated(DELTS   ))  DELTS    = 0.0 
-    if(associated(DELQS   ))  DELQS    = 0.0 
+    if(associated(SHOUT   ))  SHOUT    = 0.0
+    if(associated(HLATN   ))  HLATN    = 0.0
+    if(associated(DELTS   ))  DELTS    = 0.0
+    if(associated(DELQS   ))  DELQS    = 0.0
     if(associated(SWNDSRF ))  SWNDSRF  = 0.0
     if(associated(LWNDSRF ))  LWNDSRF  = 0.0
-    if(associated(DNICFLX ))  DNICFLX  = 0.0 
-    if(associated(GHSNOW  ))  GHSNOW   = 0.0 
-    if(associated(GHTSKIN ))  GHTSKIN  = 0.0 
-    if(associated(IMELT   ))  IMELT    = 0.0 
-    if(associated(RUNOFF  ))  RUNOFF   = 0.0 
-    if(associated(EVPICE  ))  EVPICE   = 0.0 
+    if(associated(DNICFLX ))  DNICFLX  = 0.0
+    if(associated(GHSNOW  ))  GHSNOW   = 0.0
+    if(associated(GHTSKIN ))  GHTSKIN  = 0.0
+    if(associated(IMELT   ))  IMELT    = 0.0
+    if(associated(RUNOFF  ))  RUNOFF   = 0.0
+    if(associated(EVPICE  ))  EVPICE   = 0.0
     if(associated(HLWUP   ))  HLWUP    = 0.0
     if(associated(TICE0   ))  TICE0    = 0.0
-    if(associated(ACCUM   ))  ACCUM    = 0.0 
+    if(associated(ACCUM   ))  ACCUM    = 0.0
     if(associated(MELTWTR ))  MELTWTR  = 0.0
 
     if (N_constit>0) then
@@ -3060,7 +3060,7 @@ end if
     end if
 
     ! Zero the light-absorbing aerosol (LAA) deposition rates from  GOCART:
-    
+
     select case (AEROSOL_DEPOSITION)
     case (0)
        DUDP(:,:)=0.
@@ -3075,30 +3075,30 @@ end if
        OCSV(:,:)=0.
        OCWT(:,:)=0.
        OCSD(:,:)=0.
-       
+
     case (2)
        DUDP(:,:)=0.
        DUSV(:,:)=0.
        DUWT(:,:)=0.
        DUSD(:,:)=0.
-       
+
     case (3)
        BCDP(:,:)=0.
        BCSV(:,:)=0.
        BCWT(:,:)=0.
        BCSD(:,:)=0.
-       
+
     case (4)
        OCDP(:,:)=0.
        OCSV(:,:)=0.
        OCWT(:,:)=0.
        OCSD(:,:)=0.
-       
+
     end select
 
 
     if (N_CONST_LANDICE4SNWALB /=0) then
-    
+
 ! Convert the dimentions for LAAs from GEOS_SurfGridComp.F90 to GEOS_LandIceGridComp.F90
 ! Note: Explanations of each variable
 ! TOTDEPOS(:,1): Combined dust deposition from size bin 1 (dry, conv-scav, ls-scav, sed)
@@ -3176,17 +3176,17 @@ end if
 !        RCONSTIT(:,:,15) = IRSS005(:,:)
     end if
 
-    LANDICELT = 0.0 
-    ZONEAREA  = 1.0 
+    LANDICELT = 0.0
+    ZONEAREA  = 1.0
     ! zc1 is not the actual thickness, but the vertical coordinate which is +ve upward
     ZC1       = -DZMAXI(1) * 0.5
     TKGND     = condice ! use value for ice at 0 degC
     PRECIP    = PCU + PLS + SNO
-    RAIN      = PCU + PLS 
+    RAIN      = PCU + PLS
     PERC      = 0.0
     MELTI     = 0.0
     FROZFRAC  = 0.0
-    TPSN      = 0.0  
+    TPSN      = 0.0
     AREASC    = 0.0
     HCORR     = 0.0
     ghflxsno  = 0.0
@@ -3204,13 +3204,13 @@ end if
     WESNSC    = 0.0
     SNDZSC    = 0.0
     WESNPREC  = 0.0
-    SNDZPREC  = 0.0  
-    SNDZ1PERC = 0.0 
-    WESNPERC  = 0.0 
-    WESNDENS  = 0.0 
-    WESNREPAR = 0.0 
-    RAINRF    = 0.0 
-    MLT       = 0.0 
+    SNDZPREC  = 0.0
+    SNDZ1PERC = 0.0
+    WESNPERC  = 0.0
+    WESNDENS  = 0.0
+    WESNREPAR = 0.0
+    RAINRF    = 0.0
+    MLT       = 0.0
     LNDVR     = 0.0
     LNDNR     = 0.0
     LNDVF     = 0.0
@@ -3219,7 +3219,7 @@ end if
     debugzth = .false.
 
     ! --------------------------------------------------------------------------
-    ! Get the current time. 
+    ! Get the current time.
     ! --------------------------------------------------------------------------
 
     call ESMF_ClockGet( CLOCK, currTime=CURRENT_TIME, startTime=MODELSTART, TIMESTEP=DELT,  RC=STATUS )
@@ -3283,8 +3283,8 @@ end if
     VERIFY_(STATUS)
 
     ZTH = max(0.0,ZTH)
-    
-    do N=1,NUM_SUBTILES  
+
+    do N=1,NUM_SUBTILES
        if (LANDICE_OFFLINE == 0 ) then
           CFT   = (CH(:,N)/CTATM)
           CFQ   = (CQ(:,N)/CQATM)
@@ -3303,7 +3303,7 @@ end if
           LHD    = CQ(:,N)*MAPL_ALHS*GEOS_DQSAT(TS(:,N), PS, PASCALS=.TRUE., RAMP=0.0)
           BLWN   = LANDICEEMISS*MAPL_STFBOL*TS(:,N)*TS(:,N)*TS(:,N)
           ALWN   = -3.0*BLWN*TS(:,N)
-          BLWN   =  4.0*BLWN 
+          BLWN   =  4.0*BLWN
        endif
 
        SWN = ((DRUVR+DRPAR+DRNIR) + (DFUVR+DFPAR+DFNIR))*(1.0-LANDICEALB)
@@ -3312,19 +3312,19 @@ end if
 
        LANDICECAP= (MAPL_RHOWTR*MAPL_CAPICE*LANDICEDEPTH)
 
-       EVAPI   = LHF / MAPL_ALHS 
+       EVAPI   = LHF / MAPL_ALHS
        DEVAPDT = LHD / MAPL_ALHS
-       RADDN   = LWDNSRF + SWN 
+       RADDN   = LWDNSRF + SWN
 
-       PERC  = 0.0 
-       MELTI = 0.0 
+       PERC  = 0.0
+       MELTI = 0.0
 
 
        if(N==SNOW) then
 
           ITYPE = 9
           LAI   = 0.0
-          GRN   = 0.0 
+          GRN   = 0.0
           MODISFAC = 1.0
 
           !*** have to do a transpose of these internals since their dimensions in SNOW_ALBEDO
@@ -3332,9 +3332,9 @@ end if
           WESNN = transpose(WESN)
           HTSNN = transpose(HTSN)
           SNDZN = transpose(SNDZ)
-          !*** call new/shared routine to compute albedo 
+          !*** call new/shared routine to compute albedo
 
-          call    SNOW_ALBEDO(NT, NUM_SNOW_LAYERS, N_CONST_LANDICE4SNWALB, ITYPE, LAI, ZTH, & 
+          call    SNOW_ALBEDO(NT, NUM_SNOW_LAYERS, N_CONST_LANDICE4SNWALB, ITYPE, LAI, ZTH, &
                       RHOFRESH, VISMAX, NIRMAX, SLOPE, &     !0.96, 0.68, 1.0,  & !
                       WESNN, HTSNN, SNDZN,        & ! snow stuff
                       LNDVR, LNDNR, LNDVF, LNDNF, & ! instantaneous snow-free albedos on tiles
@@ -3345,7 +3345,7 @@ end if
           VSUVR     = DRPAR + DRUVR
           VSUVF     = DFPAR + DFUVR
           SWNETSNOW = (1.-SNOVR)*VSUVR + (1.-SNOVF)*VSUVF + (1.-SNONR)*DRNIR + (1.-SNONF)*DFNIR
-          RADDN     = LWDNSRF + SWNETSNOW 
+          RADDN     = LWDNSRF + SWNETSNOW
           SWN       = SWNETSNOW
           if(associated(SNOWALB)) then
               where(FR(:,N) > 0.0)
@@ -3361,26 +3361,26 @@ end if
 
        if(N==ICE) then
           do k=1,NT
-             if(FR(k,N) > MINFRACSNO) then     
+             if(FR(k,N) > MINFRACSNO) then
                 call SOLVEICELAYER(NUM_ICE_LAYERS, DT, TICE(k,N,:), DZMAXI, 0,   &
                                  MELTI(k), DTSS=DTS(k),  RUNOFF=PERC(k),                 &
                                  lhturb=LHF(k),hlwtc=ULW(k),hsturb=SHF(k),raddn=RADDN(k),        &
                                  dlhdtc=LHD(k),dhsdtc=SHD(k),dhlwtc=BLWN(k),rain=RAIN(k),    &
-                                 rainrf=RAINRF(k),                                          & 
+                                 rainrf=RAINRF(k),                                          &
                                  lhflux=LHFO(k),shflux=SHFO(k),hlwout=HLWO(k),evapout=EVAPO(k), &
                                  ghflxice=ghflxice(k))
              else
                 TICE(k,N,:) =  TICE(k,SNOW,:)
              endif
-          enddo 
+          enddo
           TS(:,N)   =  TICE(:,N,1)
           if(associated(RUNOFF))   RUNOFF   = RUNOFF + FR(:,N) * PERC
        endif
 
-       if(N==SNOW) then 
+       if(N==SNOW) then
           LANDICELT  =  TICE(:,N,1) - MAPL_TICE
           do k=1,NT
-#if 0 
+#if 0
              LATSD=LATS(K)*rad_to_deg
              LONSD=LONS(K)*rad_to_deg
              !if(abs(LATSD-0.700003698112E+02) < 1.e-3 .and. &
@@ -3389,46 +3389,46 @@ end if
              !   abs(LONSD-(-0.433431029954E+02)) < 1.e-3 ) then
              if(abs(LATSD-0.807870232172E+02) < 1.e-3 .and. &
                 abs(LONSD-(-0.154247429558E+02)) < 1.e-3 ) then
-               print*, 'PE = ', mype, ' tile = ',k 
-             endif  
+               print*, 'PE = ', mype, ' tile = ',k
+             endif
 #endif
-             TKSNO = condice 
+             TKSNO = condice
 
           call SNOWRT( LONS(k), LATS(k),                                       &  ! in     [radians]  !!!
-                   1,NUM_SNOW_LAYERS,MAPL_LANDICE,                             &  ! in    
-                   MAXSNDZ, RHOFRESH, DZMAX,                                   &  ! in    
-                   LANDICELT(k),ZONEAREA,TKGND,PRECIP(k),SNO(k),TA(k),DT,      &  ! in    
-                   EVAPI(k),DEVAPDT(k),SHF(k),SHD(k),ULW(k),BLWN(k),           &  ! in    
-                   RADDN(k),ZC1,TOTDEPOS(k,:),                                 &  ! in    
-                   WESN(k,:),HTSN(k,:),SNDZ(k,:), RCONSTIT(k,:,:),             &  ! inout    
-                   HLWO(k), FROZFRAC(k,:),TPSN(k,:), RMELT(k,:),               &  ! out    
-                   AREASC(k),FR(K,N),PERC(k),FHGND(k),                         &  ! out   
-                   EVAPO(k),SHFO(k),LHFO(k),HCORR(k),ghflxsno(k),              &  ! out   
-                   SNDZSC(k), WESNPREC(k), SNDZPREC(k),SNDZ1PERC(k),           &  ! out    
-                   WESNPERC(k,:), WESNDENS(k,:), WESNREPAR(k,:), MLT(k),       &  ! out      
-                   EXCS(k,:), DRHO0(k,:), WESNBOT(k), TKSNO, DTS(k)       )       ! out   
+                   1,NUM_SNOW_LAYERS,MAPL_LANDICE,                             &  ! in
+                   MAXSNDZ, RHOFRESH, DZMAX,                                   &  ! in
+                   LANDICELT(k),ZONEAREA,TKGND,PRECIP(k),SNO(k),TA(k),DT,      &  ! in
+                   EVAPI(k),DEVAPDT(k),SHF(k),SHD(k),ULW(k),BLWN(k),           &  ! in
+                   RADDN(k),ZC1,TOTDEPOS(k,:),                                 &  ! in
+                   WESN(k,:),HTSN(k,:),SNDZ(k,:), RCONSTIT(k,:,:),             &  ! inout
+                   HLWO(k), FROZFRAC(k,:),TPSN(k,:), RMELT(k,:),               &  ! out
+                   AREASC(k),FR(K,N),PERC(k),FHGND(k),                         &  ! out
+                   EVAPO(k),SHFO(k),LHFO(k),HCORR(k),ghflxsno(k),              &  ! out
+                   SNDZSC(k), WESNPREC(k), SNDZPREC(k),SNDZ1PERC(k),           &  ! out
+                   WESNPERC(k,:), WESNDENS(k,:), WESNREPAR(k,:), MLT(k),       &  ! out
+                   EXCS(k,:), DRHO0(k,:), WESNBOT(k), TKSNO, DTS(k)       )       ! out
 
              ! Snow impurities update
               if (N_CONST_LANDICE4SNWALB /= 0) then
-                 if(associated(IRDU001)) IRDU001(k,:) = RCONSTIT(k,:,1) 
-                 if(associated(IRDU002)) IRDU002(k,:) = RCONSTIT(k,:,2) 
-                 if(associated(IRDU003)) IRDU003(k,:) = RCONSTIT(k,:,3) 
-                 if(associated(IRDU004)) IRDU004(k,:) = RCONSTIT(k,:,4) 
-                 if(associated(IRDU005)) IRDU005(k,:) = RCONSTIT(k,:,5) 
-                 if(associated(IRBC001)) IRBC001(k,:) = RCONSTIT(k,:,6) 
-                 if(associated(IRBC002)) IRBC002(k,:) = RCONSTIT(k,:,7) 
-                 if(associated(IROC001)) IROC001(k,:) = RCONSTIT(k,:,8) 
-                 if(associated(IROC002)) IROC002(k,:) = RCONSTIT(k,:,9) 
+                 if(associated(IRDU001)) IRDU001(k,:) = RCONSTIT(k,:,1)
+                 if(associated(IRDU002)) IRDU002(k,:) = RCONSTIT(k,:,2)
+                 if(associated(IRDU003)) IRDU003(k,:) = RCONSTIT(k,:,3)
+                 if(associated(IRDU004)) IRDU004(k,:) = RCONSTIT(k,:,4)
+                 if(associated(IRDU005)) IRDU005(k,:) = RCONSTIT(k,:,5)
+                 if(associated(IRBC001)) IRBC001(k,:) = RCONSTIT(k,:,6)
+                 if(associated(IRBC002)) IRBC002(k,:) = RCONSTIT(k,:,7)
+                 if(associated(IROC001)) IROC001(k,:) = RCONSTIT(k,:,8)
+                 if(associated(IROC002)) IROC002(k,:) = RCONSTIT(k,:,9)
               end if
            if (N_constit>0) then
-              if(associated(RMELTDU001)) RMELTDU001(k) = RMELT(k,1) 
-              if(associated(RMELTDU002)) RMELTDU002(k) = RMELT(k,2) 
-              if(associated(RMELTDU003)) RMELTDU003(k) = RMELT(k,3) 
-              if(associated(RMELTDU004)) RMELTDU004(k) = RMELT(k,4) 
-              if(associated(RMELTDU005)) RMELTDU005(k) = RMELT(k,5) 
-              if(associated(RMELTBC001)) RMELTBC001(k) = RMELT(k,6) 
-              if(associated(RMELTBC002)) RMELTBC002(k) = RMELT(k,7) 
-              if(associated(RMELTOC001)) RMELTOC001(k) = RMELT(k,8) 
+              if(associated(RMELTDU001)) RMELTDU001(k) = RMELT(k,1)
+              if(associated(RMELTDU002)) RMELTDU002(k) = RMELT(k,2)
+              if(associated(RMELTDU003)) RMELTDU003(k) = RMELT(k,3)
+              if(associated(RMELTDU004)) RMELTDU004(k) = RMELT(k,4)
+              if(associated(RMELTDU005)) RMELTDU005(k) = RMELT(k,5)
+              if(associated(RMELTBC001)) RMELTBC001(k) = RMELT(k,6)
+              if(associated(RMELTBC002)) RMELTBC002(k) = RMELT(k,7)
+              if(associated(RMELTOC001)) RMELTOC001(k) = RMELT(k,8)
               if(associated(RMELTOC002)) RMELTOC002(k) = RMELT(k,9)
            end if
 
@@ -3439,36 +3439,36 @@ end if
                          LWC(k) = sum(WESN(k,:)*(1.-FROZFRAC(k,:)))/sum(WESN(k,:))
                       else
                          KL  = 0
-                         ZKL = 0.0 
+                         ZKL = 0.0
                          do l=1,NUM_SNOW_LAYERS
-                            ZKL = ZKL + SNDZ(k,l) 
+                            ZKL = ZKL + SNDZ(k,l)
                             if(ZKL > LWCTOP) then
                               KL = l
                               exit
                             endif
-                         enddo 
+                         enddo
                          ALPHA = 1.0 - (ZKL-LWCTOP)/SNDZ(k,KL)
                          LWC(k) = (sum(WESN(k,1:KL-1)*(1.-FROZFRAC(k,1:KL-1)))+ &
                                    ALPHA*WESN(k,KL)*(1.-FROZFRAC(k,KL))) / &
-                                  (sum(WESN(k,1:KL-1))+ALPHA*WESN(k,KL))  
+                                  (sum(WESN(k,1:KL-1))+ALPHA*WESN(k,KL))
                       endif
                   else
                       LWC(k) = 0.0
-                  endif            
+                  endif
              endif
              if(FR(K,N) < MINFRACSNO) then
                 TICE(k,N,:) =  TICE(k,ICE,:)
              else
                  call SOLVEICELAYER(NUM_ICE_LAYERS, DT, TICE(k,N,:), DZMAXI, 1,   &
                                  MELTI(k),                    &
-                                 condsno=TKSNO(NUM_SNOW_LAYERS),       & 
-                                 !tsn=TPSN(k,NUM_SNOW_LAYERS),          & 
-                                 fhgnd=FHGND(k),          & 
+                                 condsno=TKSNO(NUM_SNOW_LAYERS),       &
+                                 !tsn=TPSN(k,NUM_SNOW_LAYERS),          &
+                                 fhgnd=FHGND(k),          &
                                  sndz=SNDZ(k,NUM_SNOW_LAYERS)          &
                                  )
                  if(associated(RUNOFF)) RUNOFF(K)   = RUNOFF(K) + FR(K,N) * MELTI(K)
-             endif   
-          enddo   
+             endif
+          enddo
           WESNSC = EVAPO
           !PERC = PERC + MELTI
           if(associated(RUNOFF))   RUNOFF   = RUNOFF + PERC
@@ -3477,11 +3477,11 @@ end if
        endif
 
        DQS       = GEOS_QSAT(TS(:,N), PS, PASCALS=.TRUE.,RAMP=0.0) - QS(:,N)
-       QS(:,N)   = QS(:,N) + DQS  
+       QS(:,N)   = QS(:,N) + DQS
 
        LHF = LHFO
        SHF = SHFO
-       ULW = HLWO 
+       ULW = HLWO
 
        if(associated(EVAPOUT)) EVAPOUT = EVAPOUT + FR(:,N)*EVAPO
        if(associated(SUBLIM )) SUBLIM  = SUBLIM  + FR(:,N)*EVAPO
@@ -3500,21 +3500,21 @@ end if
        if(associated(HLWUP   )) HLWUP   = HLWUP +   ULW * FR(:,N)
        if(associated(DNICFLX )) DNICFLX = DNICFLX + DIF * FR(:,N)
        if(associated(GHSNOW  )) GHSNOW  = ghflxsno
-       if(associated(ACCUM   )) ACCUM   = ACCUM - FR(:,N) * EVAPO  
-       if(associated(MELTWTR )) MELTWTR = MELTWTR + FR(:,N) * MELTI  
+       if(associated(ACCUM   )) ACCUM   = ACCUM - FR(:,N) * EVAPO
+       if(associated(MELTWTR )) MELTWTR = MELTWTR + FR(:,N) * MELTI
 
        if(associated(TICE0   )) then
           do k=1,NT
             TICE0(k,:) =  TICE0(k,:)  + TICE(k,N,:) * FR(k,N)
           enddo
-       endif 
+       endif
 
-    enddo ! NUM_SUBTILES 
+    enddo ! NUM_SUBTILES
 
     FR(:,ICE) = max(1.0-FR(:,SNOW), 0.0)
 
     if(associated(GHTSKIN )) GHTSKIN = ghflxsno*FR(:,SNOW) + ghflxice*FR(:,ICE)
-    if(associated(ACCUM )) ACCUM      = ACCUM + PRECIP   
+    if(associated(ACCUM )) ACCUM      = ACCUM + PRECIP
     if(associated(EMISS )) EMISS      = LANDICEEMISS
 
     if(associated(SNOWMASS)) SNOWMASS = sum(WESN,dim=2)
@@ -3524,12 +3524,12 @@ end if
     if(associated(SMELT ))   SMELT    = PERC
     if(associated(RAINRFZ )) RAINRFZ  = FR(:,ICE)  * RAINRF
 
-    if(associated(MELTWTR )) MELTWTR  = MELTWTR + MLT  
+    if(associated(MELTWTR )) MELTWTR  = MELTWTR + MLT
 
 
     ! Calculate surface mass balance (SMB) for ISSM
     if(associated(ICESMB)) ICESMB    = ACCUM - RUNOFF
-    
+
     ! average ICESMB over time steps between ISSM runs
     if(DO_ISSM==1) then
         if(associated(ICESMB_ISSM)) ICESMB_ISSM = ICESMB_ISSM + (ICESMB-ICESMB_ISSM)/(ISSM_NSTEPS+1)
@@ -3537,7 +3537,7 @@ end if
 
 		! update internal state
 		ICESMB_IN(:) = ICESMB_ISSM(:)
-    end if 
+    end if
 ! Update snow and landice albedos to anticipate
 !   next radiation calculation
 !-----------------------------------------------
@@ -3552,7 +3552,7 @@ end if
 
        ITYPE = 9
 
-       call    SNOW_ALBEDO(NT, NUM_SNOW_LAYERS, N_CONST_LANDICE4SNWALB, ITYPE, LAI, ZTH, & 
+       call    SNOW_ALBEDO(NT, NUM_SNOW_LAYERS, N_CONST_LANDICE4SNWALB, ITYPE, LAI, ZTH, &
                    RHOFRESH, VISMAX, NIRMAX, SLOPE,  &   ! 0.96, 0.68, 1.0,  & !
                    WESNN, HTSNN, SNDZN,        & ! snow stuff
                    LNDVR, LNDNR, LNDVF, LNDNF, & ! instantaneous snow-free albedos on tiles
@@ -3567,7 +3567,7 @@ end if
 
 
     if(associated(SNICEALB ))  then
-       SNICEALB = FR(:,ICE)*LANDICEALB +                   & 
+       SNICEALB = FR(:,ICE)*LANDICEALB +                   &
                   FR(:,SNOW)*(SNOVR*AWTVDR + SNOVF*AWTVDF  &
                             + SNONR*AWTIDR + SNONF*AWTIDF)
        where(ZTH < 1.e-6)
@@ -3594,23 +3594,23 @@ end if
 
     if(associated(RHOSNOW  )) then
        RHOSNOW = 0.0
-       do N=1,NUM_SNOW_LAYERS 
+       do N=1,NUM_SNOW_LAYERS
          !where(FR(:,SNOW) > 0.0 .and. SNDZ(:,N) > 0.0)
          where(sum(WESN,dim=2) > MINSWE)
             RHOSNOW(:,N) = WESN(:,N) / FR(:,SNOW) / SNDZ(:,N)
          elsewhere
-            RHOSNOW(:,N) = MAPL_UNDEF 
+            RHOSNOW(:,N) = MAPL_UNDEF
          endwhere
        enddo
     end if
 
     if(associated(TSNOW  )) then
        TSNOW = 0.0
-       do N=1,NUM_SNOW_LAYERS 
+       do N=1,NUM_SNOW_LAYERS
          where(FR(:,SNOW) > 0.0 .and. SNDZ(:,N) > 0.0)
             TSNOW(:,N) = TPSN(:,N)
          elsewhere
-            TSNOW(:,N) = MAPL_UNDEF 
+            TSNOW(:,N) = MAPL_UNDEF
          endwhere
        enddo
     end if
@@ -3636,7 +3636,7 @@ end if
     end if
 
     if(associated(WESC )) then
-       WESC =  WESNSC 
+       WESC =  WESNSC
     end if
 
     if(associated(SDSC )) then
@@ -3671,12 +3671,12 @@ end if
        WEBOT =  WESNBOT / DT
     end if
 
-! Run ISSM 
+! Run ISSM
 #ifdef HAVE_ISSM
     if (DO_ISSM==1) then
       call MAPL_Get (MAPL, GCS=GCS, GCNAMES=GCNAMES, RC=STATUS )
       do N=1, size(GCS)
-         if (index(GCNAMES(N), 'ISSM') /=0 ) then 
+         if (index(GCNAMES(N), 'ISSM') /=0 ) then
             call MAPL_GetObjectFromGC(GCS(N), CHILD_MAPL, RC=STATUS); VERIFY_(STATUS)
             call MAPL_Get(CHILD_MAPL, RUNALARM = ISSM_ALARM, RC=STATUS); VERIFY_(STATUS)
 
@@ -3688,7 +3688,7 @@ end if
             call MAPL_GenericRunChildren(GC, IMPORT, EXPORT, CLOCK, RC=STATUS)
             VERIFY_(STATUS)
 
-            if (ESMF_AlarmIsRinging (ISSM_ALARM, RC=STATUS)) then   
+            if (ESMF_AlarmIsRinging (ISSM_ALARM, RC=STATUS)) then
                ! if ISSM solvers were called, get exports on tile space
                if(associated(ICESURF))  ICESURF = issm_tile_state%ICESURF_TILE
                if(associated(ICETHICK)) ICETHICK = issm_tile_state%ICETHICK_TILE
@@ -3705,29 +3705,29 @@ end if
                ! update internal state for running-mean ICESMB
                ICESMB_IN(:) = ICESMB_ISSM(:)
 
-            end if 
+            end if
          end if
       end do
-    end if 
+    end if
 #endif
 
-    if(allocated (MLT)) deallocate(MLT , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (DTS)) deallocate(DTS , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (DQS)) deallocate(DQS , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (SHF)) deallocate(SHF , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (LHF)) deallocate(LHF , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (SHD)) deallocate(SHD , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (LHD)) deallocate(LHD , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (CFT)) deallocate(CFT , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (CFQ)) deallocate(CFQ , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (SWN)) deallocate(SWN , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (DIF)) deallocate(DIF , STAT=STATUS); VERIFY_(STATUS)              
-    if(allocated (ULW)) deallocate(ULW , STAT=STATUS); VERIFY_(STATUS)                  
-    if(allocated (PRECIP  )) deallocate(PRECIP  , STAT=STATUS); VERIFY_(STATUS)                  
-    if(allocated (RAIN    )) deallocate(RAIN    , STAT=STATUS); VERIFY_(STATUS)                  
-    if(allocated (RAINRF  )) deallocate(RAINRF  , STAT=STATUS); VERIFY_(STATUS)                  
-    if(allocated (PERC    )) deallocate(PERC    , STAT=STATUS); VERIFY_(STATUS)                  
-    if(allocated (MELTI   )) deallocate(MELTI   , STAT=STATUS); VERIFY_(STATUS)                  
+    if(allocated (MLT)) deallocate(MLT , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (DTS)) deallocate(DTS , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (DQS)) deallocate(DQS , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SHF)) deallocate(SHF , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (LHF)) deallocate(LHF , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SHD)) deallocate(SHD , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (LHD)) deallocate(LHD , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (CFT)) deallocate(CFT , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (CFQ)) deallocate(CFQ , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SWN)) deallocate(SWN , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (DIF)) deallocate(DIF , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (ULW)) deallocate(ULW , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (PRECIP  )) deallocate(PRECIP  , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (RAIN    )) deallocate(RAIN    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (RAINRF  )) deallocate(RAINRF  , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (PERC    )) deallocate(PERC    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (MELTI   )) deallocate(MELTI   , STAT=STATUS); VERIFY_(STATUS)
     if(allocated (FROZFRAC)) deallocate(FROZFRAC, STAT=STATUS); VERIFY_(STATUS)
     if(allocated (TPSN    )) deallocate(TPSN    , STAT=STATUS); VERIFY_(STATUS)
     if(allocated (AREASC  )) deallocate(AREASC  , STAT=STATUS); VERIFY_(STATUS)
@@ -3735,32 +3735,32 @@ end if
     if(allocated (ghflxsno)) deallocate(ghflxsno, STAT=STATUS); VERIFY_(STATUS)
     if(allocated (ghflxice)) deallocate(ghflxice, STAT=STATUS); VERIFY_(STATUS)
     if(allocated (HLWO    )) deallocate(HLWO    , STAT=STATUS); VERIFY_(STATUS)
-    if(allocated (EVAPO   )) deallocate(EVAPO   , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (LHFO    )) deallocate(LHFO    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (SHFO    )) deallocate(SHFO    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (ZTH     )) deallocate(ZTH     , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (SLR     )) deallocate(SLR     , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (EVAPI   )) deallocate(EVAPI   , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (DEVAPDT )) deallocate(DEVAPDT , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (ITYPE   )) deallocate(ITYPE   , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (LAI     )) deallocate(LAI     , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (GRN     )) deallocate(GRN     , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (MODISFAC)) deallocate(MODISFAC, STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (SNOVR    )) deallocate(SNOVR    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (SNONR    )) deallocate(SNONR    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (SNOVF    )) deallocate(SNOVF    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (SNONF    )) deallocate(SNONF    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (LNDVR    )) deallocate(LNDVR    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (LNDNR    )) deallocate(LNDNR    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (LNDVF    )) deallocate(LNDVF    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (LNDNF    )) deallocate(LNDNF    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (VSUVR    )) deallocate(VSUVR    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (VSUVF    )) deallocate(VSUVF    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (SWNETSNOW)) deallocate(SWNETSNOW, STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (RADDN    )) deallocate(RADDN    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (FHGND    )) deallocate(FHGND    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (DRHO0    )) deallocate(DRHO0    , STAT=STATUS); VERIFY_(STATUS) 
-    if(allocated (EXCS     )) deallocate(EXCS     , STAT=STATUS); VERIFY_(STATUS) 
+    if(allocated (EVAPO   )) deallocate(EVAPO   , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (LHFO    )) deallocate(LHFO    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SHFO    )) deallocate(SHFO    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (ZTH     )) deallocate(ZTH     , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SLR     )) deallocate(SLR     , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (EVAPI   )) deallocate(EVAPI   , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (DEVAPDT )) deallocate(DEVAPDT , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (ITYPE   )) deallocate(ITYPE   , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (LAI     )) deallocate(LAI     , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (GRN     )) deallocate(GRN     , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (MODISFAC)) deallocate(MODISFAC, STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SNOVR    )) deallocate(SNOVR    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SNONR    )) deallocate(SNONR    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SNOVF    )) deallocate(SNOVF    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SNONF    )) deallocate(SNONF    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (LNDVR    )) deallocate(LNDVR    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (LNDNR    )) deallocate(LNDNR    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (LNDVF    )) deallocate(LNDVF    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (LNDNF    )) deallocate(LNDNF    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (VSUVR    )) deallocate(VSUVR    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (VSUVF    )) deallocate(VSUVF    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (SWNETSNOW)) deallocate(SWNETSNOW, STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (RADDN    )) deallocate(RADDN    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (FHGND    )) deallocate(FHGND    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (DRHO0    )) deallocate(DRHO0    , STAT=STATUS); VERIFY_(STATUS)
+    if(allocated (EXCS     )) deallocate(EXCS     , STAT=STATUS); VERIFY_(STATUS)
     if(allocated (WESNSC   )) deallocate(WESNSC   , STAT=STATUS); VERIFY_(STATUS)
     if(allocated (SNDZSC   )) deallocate(SNDZSC   , STAT=STATUS); VERIFY_(STATUS)
     if(allocated (WESNPREC )) deallocate(WESNPREC , STAT=STATUS); VERIFY_(STATUS)
@@ -3775,10 +3775,10 @@ end if
     if(allocated (HTSNN    )) deallocate(HTSNN    , STAT=STATUS); VERIFY_(STATUS)
     if(allocated (SNDZN    )) deallocate(SNDZN    , STAT=STATUS); VERIFY_(STATUS)
 
-!  All done                          
-!-----------                         
+!  All done
+!-----------
 
-    RETURN_(ESMF_SUCCESS)            
+    RETURN_(ESMF_SUCCESS)
 
   end subroutine LANDICECORE
 
@@ -3794,7 +3794,7 @@ end if
                               lhflux,shflux,hlwout,evapout,          &
                               condsno, fhgnd, sndz, ghflxice      )
 
-     implicit none 
+     implicit none
 
      integer, intent(in)  :: NICE
      real,    intent(in    ) :: DTS
@@ -3810,28 +3810,28 @@ end if
      real, optional, intent(in ) ::  dlhdtc,dhsdtc,dhlwtc
      real, optional, intent(in ) ::  rain
      real, optional, intent(out) ::  rainrf
-     real, optional, intent(out) ::  lhflux,shflux,hlwout,evapout 
+     real, optional, intent(out) ::  lhflux,shflux,hlwout,evapout
      real, optional, intent(out) ::  ghflxice
      !  UPPER_BND == 1
-     real, optional, intent(in ) ::  condsno, fhgnd, sndz 
+     real, optional, intent(in ) ::  condsno, fhgnd, sndz
 
      ! Locals
      real :: melti,frrain,dtr,tsx,mass,snowd,rainf,denom,alhv,hcorr,            &
-           enew,eold,tdum,fnew,tnew,icedens,densfac,hnew                      
-     integer  ::  i     
+           enew,eold,tdum,fnew,tnew,icedens,densfac,hnew
+     integer  ::  i
      real, dimension(size(TICE)  ) :: tpsn
      real, dimension(size(TICE)  ) :: dtc,q,cl,cd,cr
      real, dimension(size(TICE)+1) :: fhsn,df
 
 
-     
+
       df     = 0.
       dtc    = 0.
       fhsn   = 0.
 
       MELT   = 0.
 
-       
+
       if(UPPER_BND == 0) then
          rainrf = 0.0
          RUNOFF = 0.0
@@ -3841,8 +3841,8 @@ end if
 
       alhv   = alhe + alhm                            !randy
 
-      fhsn(NICE+1) = 0.0  
-      df(NICE+1)   = 0.0 
+      fhsn(NICE+1) = 0.0
+      df(NICE+1)   = 0.0
 
 !**** Calculate heat fluxes between snow layers.
 
@@ -3861,9 +3861,9 @@ end if
 
       else
         df(1)   = -sqrt(condice*condsno)/((ICEDZ(1)+sndz)*0.5)
-        !fhsn(1) = df(1)*(TSN - tpsn(1)) 
+        !fhsn(1) = df(1)*(TSN - tpsn(1))
         fhsn(1) = fhgnd
-      endif 
+      endif
 
 !**** Prepare array elements for solution & coefficient matrices.
 !**** Terms are as follows:  left (cl), central (cd) & right (cr)
@@ -3891,42 +3891,42 @@ end if
 
        do i=1,NICE
           if(tpsn(i)+dtc(i) > 0.) then
-             melti  = (tpsn(i)+dtc(i))*cpw*MAPL_RHOWTR*ICEDZ(i)/MAPL_ALHF  
-             MELT   = MELT   + melti 
+             melti  = (tpsn(i)+dtc(i))*cpw*MAPL_RHOWTR*ICEDZ(i)/MAPL_ALHF
+             MELT   = MELT   + melti
              if(UPPER_BND == 0) then
-                RUNOFF = RUNOFF  + melti 
+                RUNOFF = RUNOFF  + melti
              endif
              dtc(i) = -tpsn(i)
              tpsn(i) = tpsn(i) + dtc(i)
-             if(i == 1) then 
+             if(i == 1) then
                 if(UPPER_BND == 0) then
                    RUNOFF = RUNOFF + rain * dts
                 endif
              endif
           elseif(tpsn(i)+dtc(i) == 0.0) then
              tpsn(i) = tpsn(i) + dtc(i)
-             if(i == 1) then 
+             if(i == 1) then
                 if(UPPER_BND == 0) then
                    RUNOFF = RUNOFF + rain * dts
                 endif
              endif
           else  ! temp < 0, refreeze rain if any
              tpsn(i) = tpsn(i) + dtc(i)
-             if(i == 1) then 
+             if(i == 1) then
                 if(UPPER_BND == 0) then
-                 !*** only latent heat of rain is used to raise ice temp.  
+                 !*** only latent heat of rain is used to raise ice temp.
                  !*** since AGCM assumes rain has 0 heat content
-                 dtr = rain*dts*alhm/(RHOICE*cpw*ICEDZ(i))   
+                 dtr = rain*dts*alhm/(RHOICE*cpw*ICEDZ(i))
                  if(tpsn(i)+dtr > 0.0) then
                    frrain = max(dtr-(-tpsn(i))/dtr, 1.)
                    dtr = -tpsn(i)
-                 else  
+                 else
                    frrain = 0.0
-                 endif   
+                 endif
                  tpsn(i) = tpsn(i) + dtr
                  dtc(i) = dtc(i) + dtr
                  RUNOFF = RUNOFF + frrain * rain * dts
-                 rainrf = rainrf + (1.-frrain) * rain * dts 
+                 rainrf = rainrf + (1.-frrain) * rain * dts
                 endif
              endif
           endif
@@ -3939,17 +3939,17 @@ end if
             endif
           endif
        enddo
- 
-       MELT   = MELT  / dts  
 
-       if(present(RUNOFF)) RUNOFF = RUNOFF / dts  
-       if(present(rainrf)) rainrf = rainrf / dts  
+       MELT   = MELT  / dts
 
-       if(present(dtss)) dtss = dtc(1) 
+       if(present(RUNOFF)) RUNOFF = RUNOFF / dts
+       if(present(rainrf)) rainrf = rainrf / dts
+
+       if(present(dtss)) dtss = dtc(1)
 
        TICE = tpsn + tf
 
-     end subroutine SOLVEICELAYER  
+     end subroutine SOLVEICELAYER
 
 end subroutine RUN2
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSlandice_GridComp/GEOSissm_GridComp/GEOS_ISSMGridComp.F90
@@ -6,7 +6,7 @@ module GEOS_IssmGridCompMod
 
 !BOP
 ! !MODULE: GEOS_ISSM --- Runs ISSM (Ice-sheet and Sea-level System Model)
-! 
+!
 !
 ! !DESCRIPTION:
 !
@@ -15,19 +15,19 @@ module GEOS_IssmGridCompMod
 !   Exports: ICESURF, ICETHICK, ICESMB_ISSM, ICEVX, ICEVY (defined on mesh) [true export state]
 !   Exports: ICESURF, ICETHICK, ICEVEL (defined on landice tiles) [via private internal state]
 !   Internals: ICESURF, ICETHICK, IMLS, OMLS, ISSM_NSTEPS (defined on mesh) [true internal state]
-! *** NOTES: 
+! *** NOTES:
 !            (*) currently we run over all input files (*.bin) that are found in ISSM_EXPDIR (scratch directory)
 !                (e.g., Greenland + Antarctica + any other glaciers that have been configured)
-!            (*) ISSM meshes are internal to ISSM (C++ source)--we create an ESMF_MESH version for regridding     
+!            (*) ISSM meshes are internal to ISSM (C++ source)--we create an ESMF_MESH version for regridding
 !                imports/exports that is the global combination of all ISSM meshes
-!            (*) we transform imports from landice tiles to attached grid, then regrid to the mesh 
-!            (*) ISSM outputs are saved with HISTORY via a 'mesh tile space' developed by Weiyuan Jiang (GMAO SI Team)  
-!            (*) ISSM time step is generally larger than LANDICE timestep, or even a job duration. We persist ISSM 
-!                variables across job segments through internal state checkpoints (restarts). We make sure that INTERNAL 
-!                and EXPORT variables are 'filled in' by Initialize so that LANDICE and HISTORY have access to ISSM 
-!                variables before it runs.  
-!            (*) Related, we use a custom ISSM run alarm that is keyed to the last time ISSM ran, not the simulation 
-!                start time. The number of LANDICE time steps since ISSM last ran is tracked via the internal state.  
+!            (*) we transform imports from landice tiles to attached grid, then regrid to the mesh
+!            (*) ISSM outputs are saved with HISTORY via a 'mesh tile space' developed by Weiyuan Jiang (GMAO SI Team)
+!            (*) ISSM time step is generally larger than LANDICE timestep, or even a job duration. We persist ISSM
+!                variables across job segments through internal state checkpoints (restarts). We make sure that INTERNAL
+!                and EXPORT variables are 'filled in' by Initialize so that LANDICE and HISTORY have access to ISSM
+!                variables before it runs.
+!            (*) Related, we use a custom ISSM run alarm that is keyed to the last time ISSM ran, not the simulation
+!                start time. The number of LANDICE time steps since ISSM last ran is tracked via the internal state.
 
 ! !USES:
 use iso_fortran_env, only: dp=>real64, sp=>real32
@@ -47,7 +47,7 @@ subroutine InitializeISSM(expdir, num_elements, num_nodes, comm) bind(c, name="I
   integer(c_int)                  :: num_nodes
   integer(c_int)                  :: comm
 end subroutine InitializeISSM
-    
+
 subroutine RunISSM(ISSM_DT, gcm_forcings, issm_outputs) bind(C,NAME="RunISSM")
    import :: c_ptr, c_double
    real(c_double),   value        :: ISSM_DT
@@ -63,7 +63,7 @@ end subroutine InputFromRestarts
 subroutine GetNodesISSM(nodeIds, nodeCoords) bind(C,NAME="GetNodesISSM")
    import :: c_ptr
    type(c_ptr),      value        :: nodeIds
-   type(c_ptr),      value        :: nodeCoords 
+   type(c_ptr),      value        :: nodeCoords
 end subroutine GetNodesISSM
 
 subroutine GetElementsISSM(elementIds, elementConn, elementCoords, glacIds) bind(C,NAME="GetElementsISSM")
@@ -83,10 +83,10 @@ private
 
 public SetServices
 
-! some shared derived types and parameters below:       
+! some shared derived types and parameters below:
 
 public :: T_ISSM_TILE_STATE
-public :: ISSM_TILE_WRAP
+public :: T_ISSM_TILE_WRAP
 ! define ISSM export as internal variables, will be used by the landice gridcomp
 
 type T_ISSM_TILE_STATE
@@ -98,11 +98,11 @@ type T_ISSM_TILE_STATE
     real          :: LANDICE_DT
 end type T_ISSM_TILE_STATE
 
-type ISSM_TILE_WRAP
+type T_ISSM_TILE_WRAP
    type(T_ISSM_TILE_STATE), pointer :: ptr=>null()
-end type ISSM_TILE_WRAP
+end type T_ISSM_TILE_WRAP
 
-! private internal state for regridding 
+! private internal state for regridding
 type T_ISSM_STATE
   private
   type(ESMF_RouteHandle)        :: routehandle_m2g ! routehandle for regridding mesh to grid
@@ -128,7 +128,7 @@ logical                      :: ISSM_RST_FOUND = .false. ! restart found flag
 type(T_ISSM_STATE), pointer  :: internal_state=>null()   ! internal state for regridding and halo operations
 
 contains
-                                
+
 
 !BOP
 
@@ -143,7 +143,7 @@ subroutine SetServices ( GC, RC )
     type(ESMF_GridComp), intent(INOUT) :: GC  ! gridded component
     integer, optional                  :: RC  ! return code
 
-    ! !DESCRIPTION: 
+    ! !DESCRIPTION:
 !   This version uses the MAPL\_GenericSetServices Here we set the initialize method,
 !   run method, and finalize method because we are interfacing with the external ISSM
 !   library IRF methods.
@@ -178,11 +178,11 @@ subroutine SetServices ( GC, RC )
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_INITIALIZE,   Initialize, _RC)
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_RUN,          Run,        _RC)
     call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_FINALIZE,     Finalize,   _RC)
-    
+
 !-----------------------------------
 
     call MAPL_GetObjectFromGC (GC, MAPL, _RC)
-    
+
 ! Set the state variable specs.
 !-----------------------------------
 
@@ -196,7 +196,7 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
          _RC  )
-    
+
     call MAPL_AddExportSpec(GC,                    &
          SHORT_NAME = 'ICEVX',                     &
          LONG_NAME  = 'ice_velocity_x_direction',  &
@@ -204,7 +204,7 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
          _RC  )
-    
+
     call MAPL_AddExportSpec(GC,                    &
         SHORT_NAME = 'ICEVY',                      &
         LONG_NAME  = 'ice_velocity_y_direction',   &
@@ -212,7 +212,7 @@ subroutine SetServices ( GC, RC )
         DIMS       = MAPL_DimsTileOnly,            &
         VLOCATION  = MAPL_VLocationNone,           &
         _RC  )
-    
+
     call MAPL_AddExportSpec(GC,                    &
          SHORT_NAME = 'ICETHICK',                  &
          LONG_NAME  = 'ice_thickness',             &
@@ -220,15 +220,15 @@ subroutine SetServices ( GC, RC )
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
          _RC  )
-		 
+
     call MAPL_AddExportSpec(GC,                    &
          SHORT_NAME = 'ICESMB_ISSM',               &
          LONG_NAME  = 'issm_surface_mass_balance', &
          UNITS      = 'kg m-2 s-1',                &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         _RC  )	 
-    
+         _RC  )
+
     !   Internal states:
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICESURF',                   &
@@ -236,36 +236,36 @@ subroutine SetServices ( GC, RC )
          UNITS      = 'm',                         &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         RESTART    = MAPL_RestartOptional,        &   
+         RESTART    = MAPL_RestartOptional,        &
          _RC  )
-    
+
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICETHICK',                  &
          LONG_NAME  = 'ice_sheet_thickness',       &
          UNITS      = 'm',                         &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         RESTART    = MAPL_RestartOptional,        & 
+         RESTART    = MAPL_RestartOptional,        &
          _RC  )
-    
+
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'IMLS',                      &
          LONG_NAME  = 'ice_mask_levelset',         &
          UNITS      = 'none',                      &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         RESTART    = MAPL_RestartOptional,        & 
+         RESTART    = MAPL_RestartOptional,        &
          _RC  )
-    
+
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'OMLS',                      &
          LONG_NAME  = 'ocean_mask_levelset',       &
          UNITS      = 'none',                      &
          DIMS       = MAPL_DimsTileOnly,           &
          VLOCATION  = MAPL_VLocationNone,          &
-         RESTART    = MAPL_RestartOptional,        & 
+         RESTART    = MAPL_RestartOptional,        &
          _RC  )
-    
+
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICEVX',                     &
          LONG_NAME  = 'ice_velocity_x_direction',  &
@@ -274,7 +274,7 @@ subroutine SetServices ( GC, RC )
          VLOCATION  = MAPL_VLocationNone,          &
          RESTART    = MAPL_RestartOptional,        &
          _RC  )
-    
+
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ICEVY',                     &
          LONG_NAME  = 'ice_velocity_y_direction',  &
@@ -283,7 +283,7 @@ subroutine SetServices ( GC, RC )
          VLOCATION  = MAPL_VLocationNone,          &
          RESTART    = MAPL_RestartOptional,        &
          _RC  )
-    
+
     call MAPL_AddInternalSpec(GC,                  &
          SHORT_NAME = 'ISSM_NSTEPS',               &
          LONG_NAME  = 'steps_since_last_issm',     &
@@ -307,25 +307,25 @@ subroutine SetServices ( GC, RC )
 
     call MAPL_TimerAdd(GC,    name="RUN"   ,_RC)
     call MAPL_TimerAdd(GC,    name="ISSMCore"   ,_RC)
-	
-       
+
+
 ! ----------------------------------
     call MAPL_GenericSetServices    ( GC, _RC)
-    
+
     _RETURN(_SUCCESS)
-  
+
   end subroutine SetServices
 
   ! ! INITIALIZE:
-  
+
   subroutine Initialize ( GC, IMPORT, EXPORT, CLOCK, RC )
-    type(ESMF_GridComp),     intent(INOUT) :: GC                      ! Gridded component 
+    type(ESMF_GridComp),     intent(INOUT) :: GC                      ! Gridded component
     type(ESMF_State),        intent(INOUT) :: IMPORT                  ! Import state
     type(ESMF_State),        intent(INOUT) :: EXPORT                  ! Export state
     type(ESMF_Clock),        intent(INOUT) :: CLOCK                   ! The clock
     integer, optional,       intent(OUT)   :: RC                      ! Error code
-    
-    type(MAPL_MetaComp), pointer           :: MAPL   
+
+    type(MAPL_MetaComp), pointer           :: MAPL
     type(ESMF_State)                       :: INTERNAL                ! internal state
 
     ! ISSM alarm variables
@@ -336,21 +336,21 @@ subroutine SetServices ( GC, RC )
     type(ESMF_Time)                        :: ringTime                ! time of first ring
     type(ESMF_TimeInterval)                :: ringInterval            ! ring time interval (ISSM_DT)
     real                                   :: ISSM_DT                 ! ISSM time step [s] (ISSM_DT set in AGCM.rc)
-    real                                   :: LANDICE_DT              ! landice time step [s] 
+    real                                   :: LANDICE_DT              ! landice time step [s]
     integer                                :: NSTEPS_INIT             ! landice timesteps since last ISSM run
     integer                                :: NSTEPS_RING             ! total landice timesteps between ISSM runs
     real, pointer, dimension(:)            :: ISSM_NSTEPS => null()   ! steps since last ISSM run (from internal state)
-	
+
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)             :: IAm
     integer                                :: STATUS
     character(len=ESMF_MAXSTR)             :: COMP_NAME
 
     ! virtual machine / mpi comm
-    type(ESMF_VM)                          :: vm    
+    type(ESMF_VM)                          :: vm
     integer(c_int)                         :: comm                    ! mpi comm to pass to ISSM
     integer                                :: localPET                ! ~mpi rank
-    
+
     ! mesh information
     type(ESMF_Mesh)                        :: mesh                    ! ESMF_Mesh representation of ISSM mesh
     integer, pointer, dimension(:)         :: elementTypes  => null() ! element geometry type (triangles)
@@ -364,7 +364,7 @@ subroutine SetServices ( GC, RC )
     integer, pointer, dimension(:)         :: nodeIds       => null() ! Global IDs of nodes local to PET
     integer, pointer, dimension(:)         :: nodeOwners    => null() ! Specify which PET owns each node
     integer, pointer, dimension(:)         :: glacIds       => null() ! glacier ID for each element
-    
+
     ! regridding varibales
     type(ESMF_Grid)                        :: grid                    ! atmospheric grid
     type(ESMF_RouteHandle)                 :: routehandle_m2g         ! routehandle for regridding mesh to grid
@@ -376,7 +376,7 @@ subroutine SetServices ( GC, RC )
     ! tile information
     integer                                :: NT                      ! local number of landice tiles
     type(T_ISSM_TILE_STATE), pointer       :: issm_tile_state
-    type(ISSM_TILE_WRAP)                   :: issm_tile_wrap
+    type(T_ISSM_TILE_WRAP)                 :: issm_tile_wrap
 
     ! field halo variables
     integer                                :: num_halo_nodes          ! num_nodes minus num_owned_nodes
@@ -389,17 +389,17 @@ subroutine SetServices ( GC, RC )
     integer, pointer,dimension(:)          :: owned_idx     => null() ! indices of owned nodes in arrays
 
     ! owned node coordinates (longitude,latitude)
-    real(dp),pointer,dimension(:)          :: ownedNodeCoords => null() 
+    real(dp),pointer,dimension(:)          :: ownedNodeCoords => null()
     real, allocatable, dimension(:)        :: ownedNodeLons, ownedNodeLats
 
-    ! command-line arguments to initialize ISSM 
+    ! command-line arguments to initialize ISSM
     integer                                :: i,j,k                   ! loop indices
     character(len=ESMF_MAXSTR)             :: ISSM_EXPDIR             ! directory containing ISSM input files
     character(len=ESMF_MAXSTR)             :: EXPDIR                  ! C++ compatible ISSM_EXPDIR string
 
     ! variables for creating mesh tile space
-    type(ESMF_Grid)                        :: mesh_grid               
-    type(MAPL_LocStream)                   :: mesh_locstream   
+    type(ESMF_Grid)                        :: mesh_grid
+    type(MAPL_LocStream)                   :: mesh_locstream
 
     ! variables for masking the mesh seam (triangles that cross +/-180 longitude)
     ! (needed for elements, this is not currently needed for regridding fields defined on nodes)
@@ -444,8 +444,8 @@ subroutine SetServices ( GC, RC )
     logical                                :: distgrid_match          ! check if distgrid from restarts matches nodal disgrid (locally)
     logical                                :: needRedist              ! global check for consistent distgrid across all processes
     integer,allocatable,dimension(:)       :: localFlag, globalFlag   ! arrays for vm operations
-    type(ESMF_Array)                       :: restartArray            ! array corresponding to restartDistgrid 
-    type(ESMF_Array)                       :: nodalArray              ! array corresponding to nodalDistgrid 
+    type(ESMF_Array)                       :: restartArray            ! array corresponding to restartDistgrid
+    type(ESMF_Array)                       :: nodalArray              ! array corresponding to nodalDistgrid
     type(ESMF_RouteHandle)                 :: redisthandle            ! routehandle for redistribution
 
 
@@ -454,7 +454,7 @@ subroutine SetServices ( GC, RC )
 
     Iam = "Initialize"
     call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC )
-    
+
     Iam = trim(COMP_NAME) // trim(Iam)
 
     ! Get my internal MAPL_Generic state
@@ -463,17 +463,17 @@ subroutine SetServices ( GC, RC )
     call MAPL_GetObjectFromGC ( GC, MAPL, _RC)
 
     call ESMF_VMGetCurrent(vm, _RC)
-    
+
     call ESMF_VMGet(vm,mpiCommunicator=comm,localPet=localPET,_RC)
-    
+
     ! ****************************************************
     ! call ISSM initialize C++ code so we can set up mesh
 
     ! get directory with ISSM binary input files (can modify if needed)
     call GET_ENVIRONMENT_VARIABLE("SCRDIR",ISSM_EXPDIR,STATUS=STATUS); _VERIFY(STATUS)
-    
+
     EXPDIR = trim(ISSM_EXPDIR)//"/"//c_null_char ! create string for C++
-    
+
     ! Call the C++ function for initializing ISSM
     ! gets the number of elements and nodes of the mesh
     call InitializeISSM(EXPDIR, num_elements, num_nodes, comm)
@@ -491,7 +491,7 @@ subroutine SetServices ( GC, RC )
 
     ! get information about nodes and elements
     ! node coords and element coords (centroids) are in (lon,lat)
-    call GetNodesISSM(c_loc(nodeIds), c_loc(nodeCoords)) 
+    call GetNodesISSM(c_loc(nodeIds), c_loc(nodeCoords))
     call GetElementsISSM(c_loc(elementIds), c_loc(elementConn), c_loc(elementCoords),c_loc(glacIds))
 
     elementTypes(:) = ESMF_MESHELEMTYPE_TRI ! triangular elements
@@ -501,7 +501,7 @@ subroutine SetServices ( GC, RC )
 	!
     ! NOTE: This is only relevant in regridding when fields are defined
     !       on ESMF_MESHLOC_ELEMENT (rather than ESMF_MESHLOC_NODE)
-	!       so is NOT CURRENTLY USED, but retained for possible future developments 
+	!       so is NOT CURRENTLY USED, but retained for possible future developments
     elementMask(:) = 0
     do j=1,num_elements
       n1 = elementConn(3*(j-1)+1)
@@ -518,12 +518,12 @@ subroutine SetServices ( GC, RC )
 
     ! create the ESMF mesh from ISSM mesh properties
     mesh = ESMF_MeshCreate(parametricDim=2, spatialDim=2, nodeIds=nodeIds, nodeCoords=nodeCoords, &
-            elementIds=elementIds, elementTypes=elementTypes, elementConn=elementConn,elementMask=elementMask,& 
+            elementIds=elementIds, elementTypes=elementTypes, elementConn=elementConn,elementMask=elementMask,&
             elementCoords=elementCoords,coordSys=ESMF_COORDSYS_SPH_DEG, _RC)
-    
-    ! associate ESMF_Mesh representation of ISSM mesh with GC for regridding imports/exports in Run method       
+
+    ! associate ESMF_Mesh representation of ISSM mesh with GC for regridding imports/exports in Run method
     call ESMF_GridCompSet(GC,mesh=mesh,_RC)
-    
+
     ! set up field halos
     !-----------------------------------
     call ESMF_MeshGet(mesh=mesh,nodeOwners=nodeOwners,numOwnedNodes=num_owned_nodes,nodalDistgrid=nodalDistgrid)
@@ -536,7 +536,7 @@ subroutine SetServices ( GC, RC )
     allocate(owned_idx(num_owned_nodes))
 
     call ESMF_MeshGet(mesh=mesh,ownedNodeCoords=ownedNodeCoords)
-    
+
     ! get list of (global) nodeIds that are halos on this PET
     ! and create a mask to remove these values from arrays
     i=1; k=1
@@ -549,47 +549,47 @@ subroutine SetServices ( GC, RC )
       ownedNodeIds(k) = nodeIds(j)
       owned_idx(k) = j
       k = k+1
-    end if 
+    end if
     end do
 
     ! create array with halo information
     meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,_RC)
-    
-    ! create field on ISSM mesh 
+
+    ! create field on ISSM mesh
     meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, _RC)
-    
+
     ! store the halo operation in a routehandle
     call ESMF_FieldHaloStore(meshField, routehandle=halohandle, _RC)
-    
+
     ! Set up regridding next
     !-----------------------------------
-    ! get atmospheric (attached) grid 
+    ! get atmospheric (attached) grid
     call ESMF_GridCompGet( GC, GRID=grid, _RC )
-    
+
     ! create field on atmospheric grid
     gridField = ESMF_FieldCreate(grid=grid,typekind=ESMF_TYPEKIND_R4,_RC)
-    
+
     ! create routehandle for mesh-to-grid regridding (set srcMaskValues to 1 if needed... )
-    call ESMF_FieldRegridStore(srcField=meshField, dstField=gridField,routehandle=routehandle_m2g,& 
+    call ESMF_FieldRegridStore(srcField=meshField, dstField=gridField,routehandle=routehandle_m2g,&
     unmappedaction=ESMF_UNMAPPEDACTION_IGNORE,extrapmethod=ESMF_EXTRAPMETHOD_CREEP,&
     extrapNumLevels=1,_RC)
-    
+
     ! create routehandle for grid-to-mesh regridding (set dstMaskValues to 1 if needed... )
-    call ESMF_FieldRegridStore(srcField=gridField, dstField=meshField,routehandle=routehandle_g2m,& 
+    call ESMF_FieldRegridStore(srcField=gridField, dstField=meshField,routehandle=routehandle_g2m,&
     unmappedaction=ESMF_UNMAPPEDACTION_IGNORE,extrapmethod=ESMF_EXTRAPMETHOD_NEAREST_D,_RC)
-    
+
     ! create component's private internal state
     ! stores everything needed for regrid and halo operations during run method
     allocate(internal_state, stat=STATUS); _VERIFY(STATUS)
-    
+
     allocate(internal_state%halo_idx(num_halo_nodes))
     allocate(internal_state%owned_idx(num_owned_nodes))
     allocate(internal_state%halolist(num_halo_nodes))
     internal_state%routehandle_m2g = routehandle_m2g
-    internal_state%routehandle_g2m = routehandle_g2m 
-    internal_state%halohandle = halohandle 
+    internal_state%routehandle_g2m = routehandle_g2m
+    internal_state%halohandle = halohandle
     internal_state%halo_idx = halo_idx
-    internal_state%owned_idx = owned_idx  
+    internal_state%owned_idx = owned_idx
     internal_state%grid = grid
     internal_state%mesh = mesh
     internal_state%halolist = halolist
@@ -599,7 +599,7 @@ subroutine SetServices ( GC, RC )
     ! wrap the private internal state
     wrap%ptr => internal_state
     call ESMF_UserCompSetInternalState ( GC, 'ISSM_WRAP', wrap, STATUS ); _VERIFY(STATUS)
-    
+
     ! Create losctream that match mesh element id, then set it to this GC and MAPL
     ! note: original attached/atmospheric grid and landice tile locstream have
     ! been stored in the internal state
@@ -622,11 +622,11 @@ subroutine SetServices ( GC, RC )
 
     ! Get private internal state for sending information to/from LANDICE
 	  !-----------------------------------
-	
+
     call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
     issm_tile_state => issm_tile_wrap%ptr
 
-	  ! Create Custom ISSM Run Alarm 
+	  ! Create Custom ISSM Run Alarm
     !-----------------------------------
 
     ! get internal state
@@ -636,15 +636,15 @@ subroutine SetServices ( GC, RC )
     call MAPL_GetPointer(INTERNAL, ISSM_NSTEPS, 'ISSM_NSTEPS',_RC)
     NSTEPS_INIT = nint(maxval(ISSM_NSTEPS))
 
-    ! get timestep for landice 
+    ! get timestep for landice
     LANDICE_DT = issm_tile_state%LANDICE_DT
-    
+
     ! get timestep for ISSM
     call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
-    
+
     ! total landice time steps between ISSM runs
-    NSTEPS_RING = nint(ISSM_DT/LANDICE_DT) 
-	
+    NSTEPS_RING = nint(ISSM_DT/LANDICE_DT)
+
     ! calculate initial ring time from initial time and remaining timesteps
     call ESMF_ClockGet(CLOCK,currTime=startTime)
     sec_to_ring = (NSTEPS_RING-NSTEPS_INIT-1)*nint(LANDICE_DT)
@@ -653,10 +653,10 @@ subroutine SetServices ( GC, RC )
 
     ! set ring interval to ISSM time step
     call ESMF_TimeIntervalSet(ringInterval,s=nint(ISSM_DT),_RC)
-    
+
     ! create new ISSM_ALARM
     ISSM_ALARM = ESMF_AlarmCreate(CLOCK,ringTime=ringTime,ringInterval=ringInterval,sticky=.false.,_RC)
-	  
+
 	  ! set run alarm
     call MAPL_Set(MAPL, RUNALARM = ISSM_ALARM, _RC)
 
@@ -672,7 +672,7 @@ subroutine SetServices ( GC, RC )
     allocate(IMLS_HALO(num_nodes))
     allocate(OMLS_HALO(num_nodes))
     allocate(ZEROS(num_nodes))
-    
+
     ! get pointers to restarts
     call MAPL_GetPointer(INTERNAL, ICESURF_IN, 'ICESURF', _RC)
     call MAPL_GetPointer(INTERNAL, ICETHICK_IN, 'ICETHICK',_RC)
@@ -681,7 +681,7 @@ subroutine SetServices ( GC, RC )
     call MAPL_GetPointer(INTERNAL, IMLS_IN, 'IMLS', _RC)
     call MAPL_GetPointer(INTERNAL, OMLS_IN, 'OMLS',_RC)
     call MAPL_GetPointer(INTERNAL, restartNodeIds, 'RS_NODEIDS',_RC)
-	
+
     ! if restart has been read, apply halo operation and send pointers to ISSM
     ! else, ISSM will just use default initial values in ISSM*.bin input files
     if (associated(ICETHICK_IN)) then
@@ -689,7 +689,7 @@ subroutine SetServices ( GC, RC )
         ! ISSM throws error for zero ice thickness
         ISSM_RST_FOUND = minval(ICETHICK_IN) > epsilon(ICETHICK_IN)
     end if
-    
+
     if (ISSM_RST_FOUND) then
 	  ! check if the nodal distgrid created above matches the distgrid read from the restart
 	  ! it will only be different if running over a different number of processes than when
@@ -701,10 +701,10 @@ subroutine SetServices ( GC, RC )
       if (distgrid_match) localFlag(1) = 1
       call ESMF_VMAllReduce(vm, sendData=localFlag, recvData=globalFlag, count=1, reduceflag=ESMF_REDUCE_MIN, _RC)
       needRedist = (globalFlag(1) == 0)
-	  
+
       if (needRedist) then
-	  ! create routehandle for redistribution, and redistribute all restarts from the 
-	  ! restart distgrid to the current distgrid (nodalDistgrid) 
+	  ! create routehandle for redistribution, and redistribute all restarts from the
+	  ! restart distgrid to the current distgrid (nodalDistgrid)
           restartDistgrid = ESMF_DistGridCreate(arbSeqIndexList=nint(restartNodeIds), _RC)
           restartArray=ESMF_ArrayCreate(distgrid=restartDistgrid,typekind=ESMF_TYPEKIND_R4,_RC)
           nodalArray=ESMF_ArrayCreate(distgrid=nodalDistgrid,typekind=ESMF_TYPEKIND_R4,_RC)
@@ -717,13 +717,13 @@ subroutine SetServices ( GC, RC )
 		      call apply_redist(IMLS_IN,_RC)
 		      call apply_redist(OMLS_IN,_RC)
 
-          call ESMF_VMBarrier(vm, _RC)   
-		  
+          call ESMF_VMBarrier(vm, _RC)
+
 		      call ESMF_ArrayDestroy(restartArray, _RC)
           call ESMF_ArrayDestroy(nodalArray, _RC)
-		  
-      end if 
-	
+
+      end if
+
       ! apply halo operation to all restart variables
       call apply_halo(ICESURF_IN,ICESURF_HALO,_RC)
       call apply_halo(ICETHICK_IN,ICETHICK_HALO,_RC)
@@ -734,15 +734,15 @@ subroutine SetServices ( GC, RC )
 
       ! package restarts into one pointer
       GEOS_RESTARTS(:) = 0.0_dp
-      GEOS_RESTARTS(1:num_nodes) = ICESURF_HALO(:) 
-      GEOS_RESTARTS(num_nodes+1:2*num_nodes) = ICETHICK_HALO(:) 
-      GEOS_RESTARTS(2*num_nodes+1:3*num_nodes) = ICEVX_HALO(:) 
-      GEOS_RESTARTS(3*num_nodes+1:4*num_nodes) = ICEVY_HALO(:) 
-      GEOS_RESTARTS(4*num_nodes+1:5*num_nodes) = OMLS_HALO(:) 
-      GEOS_RESTARTS(5*num_nodes+1:6*num_nodes) = IMLS_HALO(:) 
+      GEOS_RESTARTS(1:num_nodes) = ICESURF_HALO(:)
+      GEOS_RESTARTS(num_nodes+1:2*num_nodes) = ICETHICK_HALO(:)
+      GEOS_RESTARTS(2*num_nodes+1:3*num_nodes) = ICEVX_HALO(:)
+      GEOS_RESTARTS(3*num_nodes+1:4*num_nodes) = ICEVY_HALO(:)
+      GEOS_RESTARTS(4*num_nodes+1:5*num_nodes) = OMLS_HALO(:)
+      GEOS_RESTARTS(5*num_nodes+1:6*num_nodes) = IMLS_HALO(:)
 
       ! set restarts on the ISSM side
-      call ESMF_VMBarrier(vm, _RC)      
+      call ESMF_VMBarrier(vm, _RC)
       call InputFromRestarts(c_loc(GEOS_RESTARTS))
       call ESMF_VMBarrier(vm, _RC)
 
@@ -754,13 +754,13 @@ subroutine SetServices ( GC, RC )
       call RunISSM(real(ISSM_DT,kind=dp), c_loc(ZEROS), c_loc(GEOS_RESTARTS))
       call ESMF_VMBarrier(vm, _RC)
 
-      ! Unpack restart array 
-      ICESURF_HALO(:)  = GEOS_RESTARTS(1:num_nodes) 
-      ICETHICK_HALO(:) = GEOS_RESTARTS(num_nodes+1:2*num_nodes) 
+      ! Unpack restart array
+      ICESURF_HALO(:)  = GEOS_RESTARTS(1:num_nodes)
+      ICETHICK_HALO(:) = GEOS_RESTARTS(num_nodes+1:2*num_nodes)
       ICEVX_HALO(:) = GEOS_RESTARTS(2*num_nodes+1:3*num_nodes)
       ICEVY_HALO(:) = GEOS_RESTARTS(3*num_nodes+1:4*num_nodes)
-      OMLS_HALO(:)  = GEOS_RESTARTS(4*num_nodes+1:5*num_nodes) 
-      IMLS_HALO(:)  = GEOS_RESTARTS(5*num_nodes+1:6*num_nodes) 
+      OMLS_HALO(:)  = GEOS_RESTARTS(4*num_nodes+1:5*num_nodes)
+      IMLS_HALO(:)  = GEOS_RESTARTS(5*num_nodes+1:6*num_nodes)
 
       ! filter out halo points (keep the owned indices) for restarts
       if(associated(ICESURF_IN)) ICESURF_IN = ICESURF_HALO(owned_idx)
@@ -770,7 +770,7 @@ subroutine SetServices ( GC, RC )
       if(associated(OMLS_IN)) OMLS_IN = OMLS_HALO(owned_idx)
       if(associated(IMLS_IN)) IMLS_IN = IMLS_HALO(owned_idx)
 
-    end if 
+    end if
 
     ! Initialize Export pointers on mesh tile space so history has something to write
     !-----------------------------------
@@ -789,7 +789,7 @@ subroutine SetServices ( GC, RC )
 
     ! Finally, set the tile export state so landice can access values before ISSM runs
     !-----------------------------------
-	
+
     ! Regrid from mesh to tile
     call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
 
@@ -849,7 +849,7 @@ subroutine SetServices ( GC, RC )
     call ESMF_FieldDestroy(gridField, _RC)
     call ESMF_FieldDestroy(meshField, _RC)
     call ESMF_ArrayDestroy(meshArray, _RC)
-    
+
     _RETURN(_SUCCESS)
 
     contains
@@ -863,26 +863,26 @@ subroutine SetServices ( GC, RC )
 		      ! local variables:
           real(dp), pointer, dimension(:)                :: VAR_DP            ! double version of VAR_IN
           real(dp), pointer, dimension(:)                :: MESH_PTR          ! pointer for ESMF_FieldGet
-          real(dp), pointer, dimension(:)                :: ARRAY_PTR         ! pointer for ESMF_ArrayGet 
+          real(dp), pointer, dimension(:)                :: ARRAY_PTR         ! pointer for ESMF_ArrayGet
           type(ESMF_Array)                               :: meshArray         ! array for creating mesh fields
           type(ESMF_Field)                               :: meshField         ! field associated with meshArray
 
           allocate(VAR_DP(num_nodes))
           VAR_DP(:) = 0.0_dp
           VAR_DP(1:num_owned_nodes) = REAL(VAR_IN,kind=dp)
-      
+
           ! create array with halo information
           meshArray=ESMF_ArrayCreate(nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=halolist,_RC)
 
           call ESMF_ArrayGet(array=meshArray,farrayPtr=ARRAY_PTR)
           ARRAY_PTR(:) = VAR_DP(:)
 
-          ! create field on ISSM mesh 
+          ! create field on ISSM mesh
           meshField=ESMF_FieldCreate(mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, _RC)
-          
+
           ! append halo values to end of "owned" array
           call ESMF_FieldHalo(meshField, routehandle=halohandle, _RC)
-      
+
           ! get pointer to field on mesh
           call ESMF_FieldGet(meshField,farrayPtr=MESH_PTR,_RC)
 
@@ -891,8 +891,8 @@ subroutine SetServices ( GC, RC )
           VAR_HALO(halo_idx) = MESH_PTR(num_owned_nodes+1:num_nodes) ! halo nodes
 
           ! destroy field and array, deallocate pointer
-          call ESMF_FieldDestroy(meshField,_RC)  
-          call ESMF_ArrayDestroy(meshArray,_RC)  
+          call ESMF_FieldDestroy(meshField,_RC)
+          call ESMF_ArrayDestroy(meshArray,_RC)
           deallocate(VAR_DP)
 
           _RETURN(_SUCCESS)
@@ -905,7 +905,7 @@ subroutine SetServices ( GC, RC )
 
           type(ESMF_Array)                               :: restartArray ! restart array
           type(ESMF_Array)                               :: redistArray  ! redistributed array
-          real, pointer, dimension(:)                    :: redistPtr	  
+          real, pointer, dimension(:)                    :: redistPtr
 
           restartArray=ESMF_ArrayCreate(distgrid=restartDistgrid,farrayPtr=VAR_RS,_RC)
           redistArray=ESMF_ArrayCreate(distgrid=nodalDistgrid,typekind=ESMF_TYPEKIND_R4,_RC)
@@ -918,13 +918,13 @@ subroutine SetServices ( GC, RC )
 
           ! make sure all processes have finished redistribution
           call ESMF_VMBarrier(vm, _RC)
- 
+
 		      ! copy values into output
 		      VAR_RS(:) = redistPtr(:)
 
           call ESMF_VMBarrier(vm, _RC)
 		      call ESMF_ArrayDestroy(restartArray,_RC)
-		      call ESMF_ArrayDestroy(redistArray,_RC)  
+		      call ESMF_ArrayDestroy(redistArray,_RC)
 
           _RETURN(_SUCCESS)
        end subroutine apply_redist
@@ -936,12 +936,12 @@ subroutine SetServices ( GC, RC )
           real(kind=8), pointer :: centers_lon(:,:)
           real(kind=8), pointer :: centers_lat(:,:)
           integer, allocatable  :: IMs(:)
-          
+
           !comm, VM, num_owned_nodes are from containing subroutine
-          call ESMF_VMGet(vm, petcount=nDEs,  _RC) 
+          call ESMF_VMGet(vm, petcount=nDEs,  _RC)
           allocate(IMS(nDEs))
           num(1) = num_owned_nodes
-          call MAPL_CommsAllGather(vm, num, 1, IMs, 1, _RC) 
+          call MAPL_CommsAllGather(vm, num, 1, IMs, 1, _RC)
 
           ! create a mesh-grid in 1D
           mesh_grid = ESMF_GridCreate(        &
@@ -963,14 +963,14 @@ subroutine SetServices ( GC, RC )
           call ESMF_GridGetCoord(mesh_grid, coordDim=1, localDE=0, &
                staggerloc=ESMF_STAGGERLOC_CENTER, &
                farrayPtr=centers_lon, _RC)
-          centers_lon(:,1) = ownedNodeLons 
+          centers_lon(:,1) = ownedNodeLons
           call ESMF_GridGetCoord(mesh_grid, coordDim=2, localDE=0, &
                staggerloc=ESMF_STAGGERLOC_CENTER, &
                farrayPtr=centers_lat, _RC)
-          centers_lat(:,1) = ownedNodeLats 
+          centers_lat(:,1) = ownedNodeLats
 
           _RETURN(_SUCCESS)
-       end function create_mesh_grid      
+       end function create_mesh_grid
 
   end subroutine Initialize
 
@@ -981,15 +981,15 @@ subroutine SetServices ( GC, RC )
   ! ! ****** Run ISSM ice-sheet model ******
   ! !  the core C++ solvers and associated pre/post-processing of imports/exports
   ! !  are only performed at ISSM_DT intervals. However, the Run method is engaged
-  ! !  at every landice timestep to ensure that ISSM restarts persist  
+  ! !  at every landice timestep to ensure that ISSM restarts persist
   ! !ARGUMENTS:
-    type(ESMF_GridComp), intent(inout)   :: GC                      ! Gridded component 
+    type(ESMF_GridComp), intent(inout)   :: GC                      ! Gridded component
     type(ESMF_State),    intent(inout)   :: IMPORT                  ! Import state
     type(ESMF_State),    intent(inout)   :: EXPORT                  ! Export state
     type(ESMF_Clock),    intent(inout)   :: CLOCK                   ! The clock
     integer, optional,   intent(  out)   :: RC                      ! Error code
-    type(ESMF_Alarm)                     :: ALARM                   ! run alarm for ISSM component 
-    
+    type(ESMF_Alarm)                     :: ALARM                   ! run alarm for ISSM component
+
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)           :: IAm
     integer                              :: STATUS
@@ -997,7 +997,7 @@ subroutine SetServices ( GC, RC )
 
     type(MAPL_MetaComp), pointer         :: MAPL
     type(ESMF_State)                     :: INTERNAL
-    type(ESMF_VM)                        :: vm  
+    type(ESMF_VM)                        :: vm
 
     ! internal state for regridding and halo operations
     type(ESMF_Mesh)                      :: mesh                    ! ESMF version of ISSM mesh
@@ -1006,7 +1006,7 @@ subroutine SetServices ( GC, RC )
     ! tile information
     integer                              :: NT                      ! number of landice tiles
     type(T_ISSM_TILE_STATE), pointer     :: issm_tile_state
-    type(ISSM_TILE_WRAP)                 :: issm_tile_wrap
+    type(T_ISSM_TILE_WRAP)               :: issm_tile_wrap
 
     ! surface mass balance on mesh and landice tiles
 	  ! note: SMB has been time-averaged between ISSM runs
@@ -1047,10 +1047,10 @@ subroutine SetServices ( GC, RC )
     real(dp),    pointer, dimension(:)   :: OMLS_MESH    => null() ! ocean mask level set
     real, pointer, dimension(:)          :: OMLS_IN      => null() ! pointer to internal state (mesh tiles)
 
-    ! ice-flow speed on mesh and landice tiles  
+    ! ice-flow speed on mesh and landice tiles
     real(dp),    pointer, dimension(:)   :: ICEVEL_MESH  => null() ! ice flow speed on mesh tiles
     real, pointer, dimension(:)          :: ICEVEL_TILE  => null() ! ice flow speed on landice tiles
-  
+
     ! physical parameters
     real(dp), parameter                  :: rho_ice   = 917.0      ! pure ice density [kg m-3]
     real(dp)                             :: ISSM_DT                ! time step [s] (ISSM_DT set in AGCM.rc)
@@ -1059,7 +1059,7 @@ subroutine SetServices ( GC, RC )
   ! -----------------------------------------------------------
     Iam = "Run"
     call ESMF_GridCompGet(GC,name=COMP_NAME,mesh=mesh,vm=vm,_RC)
-    
+
     Iam = trim(COMP_NAME) // Iam
 
   ! Get my internal MAPL_Generic state
@@ -1068,7 +1068,7 @@ subroutine SetServices ( GC, RC )
     _VERIFY(STATUS)
 
     call MAPL_Get(MAPL,INTERNAL_ESMF_STATE = INTERNAL,_RC )
-    
+
 
     ! Start Total timer
   !------------------
@@ -1076,9 +1076,9 @@ subroutine SetServices ( GC, RC )
     call MAPL_TimerOn(MAPL,"RUN" )
 
     call MAPL_Get(MAPL, RUNALARM = ALARM, _RC )
-    
 
-    ! run ISSM at specified time steps, 
+
+    ! run ISSM at specified time steps,
     ! if bootstrapping restart and issm has run not by final time step, run anyways
     ! with timestep of zero, which just gets restart values
     if (ESMF_AlarmIsRinging (ALARM, RC=STATUS)) then
@@ -1089,12 +1089,12 @@ subroutine SetServices ( GC, RC )
 
       ! get timestep for ISSM
       call MAPL_GetResource(MAPL, ISSM_DT, Label=trim(COMP_NAME)//"_DT:",DEFAULT=302400.0, _RC)
-      
+
       ! get number of mesh elements
       call ESMF_MeshGet(mesh,nodeCount=num_nodes)
 
       ! allocate ice-elevation output (export from ISSM)
-      allocate(ISSM_OUTPUTS(num_outputs*num_nodes))  
+      allocate(ISSM_OUTPUTS(num_outputs*num_nodes))
 
       ! allocate output arrays defined on mesh nodes
       allocate(ICESURF_MESH(num_nodes))
@@ -1104,11 +1104,11 @@ subroutine SetServices ( GC, RC )
       allocate(ICEVEL_MESH(num_nodes))
       allocate(IMLS_MESH(num_nodes))
       allocate(OMLS_MESH(num_nodes))
-      
-      ! allocate input arrays defined on mesh nodes
-      allocate(ICESMB_MESH(num_nodes))  
 
-      ! initialize ISSM outputs to zero 
+      ! allocate input arrays defined on mesh nodes
+      allocate(ICESMB_MESH(num_nodes))
+
+      ! initialize ISSM outputs to zero
       ICESURF_MESH(:) = 0.0_dp
       ICETHICK_MESH(:) = 0.0_dp
       ICEVX_MESH(:) = 0.0_dp
@@ -1120,30 +1120,30 @@ subroutine SetServices ( GC, RC )
 
       ! get landice tile dimensions
       call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
-      
+
       call ESMF_UserCompGetInternalState(GC, 'ISSM_TILES', issm_tile_wrap, status); _VERIFY(STATUS)
       issm_tile_state => issm_tile_wrap%ptr
-      
+
       ! *************************************************************************** !
       ! GET ICESMB IMPORT (surface mass balance)
-      ! *************************************************************************** ! 
+      ! *************************************************************************** !
 	    ! NOTE: ICESMB (from landice) has been time-averaged between ISSM runs
 	    !       hence the name ICESMB_ISSM
-	  
-      ! allocate tiles for ICESMB 
+
+      ! allocate tiles for ICESMB
       if(.not.associated(ICESMB_TILE)) then
         allocate(ICESMB_TILE(NT), STAT=STATUS)
         _VERIFY(STATUS)
         ICESMB_TILE = MAPL_Undef
       end if
-      
-      ! copy import values into tile array 
+
+      ! copy import values into tile array
       ICESMB_TILE = issm_tile_state%ICESMB_ISSM
 
-	    ! transform ICESMB from landice tiles to mesh 
+	    ! transform ICESMB from landice tiles to mesh
       call tile_to_mesh(ICESMB_TILE,ICESMB_MESH,_RC)
 
-      ! save ICESMB on mesh elements 
+      ! save ICESMB on mesh elements
       call MAPL_GetPointer(EXPORT  , ICESMB_EX , 'ICESMB_ISSM' , _RC)
 
       if(associated(ICESMB_EX)) ICESMB_EX = ICESMB_MESH(internal_state%owned_idx)
@@ -1157,7 +1157,7 @@ subroutine SetServices ( GC, RC )
       call ESMF_VMBarrier(vm, _RC)
 	    call MAPL_TimerOn(MAPL,"ISSMCore" )
 
-      ! call run method from ISSM library 
+      ! call run method from ISSM library
       call RunISSM(ISSM_DT, c_loc(ICESMB_MESH), c_loc(ISSM_OUTPUTS))
 
       call ESMF_VMBarrier(vm, _RC)
@@ -1224,18 +1224,18 @@ subroutine SetServices ( GC, RC )
 
       ! *************************************************************************** !
 	    ! Round ISSM output to single precision and reset on the C++ side
-	    ! This ensures the same result as reading in (single-precision) restarts 
+	    ! This ensures the same result as reading in (single-precision) restarts
 	    ! *************************************************************************** !
-      ISSM_OUTPUTS = real(ISSM_OUTPUTS, kind=sp) 
-      call ESMF_VMBarrier(vm, _RC)      
-      call InputFromRestarts(c_loc(ISSM_OUTPUTS)) 
+      ISSM_OUTPUTS = real(ISSM_OUTPUTS, kind=sp)
+      call ESMF_VMBarrier(vm, _RC)
+      call InputFromRestarts(c_loc(ISSM_OUTPUTS))
       call ESMF_VMBarrier(vm, _RC)
 
-    end if 
-    
+    end if
+
     ! barrier to ensure regridding completes before any deallocates
     call ESMF_VMBarrier(vm,_RC)
-    
+
     ! deallocates
     if(associated(ICESURF_MESH))  deallocate(ICESURF_MESH)
     if(associated(ICETHICK_MESH)) deallocate(ICETHICK_MESH)
@@ -1243,8 +1243,8 @@ subroutine SetServices ( GC, RC )
     if(associated(ICEVX_MESH))    deallocate(ICEVX_MESH)
     if(associated(ICEVY_MESH))    deallocate(ICEVY_MESH)
     if(associated(IMLS_MESH))     deallocate(IMLS_MESH)
-    if(associated(OMLS_MESH))     deallocate(OMLS_MESH)  
-    if(associated(ICESMB_MESH))   deallocate(ICESMB_MESH) 
+    if(associated(OMLS_MESH))     deallocate(OMLS_MESH)
+    if(associated(ICESMB_MESH))   deallocate(ICESMB_MESH)
     if(associated(ISSM_OUTPUTS))  deallocate(ISSM_OUTPUTS)
     if(associated(ICESMB_TILE))   deallocate(ICESMB_TILE)
     if(associated(ICESURF_TILE))  deallocate(ICESURF_TILE)
@@ -1253,32 +1253,32 @@ subroutine SetServices ( GC, RC )
 
     call MAPL_TimerOff(MAPL,"RUN"  )
     call MAPL_TimerOff(MAPL,"TOTAL")
-  
+
     _RETURN(_SUCCESS)
 
   end subroutine RUN
 
 
  !BOP
-    
-!IROUTINE: Finalize   -- Finalize method for ISSM 
+
+!IROUTINE: Finalize   -- Finalize method for ISSM
 
 !INTERFACE:
 
  subroutine Finalize ( GC, IMPORT, EXPORT, CLOCK, RC )
 
     !ARGUMENTS:
-    type(ESMF_GridComp), intent(INOUT) :: GC     ! Gridded component 
+    type(ESMF_GridComp), intent(INOUT) :: GC     ! Gridded component
     type(ESMF_State),    intent(INOUT) :: IMPORT ! Import state
     type(ESMF_State),    intent(INOUT) :: EXPORT ! Export state
     type(ESMF_Clock),    intent(INOUT) :: CLOCK  ! The supervisor clock
     integer, optional,   intent(  OUT) :: RC     ! Error code:
-    
+
     !EOP
-    type(MAPL_MetaComp), pointer       :: MAPL 
+    type(MAPL_MetaComp), pointer       :: MAPL
 
 	  type(ESMF_State)                   :: INTERNAL
-    
+
     ! ErrLog Variables
     character(len=ESMF_MAXSTR)	       :: IAm
     integer			                       :: STATUS
@@ -1286,14 +1286,14 @@ subroutine SetServices ( GC, RC )
 
 
     type(T_ISSM_TILE_STATE), pointer   :: issm_tile_state
-    type(ISSM_TILE_WRAP)               :: issm_tile_wrap
+    type(T_ISSM_TILE_WRAP)             :: issm_tile_wrap
 	  real, pointer, dimension(:)        :: ISSM_NSTEPS
 
     ! Get the target components name and set-up traceback handle.
     ! -----------------------------------------------------------
     Iam = "Finalize"
     call ESMF_GridCompGet( GC, NAME=COMP_NAME, _RC )
-    
+
     Iam = trim(comp_name) // Iam
 
     call MAPL_GetObjectFromGC(GC, MAPL, STATUS)
@@ -1316,7 +1316,7 @@ subroutine SetServices ( GC, RC )
     ! Generic Finalize
     ! ------------------
     call MAPL_GenericFinalize( GC, IMPORT, EXPORT, CLOCK, _RC )
-    
+
     ! All Done
     ! ------------------
 
@@ -1339,37 +1339,37 @@ subroutine SetServices ( GC, RC )
     integer                                             :: num_owned_nodes
     integer                                             :: NT
     integer                                             :: STATUS
-  
+
     num_owned_nodes = size(internal_state%owned_idx)
 
     call MAPL_LocStreamGet(internal_state%locstream, NT_LOCAL=NT, _RC)
-    
+
     allocate(VAR_MESH_OWN(num_owned_nodes))
 
     VAR_MESH_OWN = VAR_MESH(internal_state%owned_idx)
 
-    ! allocate tiles 
+    ! allocate tiles
     if (.not.associated(VAR_TILE)) then
       allocate(VAR_TILE(NT))
       VAR_TILE = MAPL_Undef
     end if
 
     ! create source field: field on mesh nodes
-    srcField = ESMF_FieldCreate(mesh=internal_state%mesh,farrayPtr=VAR_MESH_OWN,meshloc=ESMF_MESHLOC_NODE, & 
+    srcField = ESMF_FieldCreate(mesh=internal_state%mesh,farrayPtr=VAR_MESH_OWN,meshloc=ESMF_MESHLOC_NODE, &
     datacopyflag=ESMF_DATACOPY_VALUE,_RC)
-    
+
     ! create destination field: field on grid
     dstField = ESMF_FieldCreate(grid=internal_state%grid,typekind=ESMF_TYPEKIND_R4,_RC)
-    
+
     ! regrid field from mesh to grid
     call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_m2g, _RC)
 
     ! get pointer to field on grid
     call ESMF_FieldGet(dstField,farrayPtr=VAR_GRID,_RC)
 
-    ! transform from grid to tiles  
+    ! transform from grid to tiles
     call MAPL_LocStreamTransform(internal_state%locstream,VAR_TILE,VAR_GRID, _RC)
-    
+
     ! destroy regridding fields so they can be reused
     call ESMF_FieldDestroy(srcField,_RC)
     call ESMF_FieldDestroy(dstField,_RC)
@@ -1387,41 +1387,41 @@ subroutine SetServices ( GC, RC )
 
     ! local variables:
     real, pointer, dimension(:,:)                  :: VAR_GRID => null() ! var on attached grid
-    real(dp), pointer, dimension(:)                :: MESH_PTR           ! pointer for ESMF_FieldGet 
+    real(dp), pointer, dimension(:)                :: MESH_PTR           ! pointer for ESMF_FieldGet
     type(ESMF_Field)                               :: srcField
     type(ESMF_Field)                               :: dstField
     type(ESMF_Array)                               :: meshArray
     integer                                        :: num_owned_nodes
     integer                                        :: num_nodes
-    integer                                        :: IM, JM, local_dims(3)   
+    integer                                        :: IM, JM, local_dims(3)
     integer                                        :: STATUS
 
     ! get number of nodes
     call ESMF_MeshGet(internal_state%mesh,nodeCount=num_nodes,numOwnedNodes=num_owned_nodes,_RC)
-    
+
     ! get grid dimensions
     call MAPL_GridGet(internal_state%grid, localCellCountPerDim=local_dims, _RC)
     IM = local_dims(1)
     JM = local_dims(2)
 
-    ! allocate pointer on grid for regridding 
+    ! allocate pointer on grid for regridding
     allocate(VAR_GRID(IM,JM))
-  
+
     ! transform from tile to grid
-    ! NOTE: we use the "transpose" option with MAPL_LocStreamTransformG2T 
+    ! NOTE: we use the "transpose" option with MAPL_LocStreamTransformG2T
     ! (rather than MAPL_LocStreamTransformT2G) because the "default" value is zero
     ! (rather than MAPL_UNDEF, which leads to errors when regridding onto mesh)
     call MAPL_LocStreamTransform(internal_state%locstream, VAR_TILE, VAR_GRID, TRANSPOSE=.true., _RC)
-    
+
     ! create source field on grid
     srcField = ESMF_FieldCreate(grid=internal_state%grid,farrayPtr=VAR_GRID, datacopyflag=ESMF_DATACOPY_VALUE,_RC)
-    
+
     ! create destination field on mesh elements
     meshArray=ESMF_ArrayCreate(internal_state%nodalDistgrid,typekind=ESMF_TYPEKIND_R8,haloSeqIndexList=internal_state%halolist,_RC)
-    
+
     ! create field on ISSM mesh
     dstField=ESMF_FieldCreate(internal_state%mesh, array=meshArray, meshLoc=ESMF_MESHLOC_NODE, _RC)
-    
+
     ! regrid from grid to mesh
     call ESMF_FieldRegrid(srcField, dstField, internal_state%routehandle_g2m, _RC)
 
@@ -1434,7 +1434,7 @@ subroutine SetServices ( GC, RC )
     ! copy values into VAR_MESH
     VAR_MESH(internal_state%owned_idx) = MESH_PTR(1:num_owned_nodes)          ! owned nodes
     VAR_MESH(internal_state%halo_idx) = MESH_PTR(num_owned_nodes+1:num_nodes) ! halo nodes
-    
+
     ! destroy fields and arrays so they can be reused
     deallocate(VAR_GRID)
     call ESMF_FieldDestroy(srcField,_RC)
@@ -1443,6 +1443,6 @@ subroutine SetServices ( GC, RC )
 
     _RETURN(_SUCCESS)
 
-  end subroutine tile_to_mesh  
+  end subroutine tile_to_mesh
 
 end module GEOS_IssmGridCompMod


### PR DESCRIPTION
In #1203, ISSM was added as a gridcomp. But in that code we have:

```fortran
type(ISSM_TILE_WRAP) :: issm_tile_wrap
```

While Intel seems to allow this, GNU (and Flang) does not like doing:
```fortran
type(foo) :: foo
```
where both the type and the variable have the same name. I think this is a violation of the Fortran Standards.

So this PR changes the type to be `T_ISSM_TILE_WRAP` to echo the `T_ISSM_TILE_STATE` type.

---

Note 1: Please look at this with "no whitespace". My editor did a number on these files cleaning up unnecessary whitespace.

Note 2: The reason this passed in CI is that my CI images do not have ISSM in them. They only have the minimal Baselibs. It might be a bit of work getting ISSM into them...I'll try and take a look.