### PR TITLE
Add WSPD_STABLE300M export to GEOS_DatmoDynGridComp

### DIFF
--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOSdatmodyn_GridComp/GEOS_DatmoDynGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOSdatmodyn_GridComp/GEOS_DatmoDynGridComp.F90
@@ -541,7 +541,15 @@ contains
          UNITS     ='m s-1',                                        &
          DIMS      = MAPL_DimsHorzOnly,                             &
          VLOCATION = MAPL_VLocationNone,                            &
-                                                        __RC__  )
+                                                         __RC__  )
+
+    call MAPL_AddExportSpec(GC,                                &
+         SHORT_NAME='WSPD_STABLE300M',                              &
+         LONG_NAME ='max_wind_speed_in_stable_cold_surface_layer',  &
+         UNITS     ='m s-1',                                        &
+         DIMS      = MAPL_DimsHorzOnly,                             &
+         VLOCATION = MAPL_VLocationNone,                            &
+                                                         __RC__  )
 
 
     call MAPL_AddExportSpec(GC,                                &
@@ -1185,6 +1193,7 @@ contains
                         ! else: use interactive winds
 
     integer :: IM,JM,LM,L,K,NQ,ii,NOT1,COLDSTART,Ktrc,iip1,itr,ntracs
+    logical :: is_stable
 
     real, pointer, dimension(:,:,:) :: PLE,PLEOUT
     real, pointer, dimension(:,:,:) :: ZLE
@@ -1212,6 +1221,7 @@ contains
     real, pointer, dimension(:,:)   :: DZ
     real, pointer, dimension(:,:)   :: TA
     real, pointer, dimension(:,:)   :: SPEED
+    real, pointer, dimension(:,:)   :: WSPD_STABLE300M
     real, pointer, dimension(:,:)   :: QA
     real, pointer, dimension(:,:)   :: US
     real, pointer, dimension(:,:)   :: VS
@@ -2030,7 +2040,7 @@ contains
 !    Forcing based on Phase 2 of CGILS intercomparison. See Blossey et al. (2016)
       if ( CFMIP3 ) then
 
-         ZLO = 0.5*(ZLE(:,:,0:LM-1)+ZLE(:,:,1:LM))
+     ZLO = 0.5*(ZLE(:,:,0:LM-1)+ZLE(:,:,1:LM))
 
          if (CFCSE .eq. 12) then
            zrel=1200.
@@ -2124,10 +2134,44 @@ contains
          if (associated(DQVDTDYN))  DQVDTDYN = DQVDTDYN - CFMIPRLX * ( Q - QOBS )
       end if
 
+      call MAPL_GetPointer(EXPORT, WSPD_STABLE300M, 'WSPD_STABLE300M', &
+                           ALLOC=.true., __RC__)
+      if (associated(WSPD_STABLE300M)) then
+         WSPD_STABLE300M = 0.0
+         do J = 1, JM
+            do I = 1, IM
+               ! 1. Check if surface air is freezing (T at lowest model level)
+               if (T(I,J,LM) <= MAPL_TICE) then
+                  ! Assume no inversion until proven otherwise
+                  is_stable = .false.
+                  ! Start max wind tracking with the lowest model level
+                  WSPD_STABLE300M(I,J) = SQRT(U(I,J,LM)**2 + V(I,J,LM)**2)
+                  ! 2. Scan the lowest 300m AGL (ZLE(I,J,LM) is the surface height)
+                  do K = LM-1, 1, -1
+                     ! Height AGL at mid-level using ZLO (0.5*(ZLE(K-1)+ZLE(K)))
+                     if ( (ZLO(I,J,K) - ZLE(I,J,LM)) <= 300.0 ) then
+                        ! Track maximum wind speed
+                        WSPD_STABLE300M(I,J) = MAX(WSPD_STABLE300M(I,J), &
+                                                   SQRT(U(I,J,K)**2 + V(I,J,K)**2))
+                        ! 3. Check for temperature inversion anywhere in the 300m layer
+                        if (T(I,J,K) > T(I,J,LM)) then
+                           is_stable = .true.
+                        endif
+                     else
+                        exit ! Reached top of 300m layer
+                     endif
+                  end do
+                  ! 4. If no inversion found, not a katabatic zone; zero out wind speed
+                  if (.not. is_stable) then
+                     WSPD_STABLE300M(I,J) = 0.0
+                  endif
+               endif
+            end do
+         end do
+      end if
+
       call MAPL_GetPointer(EXPORT, PREF,   'PREF'    , &
                            ALLOC=.true., __RC__)
-
-
       PREF = PREF_IN
 
       VARFLT = 0.


### PR DESCRIPTION
## Summary

Ports the `WSPD_STABLE300M` diagnostic from [FVdycoreCubed_GridComp PR #411](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/411) to the datmodyn (single-column model) component.

Tests show the SCM does not crash with this and does run. I'm not sure it is the *correct* algorithm, but Claude took a look.

## What was added

A new export field `WSPD_STABLE300M` (maximum wind speed in stable cold surface layer) to `GEOS_DatmoDynGridComp.F90`. This diagnostic detects katabatic wind conditions by:

1. Checking if the surface air temperature is at or below freezing (`MAPL_TICE`)
2. Scanning the lowest 300m AGL for the maximum wind speed
3. Checking for a temperature inversion anywhere in that 300m layer
4. Zeroing out the result if no inversion is found (not a katabatic zone)

## Related

- FVdycoreCubed_GridComp PR #411: https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/411