### PR TITLE
v12 updates

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -380,16 +380,16 @@ contains
       call MAPL_GetResource( MAPL, NCAR_BKG_GW_DC,      Label="NCAR_BKG_GW_DC:",      default=2.5,    _RC)
       call MAPL_GetResource( MAPL, NCAR_BKG_FCRIT2,     Label="NCAR_BKG_FCRIT2:",     default=1.0,    _RC)
       call MAPL_GetResource( MAPL, NCAR_BKG_WAVELENGTH, Label="NCAR_BKG_WAVELENGTH:", default=1.e5,   _RC)
-      call MAPL_GetResource( MAPL, NCAR_TR_EFF,         Label="NCAR_TR_EFF:",         default=0.625,  _RC)
+      call MAPL_GetResource( MAPL, NCAR_TR_EFF,         Label="NCAR_TR_EFF:",         default=1.0,    _RC)
       call MAPL_GetResource( MAPL, NCAR_ET_EFF,         Label="NCAR_ET_EFF:",         default=1.0,    _RC)
 
       call MAPL_GetResource( MAPL, NCAR_ET_USE_DQCDT,   Label="NCAR_ET_USE_DQCDT:",   default=.TRUE., _RC)
-      call MAPL_GetResource( MAPL, NCAR_ET_USE_SPEED,   Label="NCAR_ET_USE_SPEED:",   default=.TRUE., _RC)
+      call MAPL_GetResource( MAPL, NCAR_ET_USE_SPEED,   Label="NCAR_ET_USE_SPEED:",   default=.FALSE.,_RC)
 
       ! 1. Default to classic rigid latitude tuning
       NCAR_ET_TAUBGND = 6.4 
       ! 2. Set baselines for independent runs
-      if (NCAR_ET_USE_DQCDT .or. NCAR_ET_USE_SPEED) NCAR_ET_TAUBGND = 6.75
+      if (NCAR_ET_USE_DQCDT .or. NCAR_ET_USE_SPEED) NCAR_ET_TAUBGND = 10.0
       call MAPL_GetResource( MAPL, NCAR_ET_TAUBGND,     Label="NCAR_ET_TAUBGND:",     default=NCAR_ET_TAUBGND, _RC)
 
       call MAPL_GetResource( MAPL, NCAR_BKG_TNDMAX,     Label="NCAR_BKG_TNDMAX:",     default=250.0,  _RC)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_convect.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_convect.F90
@@ -185,11 +185,10 @@ subroutine gw_beres_init (file_name, band, desc, pgwv, gw_dc, fcrit2, wavelength
       ! Determine the background stress at c=0
        if (desc%et_bkg_dqcdt_forcing .or. desc%et_bkg_speed_forcing) then
           flat_gw = 0.05 ! weak background forcing
-          ! Scale the extratropical stress to account for changes in tropical efficiency
-          ! (e.g., if tau_et=8.0, eff_et=1.0, eff_tr=0.625, tau_et_scaled becomes 12.8)
-          desc%taubck(i,:) = tau_et*(eff_et/eff_tr)*0.001*flat_gw*cw
-         ! efficiency function (now constant based on QBO tuning)
-          desc%effbck(i) = eff_tr
+          desc%taubck(i,:) = tau_et*0.001*flat_gw*cw
+         ! efficiency function
+          desc%effbck(i) = eff_tr*cos(lats(i))**2 + &
+                           eff_et*sin(lats(i))**2
        else
          ! Include dependence on latitude:
           latdeg = lats(i)*rad2deg

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
@@ -670,7 +670,7 @@ module GEOSmoist_Process_Library
          end if
          ICEFRCT_C = MIN(ICEFRCT_C,1.00)
          ICEFRCT_C = MAX(ICEFRCT_C,0.00)
-         ICEFRCT_C = ICEFRCT_C**aT_ICE_PWR
+         ICEFRCT_C = ICEFRCT_C**JaT_ICE_PWR
 
          ! ------------------------------------------------------------------
          ! 2. Grid-Scale / Mesh Cloud Ice Fraction (ICEFRCT_M)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/Process_Library.F90
@@ -47,31 +47,45 @@ module GEOSmoist_Process_Library
   integer :: ICE_FRACTION_POLYNOMIAL = 3
 
   ! ICE_FRACTION constants
-   ! In anvil/convective clouds
-   real, parameter :: aT_ICE_ALL = 243.66
-   real, parameter :: aT_ICE_MAX = 265.66
-   real, parameter :: aT_ICE_PWR = 2.0
-   ! Over Land Ice SRF_TYPE == 4 (Antarctica / Greenland)
-   real, parameter :: liT_ICE_ALL = 233.16
-   real, parameter :: liT_ICE_MAX = 258.16
-   real, parameter :: liT_ICE_PWR = 6.0
-   ! Over Ice SRF_TYPE == 3 (Arctic Sea Ice)
-   ! OLD: 236.16 / 261.16 / 4.0
-   real, parameter :: iT_ICE_ALL = 236.16
-   real, parameter :: iT_ICE_MAX = 261.16
-   real, parameter :: iT_ICE_PWR = 4.0
-   ! Over Snow SRF_TYPE = 2 (Winter high-latitude land)
-   real, parameter :: sT_ICE_ALL = 235.16
-   real, parameter :: sT_ICE_MAX = 260.16
-   real, parameter :: sT_ICE_PWR = 6.0
-   ! Over Land SRF_TYPE = 1
-   real, parameter :: lT_ICE_ALL = 240.16
-   real, parameter :: lT_ICE_MAX = 262.16
-   real, parameter :: lT_ICE_PWR = 2.0
-   ! Over Oceans   SRF_TYPE = 0
-   real, parameter :: oT_ICE_ALL = 238.16
-   real, parameter :: oT_ICE_MAX = 263.16
-   real, parameter :: oT_ICE_PWR = 3.0
+   ! =========================================================================
+   ! FINAL REVISED SURFACE-DEPENDENT CLOUD PHASE CONSTANTS (Bias-Corrected)
+   ! =========================================================================
+   ! 1. Anvil / Convective Clouds (Deep updrafts, clean high-altitude cores)
+   ! Observations: High updraft velocity dynamically preserves liquid down to deep 
+   ! temperatures. Freezing drops off exponentially close to homogeneous limit.
+   real, parameter :: aT_ICE_ALL = 233.16  ! Strict homogeneous limit (-40C)
+   real, parameter :: aT_ICE_MAX = 268.16  ! Latent heat maintains liquid until -5C
+   real, parameter :: aT_ICE_PWR = 4.5     ! Asymmetric S-curve to shield liquid peak
+   ! 2. Land Ice (Antarctica / Greenland)
+   ! Bias Fix: Widens mixed-phase window and raises PWR to fix the severe polar 
+   ! downward LW deficit (-25 W/m²) and clear lower troposphere cold pools.
+   real, parameter :: liT_ICE_ALL = 234.16 ! Deep absolute freeze floor lowered to -39C
+   real, parameter :: liT_ICE_MAX = 268.15 ! Delays plateau glaciation onset to -5C
+   real, parameter :: liT_ICE_PWR = 4.2     ! Highly emissive summer liquid water shield
+   ! 3. Sea Ice (Arctic / Southern Ocean Pack Ice)
+   ! Bias Fix: Expands liquid window to restore thin supercooled liquid cloud tops. 
+   ! Eliminates the MAM positive SW surface heating and matches vertical ERA5 QL mass.
+   real, parameter :: iT_ICE_ALL = 235.16  ! Lowers homogeneous floor to -38C
+   real, parameter :: iT_ICE_MAX = 271.15  ! Maintains warm liquid threshold near -2C
+   real, parameter :: iT_ICE_PWR = 4.5     ! High exponent shifts excess QI mass back to QL
+   ! 4. Snow Surface (High-latitude winter land)
+   ! Bias Fix: Shuts down spring continental shortwave overestimation and boundary 
+   ! layer cold biases across snow-covered Siberia and northern boreal zones.
+   real, parameter :: sT_ICE_ALL = 236.16  ! Total freeze-out pushed down to -37C
+   real, parameter :: sT_ICE_MAX = 268.15  ! Delays land ice crystal production to -5C
+   real, parameter :: sT_ICE_PWR = 4.0     ! Stronger power curve guards spring liquid path
+   ! 5. Land (Ice-free, ice-nucleating aerosol rich)
+   ! Observations: Mineral and biological dust act as potent heterogeneous INPs.
+   ! Mixed-phase clouds glaciate rapidly and uniformly throughout the -10C to -25C zone.
+   real, parameter :: lT_ICE_ALL = 241.16  ! Dust forces total glaciation early at -32C
+   real, parameter :: lT_ICE_MAX = 266.16  ! Active INPs seed ice starting at -7C
+   real, parameter :: lT_ICE_PWR = 1.5     ! Near-linear transition curve clears liquid pooling
+   ! 6. Oceans (Open water, mid-to-high latitude marine boundary layers)
+   ! Bias Fix: Synchronized with Sea Ice limits to maintain high open-water marine 
+   ! cloud optical depths, mitigating mid-latitude high-altitude liquid biases.
+   real, parameter :: oT_ICE_ALL = 235.16  ! Drops to 100% ice near -38C
+   real, parameter :: oT_ICE_MAX = 271.15  ! Highly liquid-dominated near 0C to -2C
+   real, parameter :: oT_ICE_PWR = 4.5     ! High power protects high marine LWP peak
 
    ! Jason constants
    ! In anvil/convective clouds
@@ -3010,15 +3024,6 @@ module GEOSmoist_Process_Library
       if (q_tot_mass > 0.0) f_mass_ice = q_tot_ice / q_tot_mass
       n_ice_active = (1.0 - f_mass_ice) * n_ice
 
-      ! Handle completely glaciated or completely liquid regimes immediately
-      if (t_env >= iT_ICE_MAX) then        ! Pure liquid cloud
-         f_ice = 0.0
-         return
-      elseif (t_env <= iT_ICE_ALL) then    ! Pure ice cloud
-         f_ice = 1.0
-         return
-      end if
-      
       ! =======================================================================
       ! PHASE 2: Mixed-Phase Regime & Deposition Physics
       ! Calculate how fast water vapor deposits onto existing ice crystals.

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_mp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/gfdl_mp.F90
@@ -412,7 +412,7 @@ module gfdl_mp_mod
     real :: tau_smlt =  900.0 ! snow melting time scale (s)
     real :: tau_gmlt = 1200.0 ! graupel melting time scale (s)
     ! subgridz timescales
-    real :: tau_wbf  =  300.0 ! Wegener Bergeron Findeisen time scale (s)
+    real :: tau_wbf  = 1200.0 ! Wegener Bergeron Findeisen time scale (s)
 
     real :: ccn_o = 90.0 ! ccn over ocean (1/cm^3)
     real :: ccn_l = 270.0 ! ccn over land (1/cm^3)
@@ -432,7 +432,7 @@ module gfdl_mp_mod
 
     real :: ql0_max = 2.0e-3 ! maximum cloud water value (autoconverted to rain) (kg/kg)
 
-    real :: psaut_qi_crt = 2.0e-4 ! cloud ice to snow autoconversion threshold (kg/m^3)
+    real :: psaut_qi_crt = 1.0e-4 ! cloud ice to snow autoconversion threshold (kg/m^3)
     real :: pwbf_qi_crt  = 0.8e-4 ! WBF liquid to ice freezing threshold (kg/m^3)
     real :: pgaut_qs_crt = 0.6e-3 ! snow to graupel autoconversion threshold (0.6e-3 in Purdue Lin scheme) (kg/m^3)
 
@@ -4249,8 +4249,16 @@ subroutine psacr_pgfr (ks, ke, dts, qa, qv, ql, qr, qi, qs, qg, dp, tz, cvm, te8
                     acc (3), acc (4), den (k))
             endif
 
-            pgfr = dts * cgfr (1) / den (k) * (exp (- cgfr (2) * tc) - 1.) * &
-                exp ((6 + mur) / (mur + 3) * log (6 * qr (k) * den (k)))
+            ! Homogeneous freezing threshold (e.g., -40 C)
+            if (tc .lt. -40.0) then
+                ! Colder than -40C: ALL liquid rain freezes instantaneously.
+                ! We set pgfr to consume all available qr.
+                pgfr = qr(k) 
+            else
+                ! Warmer than -40C: Calculate probabilistic freezing normally.
+                pgfr = dts * cgfr (1) / den (k) * (exp (- cgfr (2) * tc) - 1.) * &
+                    exp ((6 + mur) / (mur + 3) * log (6 * qr (k) * den (k)))
+            endif
 
             ! --- Apply Mass and Thermal Limits ---
             sink = psacr + pgfr
@@ -4918,8 +4926,9 @@ subroutine pwbf (ks, ke, dts, qa, qv, ql, qr, qi, qs, qg, dp, tz, cvm, te8, den,
 
     real :: tc, tin, sink, dqdt, qsw, qsi, qim, tmp, fac_wbf
 
+    real :: snow_boost_mult
     real :: tau_wbf_eff
-    real, parameter :: wbf_coarse_mult = 9.0 ! How much slower WBF is at 50km vs 2km
+    real, parameter :: wbf_coarse_mult = 10.0 ! How much slower WBF is at 50km vs 2km
 
     if (.not. do_wbf) return
 
@@ -4949,9 +4958,24 @@ subroutine pwbf (ks, ke, dts, qa, qv, ql, qr, qi, qs, qg, dp, tz, cvm, te8, den,
            (qi (k) .gt. qcmin .or. tc .gt. 15.0) .and. &
             qv (k) .gt. qsi) then
 
-            sink = min (fac_wbf * ql (k), tc / icpk (k))
-            qim = pwbf_qi_crt / den (k)
-            tmp = min (sink, dim (qim, qi (k)))
+            ! 1. Homogeneous Freezing Limit (-40 C)
+            if (tc .ge. 40.0) then
+                sink = ql(k)
+                tmp = 0.0  ! All frozen liquid instantly becomes snow
+            else
+                ! Normal WBF probabilistic freezing
+                sink = min (fac_wbf * ql (k), tc / icpk (k))
+                
+                ! 2. Temperature-Dependent Snow Boost
+                ! Scales from 1.0 (at 0 C) down to 0.0 (at -40 C)
+                ! As tc gets larger (colder), the multiplier shrinks,
+                ! reducing qim and forcing more mass to spill over into qs.
+                snow_boost_mult = max(0.0, 1.0 - (tc / 40.0))
+                
+                qim = (pwbf_qi_crt * snow_boost_mult) / den (k)
+                tmp = min (sink, dim (qim, qi (k)))
+            endif
+
             mppfw = mppfw + sink * dp (k) * convt
 
             call update_qt (qa (k), qv (k), ql (k), qr (k), qi (k), qs (k), qg (k), &
@@ -5014,7 +5038,15 @@ subroutine pbigg (ks, ke, dts, qa, qv, ql, qr, qi, qs, qg, dp, tz, cvm, te8, den
                 ccn (k) = ccn (k) / den (k)
             endif
 
-            sink = 100. / (rhow * ccn (k)) * dts * (exp (0.66 * tc) - 1.) * ql (k) ** 2
+            ! Homogeneous freezing limit applied here
+            if (tc .ge. 40.0) then
+                ! Colder than -40C: ALL cloud liquid freezes instantaneously.
+                sink = ql(k)
+            else
+                ! Warmer than -40C: Calculate probabilistic Bigg freezing normally
+                sink = 100. / (rhow * ccn (k)) * dts * (exp (0.66 * tc) - 1.) * ql (k) ** 2
+            endif
+
             sink = min (ql (k), sink, tc / icpk (k))
             mppfw = mppfw + sink * dp (k) * convt
 

--- a/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOSdatmodyn_GridComp/GEOS_DatmoDynGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/GEOSdatmodyn_GridComp/GEOS_DatmoDynGridComp.F90
@@ -541,7 +541,15 @@ contains
          UNITS     ='m s-1',                                        &
          DIMS      = MAPL_DimsHorzOnly,                             &
          VLOCATION = MAPL_VLocationNone,                            &
-                                                        __RC__  )
+                                                         __RC__  )
+
+    call MAPL_AddExportSpec(GC,                                &
+         SHORT_NAME='WSPD_STABLE300M',                              &
+         LONG_NAME ='max_wind_speed_in_stable_cold_surface_layer',  &
+         UNITS     ='m s-1',                                        &
+         DIMS      = MAPL_DimsHorzOnly,                             &
+         VLOCATION = MAPL_VLocationNone,                            &
+                                                         __RC__  )
 
 
     call MAPL_AddExportSpec(GC,                                &
@@ -1185,6 +1193,7 @@ contains
                         ! else: use interactive winds
 
     integer :: IM,JM,LM,L,K,NQ,ii,NOT1,COLDSTART,Ktrc,iip1,itr,ntracs
+    logical :: is_stable
 
     real, pointer, dimension(:,:,:) :: PLE,PLEOUT
     real, pointer, dimension(:,:,:) :: ZLE
@@ -1212,6 +1221,7 @@ contains
     real, pointer, dimension(:,:)   :: DZ
     real, pointer, dimension(:,:)   :: TA
     real, pointer, dimension(:,:)   :: SPEED
+    real, pointer, dimension(:,:)   :: WSPD_STABLE300M
     real, pointer, dimension(:,:)   :: QA
     real, pointer, dimension(:,:)   :: US
     real, pointer, dimension(:,:)   :: VS
@@ -2030,7 +2040,7 @@ contains
 !    Forcing based on Phase 2 of CGILS intercomparison. See Blossey et al. (2016)
       if ( CFMIP3 ) then
 
-         ZLO = 0.5*(ZLE(:,:,0:LM-1)+ZLE(:,:,1:LM))
+     ZLO = 0.5*(ZLE(:,:,0:LM-1)+ZLE(:,:,1:LM))
 
          if (CFCSE .eq. 12) then
            zrel=1200.
@@ -2124,10 +2134,44 @@ contains
          if (associated(DQVDTDYN))  DQVDTDYN = DQVDTDYN - CFMIPRLX * ( Q - QOBS )
       end if
 
+      call MAPL_GetPointer(EXPORT, WSPD_STABLE300M, 'WSPD_STABLE300M', &
+                           ALLOC=.true., __RC__)
+      if (associated(WSPD_STABLE300M)) then
+         WSPD_STABLE300M = 0.0
+         do J = 1, JM
+            do I = 1, IM
+               ! 1. Check if surface air is freezing (T at lowest model level)
+               if (T(I,J,LM) <= MAPL_TICE) then
+                  ! Assume no inversion until proven otherwise
+                  is_stable = .false.
+                  ! Start max wind tracking with the lowest model level
+                  WSPD_STABLE300M(I,J) = SQRT(U(I,J,LM)**2 + V(I,J,LM)**2)
+                  ! 2. Scan the lowest 300m AGL (ZLE(I,J,LM) is the surface height)
+                  do K = LM-1, 1, -1
+                     ! Height AGL at mid-level using ZLO (0.5*(ZLE(K-1)+ZLE(K)))
+                     if ( (ZLO(I,J,K) - ZLE(I,J,LM)) <= 300.0 ) then
+                        ! Track maximum wind speed
+                        WSPD_STABLE300M(I,J) = MAX(WSPD_STABLE300M(I,J), &
+                                                   SQRT(U(I,J,K)**2 + V(I,J,K)**2))
+                        ! 3. Check for temperature inversion anywhere in the 300m layer
+                        if (T(I,J,K) > T(I,J,LM)) then
+                           is_stable = .true.
+                        endif
+                     else
+                        exit ! Reached top of 300m layer
+                     endif
+                  end do
+                  ! 4. If no inversion found, not a katabatic zone; zero out wind speed
+                  if (.not. is_stable) then
+                     WSPD_STABLE300M(I,J) = 0.0
+                  endif
+               endif
+            end do
+         end do
+      end if
+
       call MAPL_GetPointer(EXPORT, PREF,   'PREF'    , &
                            ALLOC=.true., __RC__)
-
-
       PREF = PREF_IN
 
       VARFLT = 0.


### PR DESCRIPTION
***Zero-difference for default L72/v11; non-zero-difference for alternative levels triggering the v12 configuration***

**Cloud Phase Partitioning and Microphysics Bias Corrections:**

- Revised the surface-dependent cloud phase constants in `Process_Library.F90` to new bias-corrected values for different surface types, aiming to improve cloud phase transitions and radiative balance in various environments. This includes changes to the temperature thresholds and power exponents controlling ice fraction transitions.
- Bugfix: updated the calculation of convective cloud ice fraction to use the correct exponent (`JaT_ICE_PWR`), ensuring consistency with the new parameterization.
- Removed immediate return logic for pure ice or liquid cloud regimes in the Bergeron partitioning routine, allowing for more nuanced mixed-phase treatment.
- Increased the Wegener-Bergeron-Findeisen (WBF) time scale and the coarse grid scaling factor to slow down the WBF process, and lowered the cloud ice-to-snow autoconversion threshold, making the scheme more physically realistic. [[1]](diffhunk://#diff-10ae95976478f34154ac7283aa5c3dceb8193ba83f1de0fa28a4c1839fd81951L415-R415) [[2]](diffhunk://#diff-10ae95976478f34154ac7283aa5c3dceb8193ba83f1de0fa28a4c1839fd81951R4929-R4931) [[3]](diffhunk://#diff-10ae95976478f34154ac7283aa5c3dceb8193ba83f1de0fa28a4c1839fd81951L435-R435)
- Added explicit handling of homogeneous freezing at -40°C in the `psacr_pgfr`, `pwbf`, and `pbigg` routines, ensuring all liquid freezes instantaneously at this threshold. Also introduced a temperature-dependent "snow boost" to favor snow production at colder temperatures in the WBF process. [[1]](diffhunk://#diff-10ae95976478f34154ac7283aa5c3dceb8193ba83f1de0fa28a4c1839fd81951R4252-R4261) [[2]](diffhunk://#diff-10ae95976478f34154ac7283aa5c3dceb8193ba83f1de0fa28a4c1839fd81951R4961-R4978) [[3]](diffhunk://#diff-10ae95976478f34154ac7283aa5c3dceb8193ba83f1de0fa28a4c1839fd81951R5041-R5049)

**Gravity Wave Drag and Efficiency Adjustments:**

- Changed default values for NCAR tropical efficiency and extratropical speed usage in `GEOS_GwdGridComp.F90`, and updated the baseline tau value for independent runs. This impacts the background gravity wave drag representation.
- Modified the initialization of the background stress and efficiency function in the gravity wave drag scheme to use a latitude-dependent blend of tropical and extratropical efficiencies, improving realism in the gravity wave parameterization.

**Stable Cold Surface Wind Diagnostic:**

- Added a new exported field `WSPD_STABLE300M` to `GEOS_DatmoDynGridComp.F90` allowing the Single Column Model to run again.