### PR TITLE
Fixes in routing model for gcc 15

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/CMakeLists.txt
@@ -6,10 +6,12 @@ set (srcs
    reservoir.F90
   )
 
+
+# routing_model.F90-specific optimization override no longer needed with gcc15.
+# - reichle + borescan, 15 July 2026
+#
 #if (CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_BUILD_TYPE MATCHES Release)
 #  set_source_files_properties(routing_model.F90 PROPERTIES COMPILE_OPTIONS ${FOPT2})
 #endif ()
-# No routing_model.F90-specific optimization override.
-# It now uses the normal compiler flags for the selected build type.
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL GEOS_LandShared ESMF::ESMF NetCDF::NetCDF_Fortran)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/CMakeLists.txt
@@ -6,8 +6,10 @@ set (srcs
    reservoir.F90
   )
 
-if (CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_BUILD_TYPE MATCHES Release)
-  set_source_files_properties(routing_model.F90 PROPERTIES COMPILE_OPTIONS ${FOPT2})
-endif ()
+#if (CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_BUILD_TYPE MATCHES Release)
+#  set_source_files_properties(routing_model.F90 PROPERTIES COMPILE_OPTIONS ${FOPT2})
+#endif ()
+# No routing_model.F90-specific optimization override.
+# It now uses the normal compiler flags for the selected build type.
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL GEOS_LandShared ESMF::ESMF NetCDF::NetCDF_Fortran)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/routing_model.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/routing_model.F90
@@ -96,7 +96,7 @@ CONTAINS
     real, parameter                         :: small = 1.e-20
 
     real, dimension(NCAT)                   :: Qrunf,Ws,Wr
-    real, dimension(NCAT)                   :: Qs0,ks,Ws_last,Wbase
+    real, dimension(NCAT)                   :: Qs0,ks,Ws_last
 
     real                                    :: dt
 
@@ -105,23 +105,24 @@ CONTAINS
     Ws    = Ws0    * rho          ! m3   -> kg
     Wr    = Wr0    * rho          ! m3   -> kg
 
-    dt = ROUTE_DT                                                         ! integer -> real
-
+    dt = ROUTE_DT                                                          ! integer -> real
+    
     ! Update state variables: ks, Ws, and Qs
-    where(Qrunf<=small)Qrunf=0.                                           ! Set runoff to zero if it is too small
 
-    ! Use a positive temporary base for fractional powers;
-    ! zero-storage results are restored to zero below.
-    Wbase=merge(Ws,1.0,Ws>0.0)
-
-    Qs0=max(0.,RRM_ALPHA_STR * Wbase**(1./(1.-RRM_mm)))                    ! Initial flow from local stream storage (kg/s)
-    ks =max(0.,(RRM_ALPHA_STR/(1.-RRM_mm)) * Wbase**(RRM_mm/(1.-RRM_mm)))  ! Flow coefficient (s^-1)
-
-    where(Ws<=0.0)
-       Qs0=0.0
-       ks=0.0
+    where( Qrunf<=small )  Qrunf=0.                                        ! Set runoff to zero if it is too small
+    
+    where( Ws>0.0 )                                                        ! Avoid 0 to the power of something, does not work with gcc15
+       
+       Qs0=max(0.,RRM_ALPHA_STR * Ws**(1./(1.-RRM_mm)))                    ! Initial flow from local stream storage (kg/s)
+       ks =max(0.,(RRM_ALPHA_STR/(1.-RRM_mm)) * Ws**(RRM_mm/(1.-RRM_mm)))  ! Flow coefficient (s^-1)
+       
+    elsewhere
+       
+       Qs0 = 0.
+       ks  = 0.
+       
     end where
-
+    
     Ws_last=Ws                                                             ! Store the current water storage
     where(ks>small)  Ws=Ws + (Qrunf-Qs0)/ks*(1.-exp(-ks*dt))               ! Update storage (kg)
     where(ks<=small) Ws=Ws + (Qrunf-Qs0)*dt                                ! Simplified update if ks is small
@@ -130,14 +131,17 @@ CONTAINS
 
     ! Update river storage and calculate river outflow
     Wr=Wr+Qs*dt
-
-    ! Use a positive temporary base for the fractional power;
-    ! zero-storage outflow is restored to zero below.
-    Wbase=merge(Wr,1.0,Wr>0.0)
-
-    Qout=max(0.,RRM_ALPHA_RIV * Wbase**(1./(1.-RRM_mm)))                   ! River flow based on water storage (kg/s)
-    where(Wr<=0.0)Qout=0.0
-
+    
+    where( Wr>0.0 )                                                        ! Avoid 0 to the power of something, does not work with gcc15
+       
+       Qout=max(0.,RRM_ALPHA_RIV * Wr**(1./(1.-RRM_mm)))                   ! River flow based on water storage (kg/s)
+       
+    elsewhere
+       
+       Qout=0.0
+       
+    end where
+       
     Qout=min(Qout,Wr/dt)                                                   ! Limit outflow to available river storage
     Wr=max(0.,Wr-Qout*dt)                                                  ! Update river storage and keep it non-negative
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/routing_model.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOSroute_GridComp/routing_model.F90
@@ -79,7 +79,6 @@ CONTAINS
   ! -------------------------
   !**** QS            = TRANSFER OF MOISTURE FROM STREAM VARIABLE TO RIVER VARIABLE       [m^3/s]
   !**** QOUT          = TRANSFER OF RIVER WATER TO THE DOWNSTREAM (DOWNRIVER) CATCHMENT   [m^3/s]  
-  
   SUBROUTINE RIVER_ROUTING_HYD (             &
        NCAT,ROUTE_DT,                        &
        Qrunf0, RRM_ALPHA_RIV, RRM_ALPHA_STR, &
@@ -87,42 +86,60 @@ CONTAINS
        Qs,Qout)
 
     IMPLICIT NONE
-    
+
     INTEGER, INTENT(IN)                     :: NCAT,ROUTE_DT
     REAL,    INTENT(IN),   DIMENSION (NCAT) :: Qrunf0
     REAL,    INTENT(IN),   DIMENSION (NCAT) :: RRM_ALPHA_RIV, RRM_ALPHA_STR
     REAL,    INTENT(INOUT),DIMENSION (NCAT) :: Ws0,Wr0
     REAL,    INTENT(OUT),  DIMENSION (NCAT) :: Qs,Qout
 
-    real, parameter                         :: small    = 1.e-20 
+    real, parameter                         :: small = 1.e-20
 
     real, dimension(NCAT)                   :: Qrunf,Ws,Wr
-    real, dimension(NCAT)                   :: Qs0,ks,Ws_last
-    
+    real, dimension(NCAT)                   :: Qs0,ks,Ws_last,Wbase
+
     real                                    :: dt
 
     ! convert volume units to mass
-    Qrunf     = Qrunf0     * rho          ! m3/s -> kg/s  
-    Ws        = Ws0        * rho          ! m3   -> kg
-    Wr        = Wr0        * rho          ! m3   -> kg
+    Qrunf = Qrunf0 * rho          ! m3/s -> kg/s
+    Ws    = Ws0    * rho          ! m3   -> kg
+    Wr    = Wr0    * rho          ! m3   -> kg
 
-    dt        = ROUTE_DT                  ! integer -> real                                                                      ! If river input is too small, set alp_r to 0
+    dt = ROUTE_DT                                                         ! integer -> real
 
-    ! Update state variables: ks, Ws, and Qs 
-    where(Qrunf<=small)Qrunf=0.                                            ! Set runoff to zero if it's too small
-    Qs0=max(0.,RRM_ALPHA_STR * Ws**(1./(1.-RRM_mm)))                       ! Initial flow from local stream storage (kg/s)
-    ks =max(0.,(RRM_ALPHA_STR/(1.-RRM_mm)) * Ws**(RRM_mm/(1.-RRM_mm)))     ! Flow coefficient (s^-1)
-    Ws_last=Ws                                                             ! Store the current water storage 
+    ! Update state variables: ks, Ws, and Qs
+    where(Qrunf<=small)Qrunf=0.                                           ! Set runoff to zero if it is too small
+
+    ! Use a positive temporary base for fractional powers;
+    ! zero-storage results are restored to zero below.
+    Wbase=merge(Ws,1.0,Ws>0.0)
+
+    Qs0=max(0.,RRM_ALPHA_STR * Wbase**(1./(1.-RRM_mm)))                    ! Initial flow from local stream storage (kg/s)
+    ks =max(0.,(RRM_ALPHA_STR/(1.-RRM_mm)) * Wbase**(RRM_mm/(1.-RRM_mm)))  ! Flow coefficient (s^-1)
+
+    where(Ws<=0.0)
+       Qs0=0.0
+       ks=0.0
+    end where
+
+    Ws_last=Ws                                                             ! Store the current water storage
     where(ks>small)  Ws=Ws + (Qrunf-Qs0)/ks*(1.-exp(-ks*dt))               ! Update storage (kg)
     where(ks<=small) Ws=Ws + (Qrunf-Qs0)*dt                                ! Simplified update if ks is small
     Ws=max(0.,Ws)                                                          ! Ensure storage is non-negative
-    Qs=max(0.,Qrunf-(Ws-Ws_last)/dt)                                       ! Calculate the local stream flow (kg/s)
+    Qs=max(0.,Qrunf-(Ws-Ws_last)/dt)                                       ! Calculate local stream flow (kg/s)
 
-    ! Calculate variables related to river routing: Qr0, kr
+    ! Update river storage and calculate river outflow
     Wr=Wr+Qs*dt
-    Qout=max(0.,RRM_ALPHA_RIV * Wr**(1./(1.-RRM_mm)))                      ! River flow based on water storage (kg/s)
-    Qout=min(Qout,Wr/dt)
-    Wr=max(0.,Wr-Qout*dt) 
+
+    ! Use a positive temporary base for the fractional power;
+    ! zero-storage outflow is restored to zero below.
+    Wbase=merge(Wr,1.0,Wr>0.0)
+
+    Qout=max(0.,RRM_ALPHA_RIV * Wbase**(1./(1.-RRM_mm)))                   ! River flow based on water storage (kg/s)
+    where(Wr<=0.0)Qout=0.0
+
+    Qout=min(Qout,Wr/dt)                                                   ! Limit outflow to available river storage
+    Wr=max(0.,Wr-Qout*dt)                                                  ! Update river storage and keep it non-negative
 
     ! convert mass units back to volume
     Ws0  = Ws  /rho        ! kg   -> m3
@@ -132,7 +149,7 @@ CONTAINS
 
     RETURN
 
-  END SUBROUTINE RIVER_ROUTING_HYD
+  END SUBROUTINE RIVER_ROUTING_HYD  
 
   ! -------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes for routing model needed by GNU compiler gcc15.
- Remove GNU optimization override for routing_model.F90 (no longer needed with gcc15 and/or the present fix).
- Avoid calculating 0 to the power of something (which trips up gcc15). 

**Trivially zero-diff for GCM simulations** (b/c routing model is not yet used in GCM tests)

Zero-diff for GEOSldas when using **Intel** compiler (confirmed by @gmao-rreichle on 16 July 2027; this test evaluated the changes in the present PR in isolation, i.e., without https://github.com/GEOS-ESM/GEOSldas/pull/864; adding GEOSldas PR#864 is **not** zero-diff).

For **GNU**, testing was only done in conjunction with the changes in https://github.com/GEOS-ESM/GEOSldas/pull/864, with the expected non-zero diff ("roundoff") result.   

---

Related PRs: 
https://github.com/GEOS-ESM/GEOSldas/pull/864

---

cc: @biljanaorescanin @weiyuan-jiang 