### PR TITLE
New option for climatological rescaling of precipitation 

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -5311,7 +5311,8 @@ module GEOS_SurfaceGridCompMod
     type (ESMF_Field)                   :: Field
     type (ESMF_Grid)                    :: GRID
     type (ESMF_Time)                    :: CurrentTime
-    character(len=ESMF_MAXSTR)          :: PRECIP_FILE
+    character(len=ESMF_MAXPATHLEN)      :: PRECIP_FILE
+    character(len=ESMF_MAXPATHLEN)      :: PRECIP_FILE_CLIMSCALE
 
     type (T_SURFACE_STATE), pointer     :: surf_internal_state
     type (SURF_wrap)                    :: wrap
@@ -6392,26 +6393,31 @@ module GEOS_SurfaceGridCompMod
 
     end if
 
-! Read in precip data. This is used in 'coupled' replay
-!------------------------------------------------------
+! Read in precip or precip clim scaling data. This is used in 'coupled' replay
+!-----------------------------------------------------------------------------
+! This code is used to have the surface components (land, salwater, etc.) see
+!  a "corrected" precip according to Rolf et al. This was used in MERRA-2 and
+!  would typically be done during reanalysis or replay. Also, OGCM-coupled
+!  replays require special treatment.
+! Alternatively, read climatological scaling factors that convert the model
+!  precipitation to an observed climatology.  This rescaled precip is then
+!  processed just like the "corrected" precipitation (that is, disaggregated
+!  into components and tapered with the (raw) model precipitation.  Introduced 
+!  for M21C to address IMERG-Late V07B quality issues while preserving the
+!  climatology of the corrected precip after the end of IMERG-Final on data-day 1 Oct 2025.
+!------------------------------------------------------------------------------------------
 
-    call MAPL_GetResource(MAPL,PRECIP_FILE,LABEL="PRECIP_FILE:",default="null", RC=STATUS)
+    call MAPL_GetResource(MAPL,PRECIP_FILE,          LABEL="PRECIP_FILE:",          default="null", RC=STATUS)
+    VERIFY_(STATUS)
+    
+    call MAPL_GetResource(MAPL,PRECIP_FILE_CLIMSCALE,LABEL="PRECIP_FILE_CLIMSCALE:",default="null", RC=STATUS)
     VERIFY_(STATUS)
 
-    call ESMF_ClockGet(CLOCK, currTime=CurrentTime, rc=STATUS)
-    VERIFY_(STATUS)
-    call ESMF_TimeGet (currentTime,               &
-                       YY=YEAR, MM=MONTH, DD=DAY, &
-                       H=HR,    M=MN,     S=SE,   &
-                                        RC=STATUS )
-    VERIFY_(STATUS)
-    call ESMF_TimeSet (currentTime,               &
-                       YY=YEAR, MM=MONTH, DD=DAY, &
-                       H=HR,    M =30,    S = 0,  &
-                                        RC=STATUS )
-    VERIFY_(STATUS)
-
-
+    ! for now, do not allow the combination of precip replacement and clim rescaling
+    
+    _ASSERT( .not. (trim(PRECIP_FILE) /= "null" .and. trim(PRECIP_FILE_CLIMSCALE) /= "null"), &
+         "only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set" )
+    
 ! These exports are the rainfalls and total snowfall that
 !  the children of surface see. They can be the exports of
 !  moist or can be read from a file.
@@ -6444,25 +6450,62 @@ module GEOS_SurfaceGridCompMod
     ICE = ICEFL
     FRZR= FRZRFL
 
-! This code is used to have the surface components (land, salwater, etc.) see
-!  a "corrected" precip according to Rolf et al. This was used in MERRA-2 and
-!  would typically be done one during reanalysis or replay. Also, OGCM-coupled
-!  replays require special treatment.
-!-----------------------------------------------------------------------------
-
-    REPLACE_PRECIP: if(PRECIP_FILE /= "null") then
+    REPLACE_PRECIP: if(trim(PRECIP_FILE) /= "null" .or. trim(PRECIP_FILE_CLIMSCALE) /= "null") then
 
        bundle = ESMF_FieldBundleCreate (NAME='PRECIP', RC=STATUS)
        VERIFY_(STATUS)
        call ESMF_FieldBundleSet(bundle, GRID=GRID, RC=STATUS)
        VERIFY_(STATUS)
 
-     ! call MAPL_CFIORead( PRECIP_FILE, CurrentTime, Bundle, RC=STATUS)
-     ! VERIFY_(STATUS)
-       call MAPL_read_bundle( Bundle, PRECIP_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
+       allocate( PRECSUM(IM,JM), stat=STATUS )
        VERIFY_(STATUS)
-       call ESMFL_BundleGetPointerToData(Bundle,'PRECTOT',PTTe, RC=STATUS)
+
+       PRECSUM = RCU+RLS+SNO+ICE+FRZR
+
+       ! get and parse current time (needed to create file time stamp)
+       
+       call ESMF_ClockGet(CLOCK, currTime=CurrentTime, rc=STATUS)
        VERIFY_(STATUS)
+       call ESMF_TimeGet (currentTime,               &
+                          YY=YEAR, MM=MONTH, DD=DAY, &
+                          H=HR,    M=MN,     S=SE,   &
+                          RC=STATUS )
+       VERIFY_(STATUS)
+       
+       if( trim(PRECIP_FILE) /= "null") then
+          
+          ! read corrected precip (PTTe) directly from (hourly) file if file exists (crashes otherwise?)
+          
+          call ESMF_TimeSet (currentTime,               &
+                             YY=YEAR, MM=MONTH, DD=DAY, &
+                             H=HR,    M =30,    S = 0,  &
+                             RC=STATUS )
+          VERIFY_(STATUS)
+          
+          call MAPL_read_bundle( Bundle, PRECIP_FILE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
+          VERIFY_(STATUS)
+          call ESMFL_BundleGetPointerToData(Bundle,'PRECTOT',PTTe, RC=STATUS)
+          VERIFY_(STATUS)
+          
+       else
+          
+          ! read clim scale factor from file and apply to uncorrected (model) precip (PRECSUM) 
+          ! to create the "corrected" precip (PTTe)
+          
+          ! climatology is daily, only need month/day information, use leap year (8888) as nominal year
+          ! (matching time stamps in files)
+          call ESMF_TimeSet (currentTime,               &
+                             YY=8888, MM=MONTH, DD=DAY, & 
+                             H=0,     M =0,     S = 0,  & 
+                             RC=STATUS ) 
+          VERIFY_(STATUS)
+                    
+          call MAPL_read_bundle( Bundle, PRECIP_FILE_CLIMSCALE, CurrentTime, regrid_method=REGRID_METHOD_CONSERVE, RC=status)
+          VERIFY_(STATUS)
+          call ESMFL_BundleGetPointerToData(Bundle,'factor_clim',PTTe, RC=STATUS)
+          PTTe = PTTe * PRECSUM
+          VERIFY_(STATUS)
+       end if
 
 
 ! Catchment required convective and large-scale rain and total snowfall,
@@ -6482,15 +6525,7 @@ module GEOS_SurfaceGridCompMod
 
        allocate( PCSCALE(IM,JM), stat=STATUS )
        VERIFY_(STATUS)
-       allocate( PRECSUM(IM,JM), stat=STATUS )
-       VERIFY_(STATUS)
 
-       ! PRECSUM = uncorrected total precip
-       ! PTTe    = total precip from file
-       
-       PRECSUM = RCU+RLS+SNO+ICE  ! do *not* add FRZR, which is liquid not solid and (probably) incl. in RCU+RLS
-                                  ! see comment re. FRZR in GEOS_CatchGridComp.F90 by reichle, 6/6/2025
-       
        where (PTTe == MAPL_UNDEF)
           RCU = PCU
           RLS = PLS
@@ -7604,7 +7639,7 @@ module GEOS_SurfaceGridCompMod
        VERIFY_(STATUS)
 
        ! Do not correct the precip over ocean tiles
-       if(Precip_File /= "null") then
+       if( trim(Precip_File) /= "null"  .or. trim(PRECIP_FILE_CLIMSCALE) /= "null" ) then
 
           call MAPL_LocStreamTransform( LOCSTREAM, TMPTILE  , PCU,     RC=STATUS); VERIFY_(STATUS)
           where(tiletype == MAPL_OCEAN)  PCUTILE = TMPTILE
@@ -7624,7 +7659,7 @@ module GEOS_SurfaceGridCompMod
        end if
 
        ! Adjust the discharge going to the ocean
-       if(Precip_File /= "null" .and. DischargeAdjustFile /= "null") then
+       if( (trim(Precip_File) /= "null"  .or. trim(PRECIP_FILE_CLIMSCALE) /= "null") .and. DischargeAdjustFile /= "null") then
 
           call MAPL_GetPointer(INTERNAL, DISCHARGE_ADJUST, 'DISCHARGE_ADJUST',  RC=STATUS)
           VERIFY_(STATUS)
@@ -7663,7 +7698,7 @@ module GEOS_SurfaceGridCompMod
     call MAPL_GetPointer(EXPORT, CN_PRCP, 'CN_PRCP', ALLOC=.true., RC=STATUS)
     VERIFY_(STATUS)
 
-    if(PRECIP_FILE /= "null") then
+    if( trim(PRECIP_FILE) /= "null" .or. trim(PRECIP_FILE_CLIMSCALE) /= "null" ) then
        TMPTILE = PCUTILE
        call MAPL_LocStreamTransform( LOCSTREAM, CN_PRCP, TMPTILE, RC=STATUS)
        VERIFY_(STATUS)
@@ -7677,7 +7712,7 @@ module GEOS_SurfaceGridCompMod
     call MAPL_GetPointer(EXPORT, PRECTOT, 'PRECTOT', ALLOC=.true., RC=STATUS)
     VERIFY_(STATUS)
 
-    if(PRECIP_FILE /= "null") then
+    if( trim(PRECIP_FILE) /= "null" .or. trim(PRECIP_FILE_CLIMSCALE) /= "null" ) then
        TMPTILE = PCUTILE + PLSTILE + SNOFLTILE + ICEFLTILE  ! do *not* add FRZR, which is liquid not solid and (probably) incl. in PCUTILE+PCSTILE
        call MAPL_LocStreamTransform( LOCSTREAM, PRECTOT, TMPTILE, RC=STATUS)
        VERIFY_(STATUS)

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -6415,7 +6415,7 @@ module GEOS_SurfaceGridCompMod
 
     ! for now, do not allow the combination of precip replacement and clim rescaling
     
-    _ASSERT( .not. (trim(PRECIP_FILE) /= "null" .and. trim(PRECIP_FILE_CLIMSCALE) /= "null"), &
+    _ASSERT( (.not. (trim(PRECIP_FILE) /= "null" .and. trim(PRECIP_FILE_CLIMSCALE) /= "null")), &
          "only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set" )
     
 ! These exports are the rainfalls and total snowfall that

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -6076,6 +6076,7 @@ module GEOS_SurfaceGridCompMod
     character(len=ESMF_MAXPATHLEN) :: SolCycFileName
     logical :: PersistSolar
     logical :: allocateRunoff
+    logical :: tmp_logical
 
 !=============================================================================
 
@@ -6414,9 +6415,10 @@ module GEOS_SurfaceGridCompMod
     VERIFY_(STATUS)
 
     ! for now, do not allow the combination of precip replacement and clim rescaling
-    
-    _ASSERT( (.not. (trim(PRECIP_FILE) /= 'null' .and. trim(PRECIP_FILE_CLIMSCALE) /= 'null')), &
-         'only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set' )
+
+    tmp_logical = .not. (trim(PRECIP_FILE) /= 'null' .and. trim(PRECIP_FILE_CLIMSCALE) /= 'null')   ! for GNU, avoid complex logical inside _ASSERT() macro
+
+    _ASSERT( tmp_logical, 'only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set' )
     
 ! These exports are the rainfalls and total snowfall that
 !  the children of surface see. They can be the exports of

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -6415,9 +6415,10 @@ module GEOS_SurfaceGridCompMod
 
     ! for now, do not allow the combination of precip replacement and clim rescaling
 
-    if (trim(PRECIP_FILE) /= 'null' .and. trim(PRECIP_FILE_CLIMSCALE) /= 'null')            &
-      _ASSERT( .FALSE., 'only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set' )
-    
+    if (trim(PRECIP_FILE) /= 'null' .and. trim(PRECIP_FILE_CLIMSCALE) /= 'null') then
+       _ASSERT( .FALSE., 'only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set' )
+    end if
+
 ! These exports are the rainfalls and total snowfall that
 !  the children of surface see. They can be the exports of
 !  moist or can be read from a file.

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -6415,8 +6415,8 @@ module GEOS_SurfaceGridCompMod
 
     ! for now, do not allow the combination of precip replacement and clim rescaling
     
-    _ASSERT( (.not. (trim(PRECIP_FILE) /= "null" .and. trim(PRECIP_FILE_CLIMSCALE) /= "null")), &
-         "only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set" )
+    _ASSERT( (.not. (trim(PRECIP_FILE) /= 'null' .and. trim(PRECIP_FILE_CLIMSCALE) /= 'null')), &
+         'only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set' )
     
 ! These exports are the rainfalls and total snowfall that
 !  the children of surface see. They can be the exports of

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -6460,7 +6460,11 @@ module GEOS_SurfaceGridCompMod
        allocate( PRECSUM(IM,JM), stat=STATUS )
        VERIFY_(STATUS)
 
-       PRECSUM = RCU+RLS+SNO+ICE+FRZR
+       ! PRECSUM = uncorrected total precip
+       ! PTTe    = total precip from file
+       
+       PRECSUM = RCU+RLS+SNO+ICE  ! do *not* add FRZR, which is liquid not solid and (probably) incl. in RCU+RLS
+                                  ! see comment re. FRZR in GEOS_CatchGridComp.F90 by reichle, 6/6/2025
 
        ! get and parse current time (needed to create file time stamp)
        

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/GEOS_SurfaceGridComp.F90
@@ -6076,7 +6076,6 @@ module GEOS_SurfaceGridCompMod
     character(len=ESMF_MAXPATHLEN) :: SolCycFileName
     logical :: PersistSolar
     logical :: allocateRunoff
-    logical :: tmp_logical
 
 !=============================================================================
 
@@ -6416,9 +6415,8 @@ module GEOS_SurfaceGridCompMod
 
     ! for now, do not allow the combination of precip replacement and clim rescaling
 
-    tmp_logical = .not. (trim(PRECIP_FILE) /= 'null' .and. trim(PRECIP_FILE_CLIMSCALE) /= 'null')   ! for GNU, avoid complex logical inside _ASSERT() macro
-
-    _ASSERT( tmp_logical, 'only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set' )
+    if (trim(PRECIP_FILE) /= 'null' .and. trim(PRECIP_FILE_CLIMSCALE) /= 'null')            &
+      _ASSERT( .FALSE., 'only one of PRECIP_FILE *or* PRECIP_FILE_CLIMSCALE can be set' )
     
 ! These exports are the rainfalls and total snowfall that
 !  the children of surface see. They can be the exports of


### PR DESCRIPTION
This PR implements a new option to rescale the model precip to an observed climatology using seasonally varying scaling parameters (as opposed to the traditional precipitation correction approach, which directly replaces the model precipitation with precipitation from external files). 

High-latitude tapering for the climatological rescaling works exactly like the high-latitude tapering for the traditional precipitation corrections. 

The new option is used in M21C.  Beginning with data-day 1 Oct 2025 (after the end of IMERG-Final data), M21C switched to climatological rescaling of the precipitation rather than use IMERG-Late, which turned out to have issues, especially over tropical land.  

The new option is turned on by providing a new rc variable PRECIP_FILE_CLIMSCALE.  The rc variable PRECIP_FILE for the traditional precipitation corrections needs to be commented out in the config file. 

**Related PRs**: 
https://github.com/GEOS-ESM/GEOSgcm_App/pull/902

**Testing**:
Successfully 0-diff tested for GEOSldas by @gmao-rreichle on 5 August 2026
Successfully 0-diff tested for GEOSgcm by @biljanaorescanin on 5 August 2026 (https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1484#issuecomment-5199442924)

cc: @gmao-qliu @biljanaorescanin 

--- 

For **reference only**, the clim rescaling of precipitation in M21C was implemented in the following PRs (which also contained an unrelated change in the atmospheric observing system):

- https://github.com/GEOS-ESM/GEOSadas/pull/441
- https://github.com/GEOS-ESM/GEOSana_GridComp/pull/238
- https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1468
- https://github.com/GEOS-ESM/GEOSgcm_App/pull/894

