### PR TITLE
Minor bug fixes for make_bcs (init do_schmidt, fix dateline argument)

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CombineRasters.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CombineRasters.F90
@@ -471,7 +471,7 @@ program mkOverlaySimple
       if ( index(Grid1, "EASE") /=0 .and. index(Grid2, "EASE") /=0) then
          l = index(TilFile, '.til')
          regrid = nx /= i_raster .or. ny /= j_raster
-         call supplemental_tile_attributes(nx, ny, regrid, 'DE',TilFile(1:l-1), Rst1)
+         call supplemental_tile_attributes(nx, ny, regrid, TilFile(1:l-1), Rst1)
       endif
     endif
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CubedSphere_GridMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/CubedSphere_GridMod.F90
@@ -59,7 +59,7 @@ contains
   real(r8)              :: alocs(2)
   real(r8)              :: target_lon,target_lat
 
-  logical doShiftWest
+  logical :: doShiftWest
   logical :: do_schmidt	
 
  isg = 1
@@ -91,10 +91,10 @@ contains
   call mirror_grid(grid_global, 0, npts, npts, 2, 6)
 ! Cell Vertices
   doShiftWest = .false.
+  do_schmidt  = .false.
   if (present(shift_west)) doShiftWest = shift_west
-    if (present(stg)) then
-     do_schmidt = .true.
-  end if
+  if (present(stg))   do_schmidt = .true.
+
    !------------------------
    ! Schmidt transformation:
    !------------------------

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkCatchParam.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkCatchParam.F90
@@ -10,7 +10,7 @@ PROGRAM mkCatchParam
   !  Usage = "mkCatchParam -x nx -y ny -g Gridname  -v LBCSV "       
   !     -x: Size of longitude dimension of input raster.            DEFAULT: 8640
   !     -y: Size of latitude dimension of input raster.             DEFAULT: 4320
-  !    !! -b: Position of dateline w.r.t. first grid cell boundaries. DEFAULT: DC (dateline-on-center)
+  !     DISCONTINUED: -b: Position of dateline w.r.t. first grid cell boundaries. DEFAULT: DC (dateline-on-center)
   !     -g: Gridname (name of the .til or .rst file without file extension)  
   !     -v: LBCSV : Land bcs version (F25, GM4, ICA, NL3, NL4, NL5, v06, v07, v08, v09, v11, ...)
   !     
@@ -117,7 +117,7 @@ PROGRAM mkCatchParam
   USAGE(2) ="     -x: Size of longitude dimension of input raster. DEFAULT: 8640              "
   USAGE(3) ="     -y: Size of latitude dimension of input raster.  DEFAULT: 4320              "
   USAGE(4) ="     -g: Gridname  (name of the .til or .rst file *without* file extension)      "
-  USAGE(5) ="   not used anymore !!-b: Position of the dateline in the first grid box (DC or DE). DEFAULT: DC  "
+  USAGE(5) ="     DISCONTINUED: -b: Position of the dateline in the first grid box (DC or DE). DEFAULT: DC  "
   USAGE(6) ="     -v: Land bcs version (F25, GM4, ICA, NL3, NL4, NL5, v06, v07, v08 v09 )     "
   USAGE(7) ="     -p: if no, it creates catchment_def and nc4 tile files then exits           "
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkCatchParam.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkCatchParam.F90
@@ -7,10 +7,10 @@ PROGRAM mkCatchParam
   !
   ! !ARGUMENTS:
   !
-  !  Usage = "mkCatchParam -x nx -y ny -g Gridname -b DL -v LBCSV "       
+  !  Usage = "mkCatchParam -x nx -y ny -g Gridname  -v LBCSV "       
   !     -x: Size of longitude dimension of input raster.            DEFAULT: 8640
   !     -y: Size of latitude dimension of input raster.             DEFAULT: 4320
-  !     -b: Position of dateline w.r.t. first grid cell boundaries. DEFAULT: DC (dateline-on-center)
+  !    !! -b: Position of dateline w.r.t. first grid cell boundaries. DEFAULT: DC (dateline-on-center)
   !     -g: Gridname (name of the .til or .rst file without file extension)  
   !     -v: LBCSV : Land bcs version (F25, GM4, ICA, NL3, NL4, NL5, v06, v07, v08, v09, v11, ...)
   !     
@@ -47,7 +47,6 @@ PROGRAM mkCatchParam
   character*1          :: opt
   character*128        :: PEATSOURCE   = ''
   character*3          :: VEGZSOURCE   = 'D&S'
-  character*2          :: DL ='DC'    
   integer              :: II, JJ, Type
   integer              :: I, J, command_argument_count, nxt
   real*8               :: dx, dy, lon0
@@ -114,11 +113,11 @@ PROGRAM mkCatchParam
   !
   !$OMP ENDPARALLEL
 
-  USAGE(1) ="Usage: mkCatchParam -x nx -y ny -g Gridname -b DL -v LBCSV                       "
+  USAGE(1) ="Usage: mkCatchParam -x nx -y ny -g Gridname  -v LBCSV                            "
   USAGE(2) ="     -x: Size of longitude dimension of input raster. DEFAULT: 8640              "
   USAGE(3) ="     -y: Size of latitude dimension of input raster.  DEFAULT: 4320              "
   USAGE(4) ="     -g: Gridname  (name of the .til or .rst file *without* file extension)      "
-  USAGE(5) ="     -b: Position of the dateline in the first grid box (DC or DE). DEFAULT: DC  "
+  USAGE(5) ="   not used anymore !!-b: Position of the dateline in the first grid box (DC or DE). DEFAULT: DC  "
   USAGE(6) ="     -v: Land bcs version (F25, GM4, ICA, NL3, NL4, NL5, v06, v07, v08 v09 )     "
   USAGE(7) ="     -p: if no, it creates catchment_def and nc4 tile files then exits           "
 
@@ -168,8 +167,6 @@ PROGRAM mkCatchParam
         LBCSV = trim(arg)
         if (trim(arg).eq."F25") F25Tag = .true.
         call init_bcs_config (trim(LBCSV))       ! get bcs details from version string
-     case ('b')
-        DL = trim(arg)
      case ('p')
         withbcs = trim(arg)
      case default
@@ -243,11 +240,6 @@ PROGRAM mkCatchParam
   write (log_file,'(a)')'============================================================'
   write (log_file,'(a)')'                                               '
 
-  if(index(Gridname,'CF')/=0) then 
-     DL = 'DE'
-     write (log_file,'(a)')'Cube-Sphere Grid - assuming dateline-on-edge (DE)'
-  endif
-
   ! ******************************************************************************
   !
   ! IMPORTANT: The top-level make_bcs script should not allow this program to
@@ -279,7 +271,7 @@ PROGRAM mkCatchParam
      if (.not.file_exists) then
         write (log_file,'(a)')'         Creating catchment def and nc4 tile file...'
         call system_clock(clock1)
-        call supplemental_tile_attributes(nc,nr,regrid,dl,fnameTil, tile_id) 
+        call supplemental_tile_attributes(nc,nr,regrid,fnameTil, tile_id) 
         call system_clock(clock2)
         seconds = (clock2-clock1)/real(clock_rate)
         write (log_file, *) '         Done. Spent   ', seconds, "  seconds"

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rmTinyCatchParaMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rmTinyCatchParaMod.F90
@@ -1249,7 +1249,7 @@ contains
     real(REAL64),      allocatable         :: rTable_keep(:,:)
     integer,           allocatable         :: iTable_keep(:,:)
     character(len=128)                     :: gName(2)
-    character(:), allocatable              :: Combined_gName
+    character(:),      allocatable         :: Combined_gName
     logical,           allocatable         :: IsOcean(:)
     logical,           allocatable         :: keep_tile(:)
 
@@ -1307,11 +1307,13 @@ contains
     n = index(fnameTil, '/', back=.true.)
     Combined_gName= fnameTil(n+1:)
 
-    if(index(Combined_gName,'CF')/=0 .or. index(Combined_gName,'EASE') /=0) then 
+    if      (Combined_gName(1:2)=='CF' .or. index(Combined_gName,'EASE')/=0) then 
       dateline = 'DE'
       write (*,*) 'Cube-Sphere or EASE Grid - assuming dateline-on-edge (DE)'
-    else
+    else if (Combined_gName(1:2)=='DE' .or. Combined_gName(1:2)=='DC')       then
       dateline = Combined_gName(1:2)
+    else
+      ASSERT_(.false.)        ! unknown (atm) grid, stopping
     endif
 
     open (10,file=fname,status='old',action='read',form='formatted')

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rmTinyCatchParaMod.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/rmTinyCatchParaMod.F90
@@ -1204,7 +1204,7 @@ contains
   END SUBROUTINE AppendLakeTypeToTileNC4
   !----------------------------------------------------------------------  
   
-  SUBROUTINE supplemental_tile_attributes(nx,ny,regrid,dateline,fnameTil, Rst_id)
+  SUBROUTINE supplemental_tile_attributes(nx,ny,regrid,fnameTil, Rst_id)
     
     ! 1) get supplemental tile attributes not provided in MAPL-generated (ASCII) tile file,
     !    incl. min/max lat/lon of each tile and tile elevation
@@ -1213,8 +1213,6 @@ contains
     integer,      intent(in) :: nx, ny
 
     logical,      intent(in) :: regrid    
-
-    character(*), intent(in) :: dateline
 
     character(*), intent(in) :: fnameTil   ! file name (w/o extension) of tile file
     integer, intent(in)      :: Rst_id(:,:)   
@@ -1233,6 +1231,7 @@ contains
     character*512                      :: fname, catch_file
     character*512                      :: gtopo30
     CHARACTER*512                      :: version
+    character(len=2)                   :: dateline
 
     REAL, allocatable                  :: limits(:,:)
 
@@ -1250,6 +1249,7 @@ contains
     real(REAL64),      allocatable         :: rTable_keep(:,:)
     integer,           allocatable         :: iTable_keep(:,:)
     character(len=128)                     :: gName(2)
+    character(:), allocatable              :: Combined_gName
     logical,           allocatable         :: IsOcean(:)
     logical,           allocatable         :: keep_tile(:)
 
@@ -1304,6 +1304,15 @@ contains
     allocate (catid(1:i_sib))
     catid=0
     fname=trim(fnameTil)//'.til'
+    n = index(fnameTil, '/', back=.true.)
+    Combined_gName= fnameTil(n+1:)
+
+    if(index(Combined_gName,'CF')/=0 .or. index(Combined_gName,'EASE') /=0) then 
+      dateline = 'DE'
+      write (*,*) 'Cube-Sphere or EASE Grid - assuming dateline-on-edge (DE)'
+    else
+      dateline = Combined_gName(1:2)
+    endif
 
     open (10,file=fname,status='old',action='read',form='formatted')
     read (10,*)ip
@@ -1417,7 +1426,7 @@ contains
        mny=-90. + float(j-1)*180./float(j_sib)
        mxy=-90. + float(j)  *180./float(j_sib)
        
-       if (index(dateline,'DE')/=0) then
+       if ( dateline == 'DE' ) then
           do i=1,i_sib          
              if( .not. IsOcean(catid(i)- ip1))then
                 mnx =-180. + float(i-1)*360./float(i_sib)


### PR DESCRIPTION
Fix bugs in make bcs, see details below.  Dateline bug fix has no impact on bcs for GMAO use cases (lat/long atm grid has not been used in a long time, and only DC lat/long was used).  

Trivially 0-diff for running the GCM and GEOSldas.

Zero-diff for make_bcs.  Tested by @biljanaorescanin on 10 August 2026.


1) Init do_schmidt variable. 
2) Fix dateline. In the python code, the dateline is never passed into mkCatchParam(). So it is theoretically possible that 'DC' is used when it should be 'DE':

https://github.com/GEOS-ESM/GEOSgcm_GridComp/blob/899cb835825b9cc6b79a30db53992ef16f28dcb2/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/make_bcs_latlon.py#L46 


The  `-b` argument for mkCatchParam() was documented [here ](https://github.com/GEOS-ESM/GEOSgcm_GridComp/blob/899cb835825b9cc6b79a30db53992ef16f28dcb2/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/mkCatchParam.F90#L13)

