### PR TITLE
Fix regression test key and GWD/held-suarez regression cleanup

### DIFF
--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/agcm-simple.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/agcm-simple.yaml
@@ -8,12 +8,12 @@ mapl:
     DataMoist:
       dso: libconfigurable_gridcomp
       config_file: data-moist.yaml
-      setservice: setservices_
+      setservices: setservices_
 
     DataAna:
       dso: libconfigurable_gridcomp
       config_file: data-ana.yaml
-      setservice: setservices_
+      setservices: setservices_
 
   connections:
     - src_name: TRADV

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
@@ -17,9 +17,7 @@ function(run_case case_name regression_data_dir)
     compare_results(${checkpoints_dir} ${expdir}/checkpoints/last)
   endif()
 
-  # execute_process(
-  #   COMMAND ${CMAKE_COMMAND} -E rm -rf ${expdir}
-  # )
+  file(REMOVE_RECURSE ${expdir})
 endfunction()
 
 run_case(${TEST_CASE} ${REGRESSION_DATA_DIR})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/gwd-ncar-sa/cap.yaml
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/gwd-ncar-sa/cap.yaml
@@ -17,7 +17,7 @@ cap:
       Root:
         dso: libconfigurable_gridcomp
         config_file: root.yaml
-        setservice: setservices_
+        setservices: setservices_
 
   checkpointing:
     enabled: true

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/gwd-ncar-sa/root.yaml
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/gwd-ncar-sa/root.yaml
@@ -19,12 +19,12 @@ mapl:
     GWD:
       dso: libGEOSgwd_GridComp.so
       config_file: gwd.yaml
-      setservice: gwd_setservices_
+      setservices: gwd_setservices_
 
     DataGwdImports:
       dso: libconfigurable_gridcomp
       config_file: data-gwd-imports.yaml
-      setservice: setservices_
+      setservices: setservices_
 
   connections:
     - src_name: PLE

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
@@ -9,8 +9,6 @@ function(run_case case_name regression_data_dir)
 
   set(root_dir ${regression_data_dir}/${case_name})
   set(num_procs "6")
-  set(start_date_time "1891-03-01T00:00:00")
-  set(restart_dir ${root_dir}/checkpoints/${start_date_time})
   set(checkpoints_dir ${root_dir}/checkpoints/last)
 
   if(NOT EXISTS ${root_dir})
@@ -18,14 +16,12 @@ function(run_case case_name regression_data_dir)
     return()
   endif()
 
-  copy_directory(${restart_dir} ${expdir}/checkpoints/${start_date_time})
+  copy_restarts(${root_dir} ${expdir})
   copy_file(${regression_data_dir}/newmfspectra40_dc25.nc ${expdir})
   run_geos(${num_procs} ${case_name} ${expdir})
   compare_results(${checkpoints_dir} ${expdir}/checkpoints/last)
 
-  # execute_process(
-  #   COMMAND ${CMAKE_COMMAND} -E rm -rf ${expdir}
-  # )
+  file(REMOVE_RECURSE ${expdir})
 endfunction()
 
 run_case(${TEST_CASE} ${REGRESSION_DATA_DIR})


### PR DESCRIPTION
## Summary
- Fix regression test key: `setservice` -> `setservices`
- GWD regression: use `copy_restarts()` helper and enable `expdir` cleanup via `file(REMOVE_RECURSE ...)`
- Held-Suarez regression: replace commented-out `execute_process` with `file(REMOVE_RECURSE ...)` for cleanup

## Test plan
- [x] Regression tests pass for GWD and Held-Suarez cases