### PR TITLE
Enable GEOSradiation_GridComp (IRRAD-only) in the physics build

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/CMakeLists.txt
@@ -1,12 +1,12 @@
 esma_set_this ()
 
 set (alldirs
-  GEOSchem_GridComp       # restricted to GOCART only - see GEOSchem_GridComp/CMakeLists.txt
-  # GEOSmoist_GridComp     # not yet ported to MAPL3 - restore when ported
-  # GEOSsurface_GridComp   # not yet ported to MAPL3 - restore when ported
+  GEOSchem_GridComp         # restricted to GOCART only - see GEOSchem_GridComp/CMakeLists.txt
+  # GEOSmoist_GridComp      # not yet ported to MAPL3 - restore when ported
+  # GEOSsurface_GridComp    # not yet ported to MAPL3 - restore when ported
   # GEOSturbulence_GridComp # not yet ported to MAPL3 - restore when ported
   GEOSgwd_GridComp
-  # GEOSradiation_GridComp # not yet ported to MAPL3 - restore when ported
+  GEOSradiation_GridComp    # restricted to IRRAD only - see GEOSradiation_GridComp/CMakeLists.txt
   )
 
 # Temporarily bypass GEOSphysics top-level library: GEOS_PhysicsGridComp.F90


### PR DESCRIPTION
## Summary
- The MAPL3 IRRAD port is ready enough to build; uncomment `GEOSradiation_GridComp` in `GEOSphysics_GridComp`'s `alldirs` list.
- Matches the same "restricted to `<X>` only" pattern already used for `GEOSchem_GridComp`'s GOCART-only build.

## Test plan
- [x] Confirm the physics build picks up `GEOSradiation_GridComp` and builds IRRAD successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)