### PR TITLE
GEOSgwd regression: skip comparison for GNU compiler, tighten tolerance

### DIFF
--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
@@ -19,7 +19,13 @@ function(run_case case_name regression_data_dir)
   copy_restarts(${root_dir} ${expdir})
   copy_file(${regression_data_dir}/newmfspectra40_dc25.nc ${expdir})
   run_geos(${num_procs} ${case_name} ${expdir})
-  compare_results(${checkpoints_dir} ${expdir}/checkpoints/last NANS_ARE_EQUAL TOLERANCE 3.1e-5)
+  if(NOT FORTRAN_COMPILER_ID STREQUAL "GNU") # skip comparison for GNU compiler
+    compare_results(
+      ${checkpoints_dir} ${expdir}/checkpoints/last
+      NANS_ARE_EQUAL
+      TOLERANCE 1.6e-5
+    )
+  endif()
 
   file(REMOVE_RECURSE ${expdir})
 endfunction()


### PR DESCRIPTION
## Summary
- Skip `compare_results` in the GEOSgwd regression `run_case.cmake` when built with GNU, mirroring the same fix applied to FVdycoreCubed_GridComp and GOCART2G (GEOS-ESM/GOCART#474). Depends on the `FORTRAN_COMPILER_ID` plumbing added in ESMA_cmake (GEOS-ESM/ESMA_cmake#570 / #571).
- Tighten comparison tolerance from 3.1e-5 to 1.6e-5.

## Test plan
- [ ] CI passes