### PR TITLE
Add mapl.setServices blocks to Held-Suarez regression YAMLs

### DIFF
--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/agcm-simple.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/agcm-simple.yaml
@@ -1,5 +1,9 @@
 ---
 mapl:
+  setServices:
+    sharedObj: libGEOSagcm_GridComp.so
+    userRoutine: setservices_
+
   geometry:
     kind: from_child
     provider: SDYN

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/cap.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/cap.yaml
@@ -15,6 +15,10 @@ cap:
   root_name: AGCM
 
   mapl:
+
+    setServices:
+      sharedObj: libMAPL.cap
+
     children:
       History:
         dso: libMAPL.history

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/data-ana.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/data-ana.yaml
@@ -1,4 +1,8 @@
 mapl:
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_
+
   states:
     internal:
       DQVANA:

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/data-moist.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/data-moist.yaml
@@ -1,4 +1,8 @@
 mapl:
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_
+
   states:
     internal:
       Q:

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/dyn.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/dyn.yaml
@@ -24,6 +24,10 @@ geometry:
     field_center: PE
 
 mapl:
+  setServices:
+    sharedObj: libFVdycoreCubed_GridComp
+    userRoutine: fvdycorecubed_setservices_
+
   misc:
     checkpoint:
       export: true

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/held-suarez.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/held-suarez.yaml
@@ -3,6 +3,9 @@ P_D: 0.0
 TAUF: 10.
 
 mapl:
+  # We don't need the setServices block here, since
+  # the parent creates this child in source, via
+  # call MAPL_GridCompAddChild(gc, "PHYS", PHYS_SetServices, "held-suarez.yaml", _RC)
   misc:
     checkpoint:
       export: true

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/history.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/history.yaml
@@ -11,3 +11,7 @@ collections:
     time_spec: *one_hour
     var_list:
       DISS_HS: {source: PHYS.DISS}
+
+mapl:
+  setServices:
+    sharedObj: libMAPL.history


### PR DESCRIPTION
Adds `mapl.setServices` (sharedObj/userRoutine) entries to the Held-Suarez regression YAML configs (agcm-simple, data-ana, data-moist, dyn, history), and a comment in held-suarez.yaml explaining why it doesn't need one.