### PR TITLE
GEOSgwd/hs regression: compare only against IntelLLVM baselines

### DIFF
--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/cap.yaml
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/held-suarez/cap.yaml
@@ -15,7 +15,6 @@ cap:
   root_name: AGCM
 
   mapl:
-
     setServices:
       sharedObj: libMAPL.cap
 

--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
@@ -13,7 +13,7 @@ function(run_case case_name regression_data_dir)
   run_geos(${num_procs} ${case_name} ${expdir})
   if (NOT EXISTS ${checkpoints_dir})
     message(WARNING "Baseline directory [${checkpoints_dir}] not found. Skipping comparison.")
-  else()
+  elseif(FORTRAN_COMPILER_ID STREQUAL "IntelLLVM") # only compare against IntelLLVM baselines
     compare_results(${checkpoints_dir} ${expdir}/checkpoints/last)
   endif()
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
@@ -19,12 +19,8 @@ function(run_case case_name regression_data_dir)
   copy_restarts(${root_dir} ${expdir})
   copy_file(${regression_data_dir}/newmfspectra40_dc25.nc ${expdir})
   run_geos(${num_procs} ${case_name} ${expdir})
-  if(NOT FORTRAN_COMPILER_ID STREQUAL "GNU") # skip comparison for GNU compiler
-    compare_results(
-      ${checkpoints_dir} ${expdir}/checkpoints/last
-      NANS_ARE_EQUAL
-      TOLERANCE 1.6e-5
-    )
+  if(FORTRAN_COMPILER_ID STREQUAL "IntelLLVM") # only compare against IntelLLVM baselines
+    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last NANS_ARE_EQUAL)
   endif()
 
   file(REMOVE_RECURSE ${expdir})


### PR DESCRIPTION
Only run the checkpoint comparison in the GEOSgwd/hs_GridComp regression test when the Fortran compiler is IntelLLVM, since baselines are generated with IntelLLVM.