### PR TITLE
GEOSgwd/hs regression: exclude coordinate variables

### DIFF
--- a/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOShs_GridComp/regression/run_case.cmake
@@ -14,7 +14,11 @@ function(run_case case_name regression_data_dir)
   if (NOT EXISTS ${checkpoints_dir})
     message(WARNING "Baseline directory [${checkpoints_dir}] not found. Skipping comparison.")
   elseif(FORTRAN_COMPILER_ID STREQUAL "IntelLLVM") # only compare against IntelLLVM baselines
-    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last)
+    compare_results(
+      ${checkpoints_dir} ${expdir}/checkpoints/last
+      NANS_ARE_EQUAL
+      EXCLUDE_VARS lons lats corner_lons corner_lats
+    )
   endif()
 
   file(REMOVE_RECURSE ${expdir})

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
@@ -20,7 +20,8 @@ function(run_case case_name regression_data_dir)
   copy_file(${regression_data_dir}/newmfspectra40_dc25.nc ${expdir})
   run_geos(${num_procs} ${case_name} ${expdir})
   if(FORTRAN_COMPILER_ID STREQUAL "IntelLLVM") # only compare against IntelLLVM baselines
-    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last
+    compare_results(
+      ${checkpoints_dir} ${expdir}/checkpoints/last
       NANS_ARE_EQUAL
       EXCLUDE_VARS lons lats corner_lons corner_lats
     )

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/regression/run_case.cmake
@@ -20,7 +20,10 @@ function(run_case case_name regression_data_dir)
   copy_file(${regression_data_dir}/newmfspectra40_dc25.nc ${expdir})
   run_geos(${num_procs} ${case_name} ${expdir})
   if(FORTRAN_COMPILER_ID STREQUAL "IntelLLVM") # only compare against IntelLLVM baselines
-    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last NANS_ARE_EQUAL)
+    compare_results(${checkpoints_dir} ${expdir}/checkpoints/last
+      NANS_ARE_EQUAL
+      EXCLUDE_VARS lons lats corner_lons corner_lats
+    )
   endif()
 
   file(REMOVE_RECURSE ${expdir})


### PR DESCRIPTION
Exclude longitude and latitude coordinate variables from GEOSgwd/hs checkpoint comparisons.

These coordinates are already omitted by comparable regression coverage and should not determine the physics regression result.