### PR TITLE
Add GEOS-MLT GWD tapering and Python bridge support

### DIFF
--- a/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
+++ b/GEOSagcm_GridComp/GEOS_AgcmGridComp.F90
@@ -45,6 +45,9 @@ module GEOS_AgcmGridCompMod
   use Chem_GroupMod
   use Bundle_IncrementMod
 
+  use MAPL_Mod,          only: MAPL_Get
+  use MAPL_PythonBridge, only: initialize_python_bridge
+
   implicit none
   private
 
@@ -1203,6 +1206,8 @@ contains
    character(len=ESMF_MAXSTR)          :: STRING
    character(len=ESMF_MAXSTR)          :: rplMode
 
+   integer :: IM, JM, LM ! +++ awlee
+
 ! =============================================================================
 
 ! Begin...
@@ -1222,6 +1227,14 @@ contains
 
 
     call MAPL_TimerOn(STATE,"INITIALIZE")
+
+    ! +++ awlee
+    ! Spin the MAPL python bridge
+    call MAPL_Get ( STATE, IM=IM, JM=JM, LM=LM, RC=STATUS )
+    VERIFY_(STATUS)
+    call initialize_python_bridge( IM, JM, LM )
+    ! --- awlee
+
 
 ! Call Initialize for every Child
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -60,6 +60,8 @@ module GEOS_GwdGridCompMod
       real :: GEOS_BGSTRESS
       real :: GEOS_EFFGWBKG
       real :: GEOS_EFFGWORO
+      logical :: GEOS_MLT
+      real :: GWD_TOP_PRESSURE
       integer :: GEOS_PGWV
       real :: NCAR_EFFGWBKG
       real :: NCAR_EFFGWORO
@@ -299,6 +301,17 @@ contains
       call MAPL_GetResource(MAPL,STRETCH_FACTOR,'AGCM.STRETCH_FACTOR:', default=1.0, _RC)
       imsize = imsize*CEILING(STRETCH_FACTOR)
       sigma = 1.0-0.9839*exp(-0.09835*4.e7*0.9/imsize/1000.) ! Based on Arakawa 2011 sigma used in GF2020
+
+      ! GEOS-MLT gravity wave drag top pressure cutoff
+      ! ----------------------------------------------
+      ! The cutoff is active only for GEOS-MLT. Pressure is in Pa, and the
+      ! default 1.0 Pa corresponds to 0.01 hPa.
+      call MAPL_GetResource( MAPL, self%GEOS_MLT, Label="GEOS_MLT:", default=.false., _RC)
+      self%GWD_TOP_PRESSURE = 1.0
+      if (self%GEOS_MLT) then
+         call MAPL_GetResource( MAPL, self%GWD_TOP_PRESSURE, &
+              Label="GWD_TOP_PRESSURE:", default=1.0, _RC)
+      end if
 
       ! Background Gravity wave drag
       ! ----------------------------
@@ -688,6 +701,7 @@ contains
                  TAUXB_TMP_NCAR, TAUYB_TMP_NCAR,  &
                  self%NCAR_EFFGWORO, &
                  self%NCAR_EFFGWBKG, self%alpha, &
+                 self%GEOS_MLT, self%GWD_TOP_PRESSURE, &
                  _RC)
          endif
          !call MAPL_TimerOff(MAPL,"-INTR_NCAR")
@@ -717,6 +731,7 @@ contains
                  self%GEOS_BGSTRESS, &
                  self%GEOS_EFFGWORO, &
                  self%GEOS_EFFGWBKG, &
+                 self%GEOS_MLT, self%GWD_TOP_PRESSURE, &
                  _RC)
          endif
          !call MAPL_TimerOff(MAPL,"-INTR_GEOS")

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/GEOS_GwdGridComp.F90
@@ -62,6 +62,7 @@ module GEOS_GwdGridCompMod
       real :: GEOS_EFFGWORO
       logical :: GEOS_MLT
       real :: GWD_TOP_PRESSURE
+      real, allocatable :: GWD_TOP_RAMP(:)
       integer :: GEOS_PGWV
       real :: NCAR_EFFGWBKG
       real :: NCAR_EFFGWORO
@@ -227,7 +228,9 @@ contains
       character(len=2)           :: dateline
       integer                    :: imsize,nn
       integer                    :: LM
+      integer                    :: K, BOTNDX
       real                       :: sigma,STRETCH_FACTOR
+      real                       :: PREF_MID
 
       real, pointer, dimension(:)      :: PREF
 
@@ -302,15 +305,15 @@ contains
       imsize = imsize*CEILING(STRETCH_FACTOR)
       sigma = 1.0-0.9839*exp(-0.09835*4.e7*0.9/imsize/1000.) ! Based on Arakawa 2011 sigma used in GF2020
 
-      ! GEOS-MLT gravity wave drag top pressure cutoff
-      ! ----------------------------------------------
-      ! The cutoff is active only for GEOS-MLT. Pressure is in Pa, and the
-      ! default 1.0 Pa corresponds to 0.01 hPa.
+      ! GEOS-MLT gravity wave drag upper-atmosphere taper pressure
+      ! ----------------------------------------------------------
+      ! GWD_TOP_PRESSURE is the reference pressure used to locate the start
+      ! of the upper-atmosphere GWD taper.
       call MAPL_GetResource( MAPL, self%GEOS_MLT, Label="GEOS_MLT:", default=.false., _RC)
-      self%GWD_TOP_PRESSURE = 1.0
+      self%GWD_TOP_PRESSURE = 0.006
       if (self%GEOS_MLT) then
          call MAPL_GetResource( MAPL, self%GWD_TOP_PRESSURE, &
-              Label="GWD_TOP_PRESSURE:", default=1.0, _RC)
+              Label="GWD_TOP_PRESSURE:", default=0.006, _RC)
       end if
 
       ! Background Gravity wave drag
@@ -421,6 +424,37 @@ contains
       allocate(self%alpha(LM+1), _STAT)
       call MAPL_GetPointer( IMPORT, PREF,     'PREF',    _RC )
       call gw_newtonian_set(LM, PREF, self%alpha)
+
+      ! Build the GEOS-MLT upper-atmosphere GWD taper from the
+      ! reference-pressure grid. Level 1 is the top model layer.
+      if (self%GEOS_MLT) then
+         allocate(self%GWD_TOP_RAMP(LM), _STAT)
+         self%GWD_TOP_RAMP = 1.0
+
+         if (self%GWD_TOP_PRESSURE > 0.0) then
+            BOTNDX = LM + 1
+            do K = 1, LM
+               PREF_MID = 0.5 * (PREF(K) + PREF(K+1))
+               if (PREF_MID > self%GWD_TOP_PRESSURE) then
+                  BOTNDX = K
+                  exit
+               end if
+            end do
+
+            ! Taper upward from BOTNDX while levels below BOTNDX
+            ! retain a factor of one.
+            if (BOTNDX > 1 .and. BOTNDX <= LM) then
+               do K = BOTNDX, 1, -1
+                  if (PREF(K+1) > 0.0 .and. PREF(K) >= 0.0) then
+                     self%GWD_TOP_RAMP(K) = self%GWD_TOP_RAMP(K+1) * &
+                          PREF(K) / PREF(K+1)
+                  else
+                     self%GWD_TOP_RAMP(K) = 0.0
+                  end if
+               end do
+            end if
+         end if
+      end if
 
       ! All done
       !---------
@@ -701,7 +735,6 @@ contains
                  TAUXB_TMP_NCAR, TAUYB_TMP_NCAR,  &
                  self%NCAR_EFFGWORO, &
                  self%NCAR_EFFGWBKG, self%alpha, &
-                 self%GEOS_MLT, self%GWD_TOP_PRESSURE, &
                  _RC)
          endif
          !call MAPL_TimerOff(MAPL,"-INTR_NCAR")
@@ -731,7 +764,6 @@ contains
                  self%GEOS_BGSTRESS, &
                  self%GEOS_EFFGWORO, &
                  self%GEOS_EFFGWBKG, &
-                 self%GEOS_MLT, self%GWD_TOP_PRESSURE, &
                  _RC)
          endif
          !call MAPL_TimerOff(MAPL,"-INTR_GEOS")
@@ -749,6 +781,21 @@ contains
          DTDT_ORG=DTDT_ORG_GEOS+DTDT_ORG_NCAR
          TAUXO_TMP=TAUXO_TMP_GEOS+TAUXO_TMP_NCAR
          TAUYO_TMP=TAUYO_TMP_GEOS+TAUYO_TMP_NCAR
+
+         ! Apply the GEOS-MLT upper-atmosphere taper to the final GWD
+         ! tendencies. The wave-drag schemes themselves retain their
+         ! original full-column propagation and stress calculations.
+         if (self%GEOS_MLT) then
+            do L = 1, LM
+               DUDT_GWD(:,:,L) = DUDT_GWD(:,:,L) * self%GWD_TOP_RAMP(L)
+               DVDT_GWD(:,:,L) = DVDT_GWD(:,:,L) * self%GWD_TOP_RAMP(L)
+               DTDT_GWD(:,:,L) = DTDT_GWD(:,:,L) * self%GWD_TOP_RAMP(L)
+
+               DUDT_ORG(:,:,L) = DUDT_ORG(:,:,L) * self%GWD_TOP_RAMP(L)
+               DVDT_ORG(:,:,L) = DVDT_ORG(:,:,L) * self%GWD_TOP_RAMP(L)
+               DTDT_ORG(:,:,L) = DTDT_ORG(:,:,L) * self%GWD_TOP_RAMP(L)
+            end do
+         end if
          !call MAPL_TimerOff(MAPL,"-INTR")
 
          CALL POSTINTR(IM*JM, LM, DT, H0, HH, Z1, TAU1, &

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/gw_drag.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/gw_drag.F90
@@ -153,6 +153,7 @@ contains
     real    :: cw (-pgwv:pgwv)      ! wave phase speeds
     real    :: cw4(-pgwv:pgwv)      ! wave phase speeds
 
+    
 !-----------------------------------------------------------------------------
 
 ! Assign wave phase speeds
@@ -292,8 +293,8 @@ contains
 
 ! Add the orographic tendencies to the spectrum tendencies
 ! Compute the temperature tendency from energy conservation (includes spectrum).
-
-          do k = 1, pver
+          
+          do k = 1, pver              
              dudt_org_dev(i,k) =                     utgw(k)
              dvdt_org_dev(i,k) =                     vtgw(k)
              dtdt_org_dev(i,k) =                     ttgw(k)
@@ -308,7 +309,24 @@ contains
        end if
 
     end do I_LOOP
-    rc = 0
+    
+    !-----------------------------------------------------------------------
+    ! GEOS_MLT: Zero out gravity wave drag tendencies above model top (top 7 levels)
+    ! Levels 1-7 (interfaces 0-7) are above native model top (~80 km / 0.01 hPa
+    ! *** Removed due to zero difference in GWD when included ***
+    !-----------------------------------------------------------------------
+    !do i = 1, pcols
+    !   do k = 1, 7
+    !      dudt_gwd_dev(i,k) = 0.
+    !      dvdt_gwd_dev(i,k) = 0.
+    !      dtdt_gwd_dev(i,k) = 0.
+    !      dudt_org_dev(i,k) = 0.
+    !      dvdt_org_dev(i,k) = 0.
+    !      dtdt_org_dev(i,k) = 0.
+    !   end do
+    !end do   
+    
+    rc = 0    
 
     return
   end subroutine gw_intr
@@ -489,14 +507,22 @@ contains
     end if
 
 ! Project the local wind at midpoints onto the source wind.
-    do k = 1, pver
+    
+    !do k = 1, pver
+    do k = 8, pver  ! GEOS_MLT
        ubm(k) = u(i,k) * xv + v(i,k) * yv
     end do
 
 ! Compute the interface wind projection by averaging the midpoint winds.
 ! Use the top level wind at the top interface.
-    ubi(0) = ubm(1)
-    do k = 1, pver
+    
+    !ubi(0) = ubm(1)
+    !do k = 1, pver
+    !   ubi(k) = ubm(k)
+    !end do
+
+    ubi(0) = ubm(8)             ! GEOS_MLT 
+    do k = 8, pver
        ubi(k) = ubm(k)
     end do
 
@@ -647,13 +673,14 @@ contains
     end if
 
 ! Project the local wind at midpoints onto the source wind.
-    do k = 1, pver
+    !do k = 1, pver
+    do k = 8, pver
        ubm(k) = u(i,k) * xv + v(i,k) * yv
     end do
 
 ! Compute the bottom interface wind projection using the midpoint winds.
     ubi(0) = ubm(1)
-    do k = 1, pver
+    do k = 8, pver
        ubi(k) = ubm(k)
     end do
 
@@ -862,7 +889,7 @@ contains
 
 ! Loop from bottom to top to get stress profiles
     do l = -ngwv, ngwv
-       do k = pver-1, ktop, -1
+       do k = pver-1, ktop, -1   
           if (k <= kbot-1) then
              d = dback(k)
              ubmc = ubi(k) - c(l)
@@ -1074,6 +1101,7 @@ contains
 !-----------------------------------------------------------------------
     tau0x = tau(0,kbot) * xv * effgw*utfac
     tau0y = tau(0,kbot) * yv * effgw*utfac
+
 
     return
   end subroutine gw_drag_prof

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/gw_drag.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/gw_drag.F90
@@ -63,7 +63,7 @@ contains
           taugwdx_dev,  taugwdy_dev,  tauox_dev,    tauoy_dev,  feo_dev,           &
           taubkgx_dev,  taubkgy_dev,  taubx_dev,    tauby_dev,  feb_dev,           &
           fepo_dev,     fepb_dev,     utbsrc_dev,   vtbsrc_dev, ttbsrc_dev,        &
-          bgstressmax,  effgworo,     effgwbkg,     geos_mlt, gwd_top_pressure, rc )
+          bgstressmax,  effgworo,     effgwbkg,     rc )
 
 !-----------------------------------------------------------------------
 ! Interface for multiple gravity wave drag parameterization.
@@ -77,8 +77,6 @@ contains
     real,    intent(in   ) :: bgstressmax              ! Max of equatorial profile of BG stress factor
     real,    intent(in   ) :: effgwbkg                 ! tendency efficiency for background gwd (Default = 0.125)
     real,    intent(in   ) :: effgworo                 ! tendency efficiency for orographic gwd (Default = 0.125)
-    logical, intent(in   ) :: geos_mlt                 ! apply GEOS-MLT-specific GWD top cutoff
-    real,    intent(in   ) :: gwd_top_pressure         ! GEOS-MLT top pressure cutoff for GWD tendencies (Pa)
     real,    intent(in   ) :: pint_dev(pcols,pver+1)   ! pressure at the layer edges
     real,    intent(in   ) :: t_dev(pcols,pver)        ! temperature at layers
     real,    intent(in   ) :: u_dev(pcols,pver)        ! zonal wind at layers
@@ -122,7 +120,6 @@ contains
     integer :: kbotoro                  ! launch-level index for orographic
     integer :: kbotbg                   ! launch-level index for background
     integer :: ktopbg, ktoporo          ! top interface of gwd region
-    integer :: ktop_gwd                 ! pressure-based top interface of gwd region
     integer :: kldv                     ! top interface of low level stress divergence region
     integer :: kldvmn                   ! min value of kldv
     integer :: ksrc                     ! index of top interface of source region
@@ -180,16 +177,6 @@ contains
 
     I_LOOP: do i = 1, pcols
 
-! GEOS_MLT: Set the top of the active GWD region from the instantaneous
-! layer pressure. Native GEOS retains the original full-column GWD behavior.
-       ktop_gwd = 0
-       if (geos_mlt) then
-          do k = 1, pver
-             if (pmid_dev(i,k) >= gwd_top_pressure) exit
-             ktop_gwd = k
-          end do
-       end if
-
 ! zero net tendencies prior to runs
        do k = 1, pver
          dudt_gwd_dev(i,k) = 0.
@@ -230,7 +217,7 @@ contains
 !-----------------------------------------------------------------------------
        if (effgwbkg > 0.0 .and. pgwv > 0) then
 
-          ktopbg  = ktop_gwd
+          ktopbg  = 0
           do k = 0, pver
              if (pref_dev(k+1) .lt. 40000.) then
                 kbotbg = k    ! spectrum source at 400 mb
@@ -280,7 +267,7 @@ contains
 !-----------------------------------------------------------------------------
        if (effgworo > 0.0) then
 
-          ktoporo = ktop_gwd
+          ktoporo = 0
           kbotoro = pver
 
 ! Determine the orographic wave source
@@ -322,9 +309,6 @@ contains
        end if
 
     end do I_LOOP
-    
-    ! For GEOS_MLT, pressure-based ktop_gwd leaves tendencies above
-    ! gwd_top_pressure at their initialized zero values.
     
     rc = 0    
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/gw_drag.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/gw_drag.F90
@@ -51,7 +51,6 @@ module gw_drag
   real, parameter :: ROG     = MAPL_RGAS/MAPL_GRAV
   real, parameter :: OROKO2  = 0.5 * KWVO     ! 1/2 * horizontal wavenumber
   real, parameter :: PI_GWD  = 4.0*atan(1.0)  ! This is *not* MAPL_PI
-  real, parameter :: GWD_TOP_PRESSURE = 1.0   ! 0.01 hPa in Pa
 contains
 
 !===============================================================================
@@ -64,7 +63,7 @@ contains
           taugwdx_dev,  taugwdy_dev,  tauox_dev,    tauoy_dev,  feo_dev,           &
           taubkgx_dev,  taubkgy_dev,  taubx_dev,    tauby_dev,  feb_dev,           &
           fepo_dev,     fepb_dev,     utbsrc_dev,   vtbsrc_dev, ttbsrc_dev,        &
-          bgstressmax,  effgworo,     effgwbkg,     rc            )
+          bgstressmax,  effgworo,     effgwbkg,     geos_mlt, gwd_top_pressure, rc )
 
 !-----------------------------------------------------------------------
 ! Interface for multiple gravity wave drag parameterization.
@@ -78,6 +77,8 @@ contains
     real,    intent(in   ) :: bgstressmax              ! Max of equatorial profile of BG stress factor
     real,    intent(in   ) :: effgwbkg                 ! tendency efficiency for background gwd (Default = 0.125)
     real,    intent(in   ) :: effgworo                 ! tendency efficiency for orographic gwd (Default = 0.125)
+    logical, intent(in   ) :: geos_mlt                 ! apply GEOS-MLT-specific GWD top cutoff
+    real,    intent(in   ) :: gwd_top_pressure         ! GEOS-MLT top pressure cutoff for GWD tendencies (Pa)
     real,    intent(in   ) :: pint_dev(pcols,pver+1)   ! pressure at the layer edges
     real,    intent(in   ) :: t_dev(pcols,pver)        ! temperature at layers
     real,    intent(in   ) :: u_dev(pcols,pver)        ! zonal wind at layers
@@ -179,14 +180,15 @@ contains
 
     I_LOOP: do i = 1, pcols
 
-! Set the top of the active GWD region from the instantaneous layer pressure.
-! Levels are ordered from the model top downward.  A layer is excluded only
-! when its midpoint pressure is above (less than) 0.01 hPa.
+! GEOS_MLT: Set the top of the active GWD region from the instantaneous
+! layer pressure. Native GEOS retains the original full-column GWD behavior.
        ktop_gwd = 0
-       do k = 1, pver
-          if (pmid_dev(i,k) >= GWD_TOP_PRESSURE) exit
-          ktop_gwd = k
-       end do
+       if (geos_mlt) then
+          do k = 1, pver
+             if (pmid_dev(i,k) >= gwd_top_pressure) exit
+             ktop_gwd = k
+          end do
+       end if
 
 ! zero net tendencies prior to runs
        do k = 1, pver
@@ -321,8 +323,8 @@ contains
 
     end do I_LOOP
     
-    ! The pressure-based ktop_gwd passed to gw_drag_prof leaves tendencies
-    ! above 0.01 hPa at their initialized zero values.
+    ! For GEOS_MLT, pressure-based ktop_gwd leaves tendencies above
+    ! gwd_top_pressure at their initialized zero values.
     
     rc = 0    
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/gw_drag.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/gw_drag.F90
@@ -51,6 +51,7 @@ module gw_drag
   real, parameter :: ROG     = MAPL_RGAS/MAPL_GRAV
   real, parameter :: OROKO2  = 0.5 * KWVO     ! 1/2 * horizontal wavenumber
   real, parameter :: PI_GWD  = 4.0*atan(1.0)  ! This is *not* MAPL_PI
+  real, parameter :: GWD_TOP_PRESSURE = 1.0   ! 0.01 hPa in Pa
 contains
 
 !===============================================================================
@@ -120,6 +121,7 @@ contains
     integer :: kbotoro                  ! launch-level index for orographic
     integer :: kbotbg                   ! launch-level index for background
     integer :: ktopbg, ktoporo          ! top interface of gwd region
+    integer :: ktop_gwd                 ! pressure-based top interface of gwd region
     integer :: kldv                     ! top interface of low level stress divergence region
     integer :: kldvmn                   ! min value of kldv
     integer :: ksrc                     ! index of top interface of source region
@@ -177,6 +179,15 @@ contains
 
     I_LOOP: do i = 1, pcols
 
+! Set the top of the active GWD region from the instantaneous layer pressure.
+! Levels are ordered from the model top downward.  A layer is excluded only
+! when its midpoint pressure is above (less than) 0.01 hPa.
+       ktop_gwd = 0
+       do k = 1, pver
+          if (pmid_dev(i,k) >= GWD_TOP_PRESSURE) exit
+          ktop_gwd = k
+       end do
+
 ! zero net tendencies prior to runs
        do k = 1, pver
          dudt_gwd_dev(i,k) = 0.
@@ -217,7 +228,7 @@ contains
 !-----------------------------------------------------------------------------
        if (effgwbkg > 0.0 .and. pgwv > 0) then
 
-          ktopbg  = 0
+          ktopbg  = ktop_gwd
           do k = 0, pver
              if (pref_dev(k+1) .lt. 40000.) then
                 kbotbg = k    ! spectrum source at 400 mb
@@ -267,7 +278,7 @@ contains
 !-----------------------------------------------------------------------------
        if (effgworo > 0.0) then
 
-          ktoporo = 0
+          ktoporo = ktop_gwd
           kbotoro = pver
 
 ! Determine the orographic wave source
@@ -310,21 +321,8 @@ contains
 
     end do I_LOOP
     
-    !-----------------------------------------------------------------------
-    ! GEOS_MLT: Zero out gravity wave drag tendencies above model top (top 7 levels)
-    ! Levels 1-7 (interfaces 0-7) are above native model top (~80 km / 0.01 hPa
-    ! *** Removed due to zero difference in GWD when included ***
-    !-----------------------------------------------------------------------
-    !do i = 1, pcols
-    !   do k = 1, 7
-    !      dudt_gwd_dev(i,k) = 0.
-    !      dvdt_gwd_dev(i,k) = 0.
-    !      dtdt_gwd_dev(i,k) = 0.
-    !      dudt_org_dev(i,k) = 0.
-    !      dvdt_org_dev(i,k) = 0.
-    !      dtdt_org_dev(i,k) = 0.
-    !   end do
-    !end do   
+    ! The pressure-based ktop_gwd passed to gw_drag_prof leaves tendencies
+    ! above 0.01 hPa at their initialized zero values.
     
     rc = 0    
 
@@ -508,21 +506,15 @@ contains
 
 ! Project the local wind at midpoints onto the source wind.
     
-    !do k = 1, pver
-    do k = 8, pver  ! GEOS_MLT
+    do k = 1, pver
        ubm(k) = u(i,k) * xv + v(i,k) * yv
     end do
 
 ! Compute the interface wind projection by averaging the midpoint winds.
 ! Use the top level wind at the top interface.
     
-    !ubi(0) = ubm(1)
-    !do k = 1, pver
-    !   ubi(k) = ubm(k)
-    !end do
-
-    ubi(0) = ubm(8)             ! GEOS_MLT 
-    do k = 8, pver
+    ubi(0) = ubm(1)
+    do k = 1, pver
        ubi(k) = ubm(k)
     end do
 
@@ -673,14 +665,13 @@ contains
     end if
 
 ! Project the local wind at midpoints onto the source wind.
-    !do k = 1, pver
-    do k = 8, pver
+    do k = 1, pver
        ubm(k) = u(i,k) * xv + v(i,k) * yv
     end do
 
-! Compute the bottom interface wind projection using the midpoint winds.
+    ! Compute the bottom interface wind projection using the midpoint winds.
     ubi(0) = ubm(1)
-    do k = 8, pver
+    do k = 1, pver
        ubi(k) = ubm(k)
     end do
 

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
@@ -254,10 +254,27 @@ contains
      dtdt_gwd_dev = dtdt_gwd_dev + dtdt_org_dev
      endif
 
+     ! GEOS_MLT: Zero out gravity wave drag tendencies above model top
+     ! k=1 is at model top, k=pver is at surface
+     ! Top 7 levels (k=1 to k=7) are above ~80 km / 0.01 hPa
+     
+     do k = 1, 7
+        dudt_gwd_dev(:,k) = 0.
+        dvdt_gwd_dev(:,k) = 0.
+        dtdt_gwd_dev(:,k) = 0.
+        dudt_org_dev(:,k) = 0.
+        dvdt_org_dev(:,k) = 0.
+        dtdt_org_dev(:,k) = 0.
+     end do
+
+
      taugwdx_dev(1:pcols)         = 0.0  !zonal      gravity wave surface    stress
      taugwdy_dev(1:pcols)         = 0.0  !meridional gravity wave surface    stress
      taubkgx_dev(1:pcols)         = 0.0  !zonal      gravity wave background stress
      taubkgy_dev(1:pcols)         = 0.0  !meridional gravity wave background stress
+
+
+
 
     return
   end subroutine gw_intr_ncar

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
@@ -50,6 +50,7 @@ module gw_drag_ncar
   real, parameter :: ROG     = MAPL_RGAS/MAPL_GRAV
   real, parameter :: OROKO2  = 0.5 * KWVO     ! 1/2 * horizontal wavenumber
   real, parameter :: PI_GWD  = 4.0*atan(1.0)  ! This is *not* MAPL_PI
+  real, parameter :: GWD_TOP_PRESSURE = 1.0   ! 0.01 hPa in Pa
 contains
 
 !===============================================================================
@@ -254,18 +255,16 @@ contains
      dtdt_gwd_dev = dtdt_gwd_dev + dtdt_org_dev
      endif
 
-     ! GEOS_MLT: Zero out gravity wave drag tendencies above model top
-     ! k=1 is at model top, k=pver is at surface
-     ! Top 7 levels (k=1 to k=7) are above ~80 km / 0.01 hPa
-     
-     do k = 1, 7
-        dudt_gwd_dev(:,k) = 0.
-        dvdt_gwd_dev(:,k) = 0.
-        dtdt_gwd_dev(:,k) = 0.
-        dudt_org_dev(:,k) = 0.
-        dvdt_org_dev(:,k) = 0.
-        dtdt_org_dev(:,k) = 0.
-     end do
+     ! GEOS_MLT: Suppress layer-centered GWD tendencies above 0.01 hPa.
+     ! pmid_dev is in Pa and may vary by column
+     where (pmid_dev < GWD_TOP_PRESSURE)
+        dudt_gwd_dev = 0.
+        dvdt_gwd_dev = 0.
+        dtdt_gwd_dev = 0.
+        dudt_org_dev = 0.
+        dvdt_org_dev = 0.
+        dtdt_org_dev = 0.
+     end where
 
 
      taugwdx_dev(1:pcols)         = 0.0  !zonal      gravity wave surface    stress

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
@@ -67,7 +67,7 @@ contains
           dudt_org_dev,  dvdt_org_dev,  dtdt_org_dev,                                &
           taugwdx_dev,   taugwdy_dev,   &
           taubkgx_dev,   taubkgy_dev,   &
-          effgworo,      effgwbkg,      alpha, geos_mlt, gwd_top_pressure, rc )
+          effgworo,      effgwbkg,      alpha, rc )
 
 !-----------------------------------------------------------------------
 ! Interface for multiple gravity wave drag parameterization.
@@ -86,8 +86,6 @@ contains
     type(BeresSourceDesc), intent(inout) :: beres_dc_desc ! Table descriptor for DeepCu Beres scheme
     real,    intent(in   ) :: effgwbkg                 ! tendency efficiency for background gwd (Default = 0.125)
     real,    intent(in   ) :: effgworo                 ! tendency efficiency for orographic gwd (Default = 0.125)
-    logical, intent(in   ) :: geos_mlt                 ! apply GEOS-MLT-specific GWD top cutoff
-    real,    intent(in   ) :: gwd_top_pressure         ! GEOS-MLT top pressure cutoff for GWD tendencies (Pa)
     real,    intent(in   ) :: pint_dev(pcols,pver+1)   ! pressure at the layer edges
     real,    intent(in   ) :: t_dev(pcols,pver)        ! temperature at layers
     real,    intent(in   ) :: u_dev(pcols,pver)        ! zonal wind at layers
@@ -255,20 +253,6 @@ contains
      dvdt_gwd_dev = dvdt_gwd_dev + dvdt_org_dev
      dtdt_gwd_dev = dtdt_gwd_dev + dtdt_org_dev
      endif
-
-     ! GEOS_MLT: Suppress layer-centered GWD tendencies above the configured
-     ! cutoff. Native GEOS retains the original unmasked GWD tendencies.
-     if (geos_mlt) then
-        where (pmid_dev < gwd_top_pressure)
-           dudt_gwd_dev = 0.
-           dvdt_gwd_dev = 0.
-           dtdt_gwd_dev = 0.
-           dudt_org_dev = 0.
-           dvdt_org_dev = 0.
-           dtdt_org_dev = 0.
-        end where
-     end if
-
 
      taugwdx_dev(1:pcols)         = 0.0  !zonal      gravity wave surface    stress
      taugwdy_dev(1:pcols)         = 0.0  !meridional gravity wave surface    stress

--- a/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
+++ b/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/ncar_gwd/gw_drag.F90
@@ -50,7 +50,6 @@ module gw_drag_ncar
   real, parameter :: ROG     = MAPL_RGAS/MAPL_GRAV
   real, parameter :: OROKO2  = 0.5 * KWVO     ! 1/2 * horizontal wavenumber
   real, parameter :: PI_GWD  = 4.0*atan(1.0)  ! This is *not* MAPL_PI
-  real, parameter :: GWD_TOP_PRESSURE = 1.0   ! 0.01 hPa in Pa
 contains
 
 !===============================================================================
@@ -68,7 +67,7 @@ contains
           dudt_org_dev,  dvdt_org_dev,  dtdt_org_dev,                                &
           taugwdx_dev,   taugwdy_dev,   &
           taubkgx_dev,   taubkgy_dev,   &
-          effgworo,      effgwbkg,      alpha, rc            )
+          effgworo,      effgwbkg,      alpha, geos_mlt, gwd_top_pressure, rc )
 
 !-----------------------------------------------------------------------
 ! Interface for multiple gravity wave drag parameterization.
@@ -87,6 +86,8 @@ contains
     type(BeresSourceDesc), intent(inout) :: beres_dc_desc ! Table descriptor for DeepCu Beres scheme
     real,    intent(in   ) :: effgwbkg                 ! tendency efficiency for background gwd (Default = 0.125)
     real,    intent(in   ) :: effgworo                 ! tendency efficiency for orographic gwd (Default = 0.125)
+    logical, intent(in   ) :: geos_mlt                 ! apply GEOS-MLT-specific GWD top cutoff
+    real,    intent(in   ) :: gwd_top_pressure         ! GEOS-MLT top pressure cutoff for GWD tendencies (Pa)
     real,    intent(in   ) :: pint_dev(pcols,pver+1)   ! pressure at the layer edges
     real,    intent(in   ) :: t_dev(pcols,pver)        ! temperature at layers
     real,    intent(in   ) :: u_dev(pcols,pver)        ! zonal wind at layers
@@ -255,16 +256,18 @@ contains
      dtdt_gwd_dev = dtdt_gwd_dev + dtdt_org_dev
      endif
 
-     ! GEOS_MLT: Suppress layer-centered GWD tendencies above 0.01 hPa.
-     ! pmid_dev is in Pa and may vary by column
-     where (pmid_dev < GWD_TOP_PRESSURE)
-        dudt_gwd_dev = 0.
-        dvdt_gwd_dev = 0.
-        dtdt_gwd_dev = 0.
-        dudt_org_dev = 0.
-        dvdt_org_dev = 0.
-        dtdt_org_dev = 0.
-     end where
+     ! GEOS_MLT: Suppress layer-centered GWD tendencies above the configured
+     ! cutoff. Native GEOS retains the original unmasked GWD tendencies.
+     if (geos_mlt) then
+        where (pmid_dev < gwd_top_pressure)
+           dudt_gwd_dev = 0.
+           dvdt_gwd_dev = 0.
+           dtdt_gwd_dev = 0.
+           dudt_org_dev = 0.
+           dvdt_org_dev = 0.
+           dtdt_org_dev = 0.
+        end where
+     end if
 
 
      taugwdx_dev(1:pcols)         = 0.0  !zonal      gravity wave surface    stress


### PR DESCRIPTION
## Summary

This PR merges the GEOS-MLT updates into the `GEOS-11_7_2-MLT-0_0_1` integration branch.

The changes include updates to the upper atmosphere GWD tapering and initialization of the MAPL Python bridge.

### Changes

- Add a pressure based taper for GEOS-MLT GWD tendencies.
- Use `GWD_TOP_PRESSURE` to define the start of the GWD taper.
- Construct the taper from the reference pressure profile so that GWD tendencies decrease smoothly toward the model top.
- Apply the taper consistently to momentum and temperature tendencies from the combined GEOS and NCAR GWD schemes.
- Keep the GWD taper active only when `GEOS_MLT` is enabled so that standard GEOS configurations retain their original GWD behavior.
- Initialize the MAPL Python bridge in the AGCM GridComp using the model dimensions (IM, JM, LM).

The target integration branch is based on GEOSgcm_GridComp v2.7.5 used by GEOSgcm v11.7.2.